### PR TITLE
refactor: ImageQualityAnalyzerの例外処理を改善しロギングを追加

### DIFF
--- a/src/analyzers/image_quality_analyzer.py
+++ b/src/analyzers/image_quality_analyzer.py
@@ -1,15 +1,19 @@
 """Image quality analyzer using CLIP and computer vision metrics."""
 
+import logging
 from typing import Optional
 import numpy as np
 import cv2
 import torch
 from transformers import CLIPProcessor, CLIPModel
 from PIL import Image
+from PIL import UnidentifiedImageError
 
 from ..models.image_metrics import ImageMetrics
 from ..models.genre_weights import GenreWeights
 from .metric_normalizer import MetricNormalizer
+
+logger = logging.getLogger(__name__)
 
 
 class ImageQualityAnalyzer:
@@ -77,5 +81,38 @@ class ImageQualityAnalyzer:
             penalty = 0.6 if raw["brightness"] < 40 else 0.0
             total = max(0.0, (weighted_sum + (semantic * 0.2) - penalty) * 100.0)
             return ImageMetrics(path, raw, norm, semantic, total, features)
-        except Exception:
+        # 正常な失敗（画像ファイルの問題）
+        except (
+            FileNotFoundError,
+            UnidentifiedImageError,
+            OSError,
+        ) as e:
+            logger.warning(
+                f"画像分析をスキップしました: {path}, 理由: {type(e).__name__}: {e}"
+            )
             return None
+        except cv2.error as e:
+            # OpenCV処理で破損画像を検出（文字列表記）
+            logger.warning(f"画像分析をスキップしました: {path}, 理由: cv2.error: {e}")
+            return None
+        except ValueError as e:
+            # 画像サイズが異常、配列操作不可
+            logger.warning(
+                f"画像分析をスキップしました: {path}, 理由: {type(e).__name__}: {e}"
+            )
+            return None
+        # 異常な失敗（実装バグ）
+        except (
+            AttributeError,
+            TypeError,
+            KeyError,
+            IndexError,
+            RuntimeError,
+            torch.cuda.OutOfMemoryError,
+            MemoryError,
+        ):
+            logger.error(
+                f"予期しないエラーが発生しました: {path}",
+                exc_info=True,
+            )
+            raise

--- a/tests/analyzers/test_image_quality_analyzer.py
+++ b/tests/analyzers/test_image_quality_analyzer.py
@@ -8,6 +8,7 @@
 5. 高速実行（約2-5秒） - 重いモデルロードなし
 """
 
+import logging
 from pathlib import Path
 from typing import Generator
 from unittest.mock import MagicMock, patch
@@ -16,6 +17,7 @@ import cv2
 import numpy as np
 import pytest
 import torch
+from PIL import UnidentifiedImageError
 
 from src.analyzers.image_quality_analyzer import ImageQualityAnalyzer
 from src.models.image_metrics import ImageMetrics
@@ -638,3 +640,174 @@ def test_analyze_produces_consistent_results_for_same_image(
         assert result1.normalized_metrics[key] == result2.normalized_metrics[key]
     # Features should be identical
     assert np.array_equal(result1.features, result2.features)
+
+
+# ============================================================================
+# Tests for exception handling and logging (4 tests)
+# ============================================================================
+
+
+def test_analyze_logs_warning_for_corrupted_image(
+    mock_clip_model: MagicMock,  # noqa: ARG001
+    mock_clip_processor: MagicMock,  # noqa: ARG001
+    sample_image_path: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """PILで画像を開く際のエラー時にWARNINGログを出力する.
+
+    Given:
+        - アナライザインスタンス
+        - 有効なテスト画像（cv2.imreadは成功する）
+        - ログキャプチャ設定（WARNINGレベル以上）
+    When:
+        - PIL.Image.openでUnidentifiedImageErrorが発生するようにモック化
+    Then:
+        - WARNINGレベルのログが出力される
+        - ログメッセージにパスと例外内容が含まれる
+        - Noneを返す（正常な失敗）
+    """
+    # Arrange
+    caplog.set_level(logging.WARNING)
+    analyzer = ImageQualityAnalyzer()
+
+    # PIL.Image.openをモック化してUnidentifiedImageErrorを発生
+    with patch(
+        "PIL.Image.open",
+        side_effect=UnidentifiedImageError("Cannot identify image file"),
+    ):
+        # Act
+        result = analyzer.analyze(sample_image_path)
+
+        # Assert
+        assert result is None
+        # WARNINGログが出力されていることを確認
+        assert len(caplog.records) > 0
+        # 最新のログレコードがWARNINGであることを確認
+        warning_log = caplog.records[-1]
+        assert warning_log.levelno == logging.WARNING
+        # ログメッセージにパスと例外情報が含まれていることを確認
+        log_message = warning_log.getMessage()
+        assert sample_image_path in log_message
+        assert "画像分析をスキップしました" in log_message
+        assert "UnidentifiedImageError" in log_message
+
+
+def test_analyze_re_raises_exception_for_attribute_error(
+    mock_clip_model: MagicMock,  # noqa: ARG001
+    mock_clip_processor: MagicMock,  # noqa: ARG001
+    sample_image_path: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """実装バグ（AttributeError）時に例外を再スローする.
+
+    Given:
+        - アナライザインスタンス
+        - 有効なテスト画像
+        - ログキャプチャ設定（ERRORレベル以上）
+    When:
+        - analyzeメソッド内でAttributeErrorが発生するようにモック化
+    Then:
+        - ERRORレベルのログが出力される
+        - AttributeErrorが再スローされる
+    """
+    # Arrange
+    caplog.set_level(logging.ERROR)
+    analyzer = ImageQualityAnalyzer()
+    # _extract_diversity_featuresメソッドをモック化してAttributeErrorを発生
+    with patch.object(
+        analyzer,
+        "_extract_diversity_features",
+        side_effect=AttributeError("Test attribute error"),
+    ):
+        # Act & Assert
+        with pytest.raises(AttributeError, match="Test attribute error"):
+            analyzer.analyze(sample_image_path)
+
+        # ERRORログが出力されていることを確認
+        assert len(caplog.records) > 0
+        error_log = caplog.records[-1]
+        assert error_log.levelno == logging.ERROR
+        # ログメッセージにパスが含まれていることを確認
+        log_message = error_log.getMessage()
+        assert sample_image_path in log_message
+        assert "予期しないエラーが発生しました" in log_message
+
+
+def test_analyze_re_raises_exception_for_type_error(
+    mock_clip_model: MagicMock,  # noqa: ARG001
+    mock_clip_processor: MagicMock,  # noqa: ARG001
+    sample_image_path: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """実装バグ（TypeError）時に例外を再スローする.
+
+    Given:
+        - アナライザインスタンス
+        - 有効なテスト画像
+        - ログキャプチャ設定（ERRORレベル以上）
+    When:
+        - analyzeメソッド内でTypeErrorが発生するようにモック化
+    Then:
+        - ERRORレベルのログが出力される
+        - TypeErrorが再スローされる
+    """
+    # Arrange
+    caplog.set_level(logging.ERROR)
+    analyzer = ImageQualityAnalyzer()
+    # 内部メソッドをモック化してTypeErrorを発生
+    with patch.object(
+        analyzer,
+        "_extract_diversity_features",
+        side_effect=TypeError("Test type error"),
+    ):
+        # Act & Assert
+        with pytest.raises(TypeError, match="Test type error"):
+            analyzer.analyze(sample_image_path)
+
+        # ERRORログが出力されていることを確認
+        assert len(caplog.records) > 0
+        error_log = caplog.records[-1]
+        assert error_log.levelno == logging.ERROR
+        log_message = error_log.getMessage()
+        assert sample_image_path in log_message
+        assert "予期しないエラーが発生しました" in log_message
+
+
+def test_analyze_re_raises_exception_for_key_error(
+    mock_clip_model: MagicMock,  # noqa: ARG001
+    mock_clip_processor: MagicMock,  # noqa: ARG001
+    sample_image_path: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """実装バグ（KeyError）時に例外を再スローする.
+
+    Given:
+        - アナライザインスタンス
+        - 有効なテスト画像
+        - ログキャプチャ設定（ERRORレベル以上）
+    When:
+        - analyzeメソッド内でKeyErrorが発生するようにモック化
+    Then:
+        - ERRORレベルのログが出力される
+        - KeyErrorが再スローされる
+    """
+    # Arrange
+    caplog.set_level(logging.ERROR)
+    analyzer = ImageQualityAnalyzer()
+    # 内部メソッドをモック化してKeyErrorを発生
+    with patch.object(
+        analyzer,
+        "_extract_diversity_features",
+        side_effect=KeyError("test_key"),
+    ):
+        # Act & Assert
+        with pytest.raises(KeyError, match="test_key"):
+            analyzer.analyze(sample_image_path)
+
+        # ERRORログが出力されていることを確認
+        assert len(caplog.records) > 0
+        error_log = caplog.records[-1]
+        assert error_log.levelno == logging.ERROR
+        log_message = error_log.getMessage()
+        assert sample_image_path in log_message
+        assert "予期しないエラーが発生しました" in log_message


### PR DESCRIPTION
## 概要

`ImageQualityAnalyzer.analyze()` メソッドの広範な `except Exception:` を具体的な例外種別ごとのハンドリングに置き換え、適切なロギングを追加しました。

## 変更内容

### 例外処理の分類

**正常な失敗（WARNINGログ + None返す）**
- `FileNotFoundError`: ファイルが存在しない
- `PIL.UnidentifiedImageError`: PILで画像として認識できない
- `OSError`: ファイル読み込み権限なし、ディスクI/Oエラー
- `cv2.error`: OpenCV処理で破損画像を検出
- `ValueError`: 画像サイズが異常、配列操作不可

**異常な失敗（ERRORログ + 例外再スロー）**
- `AttributeError`: オブジェクトの属性アクセス失敗（実装ミス）
- `TypeError`: 型の不一致（実装ミス）
- `KeyError`: 辞書のキーエラー（実装ミス）
- `IndexError`: リスト/配列のインデックスエラー（実装ミス）
- `RuntimeError`: 一般的な実行時エラー（ロジックエラー）
- `torch.cuda.OutOfMemoryError`: GPUメモリ不足
- `MemoryError`: システムメモリ不足

### ロギング実装

- 正常な失敗: `logger.warning(f"画像分析をスキップしました: {path}, 理由: {type(e).__name__}: {e}")`
- 異常な失敗: `logger.error(f"予期しないエラーが発生しました: {path}", exc_info=True)` → `raise`

### テスト追加

例外処理とログ出力を検証する4つのテストを追加：
1. `test_analyze_logs_warning_for_corrupted_image`: PILエラー時のWARNINGログ出力検証
2. `test_analyze_re_raises_exception_for_attribute_error`: AttributeErrorの再スロー検証
3. `test_analyze_re_raises_exception_for_type_error`: TypeErrorの再スロー検証
4. `test_analyze_re_raises_exception_for_key_error`: KeyErrorの再スロー検証

## メリット

- **障害検知可能**: 実装バグによる例外が適切に伝播し、障害を検知できる
- **デバッグ容易化**: 例外情報とスタックトレースがログに記録される
- **原因の明確化**: 正常な失敗と異常な失敗が明確に区別される

## テスト

- 全51件のテストがパスすることを確認
- 新規テストでログ出力と例外再スロー動作を検証