### PR TITLE
fix: Image.open()のファイル記述子リークを修正

### DIFF
--- a/src/analyzers/image_quality_analyzer.py
+++ b/src/analyzers/image_quality_analyzer.py
@@ -62,13 +62,16 @@ class ImageQualityAnalyzer:
             }
             norm = MetricNormalizer.normalize_all(raw)
             with torch.no_grad():
-                inputs = self.processor(
-                    text=["epic game scenery"],
-                    images=Image.open(path),
-                    return_tensors="pt",
-                    padding=True,
-                ).to(self.device)
-                semantic = float(self.model(**inputs).logits_per_image[0][0]) / 100.0
+                with Image.open(path) as pil_img:
+                    inputs = self.processor(
+                        text=["epic game scenery"],
+                        images=pil_img,
+                        return_tensors="pt",
+                        padding=True,
+                    ).to(self.device)
+                    semantic = (
+                        float(self.model(**inputs).logits_per_image[0][0]) / 100.0
+                    )
 
             weighted_sum = sum(
                 norm[k] * self.weights.get(k, 0.0) for k in norm if k in self.weights


### PR DESCRIPTION
## 概要
- `Image.open()`をwithステートメントで囲み、ファイル記述子の適切なクローズを実装
- 大量処理時のファイル記述子リークを防止

## 変更内容
- PIL Image.open()をwithステートメントでラップ
- ファイルが使用後に確実にクローズされるように修正

## テスト計画
- [x] 既存の全テストがパスすることを確認 (47/47 passed)
- [x] image_quality_analyzerのテストがパスすることを確認 (14/14 passed)