### PR TITLE
refactor: FileUtilsクラスの追加とファイル重複回避機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,10 @@ uv sync
 
 ## 使用方法
 
-### CLIコマンド (推奨)
+### 実行方法
 
 ```bash
 uv run game-screen-pick <入力フォルダ> [オプション]
-```
-
-### 直接実行
-
-```bash
-uv run python src/main.py <入力フォルダ> [オプション]
 ```
 
 ### オプション

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,6 +3,7 @@
 from .models import ImageMetrics, GenreWeights
 from .analyzers import MetricNormalizer, ImageQualityAnalyzer
 from .services import GameScreenPicker
+from .utils import FileUtils
 
 __all__ = [
     "ImageMetrics",
@@ -10,4 +11,5 @@ __all__ = [
     "MetricNormalizer",
     "ImageQualityAnalyzer",
     "GameScreenPicker",
+    "FileUtils",
 ]

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from .analyzers import ImageQualityAnalyzer
 from .models.genre_weights import GenreWeights
 from .services import GameScreenPicker
+from .utils.file_utils import FileUtils
 
 
 def main() -> None:
@@ -45,7 +46,9 @@ def main() -> None:
         out = Path(args.copy_to)
         out.mkdir(parents=True, exist_ok=True)
         for res in best:
-            shutil.copy2(res.path, out / Path(res.path).name)
+            original_filename = Path(res.path).name
+            unique_dest = FileUtils.get_unique_destination(out, original_filename)
+            shutil.copy2(res.path, unique_dest)
         print(f"\n{len(best)} 枚を {args.copy_to} に保存しました（多様性確保済み）。")
 
     print("\n--- 選択された画像一覧 ---")

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utils package for file operations."""
+
+from .file_utils import FileUtils
+
+__all__ = ["FileUtils"]

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -1,0 +1,40 @@
+"""ファイル操作ユーティリティ."""
+
+from pathlib import Path
+
+
+class FileUtils:
+    """ファイル操作ユーティリティクラス.
+
+    出力ディレクトリ内で一意なファイルパスを生成する静的メソッドを提供する。
+    """
+
+    @staticmethod
+    def get_unique_destination(dest_dir: Path, filename: str) -> Path:
+        """出力ディレクトリ内で一意なファイルパスを生成する.
+
+        同名のファイルが存在する場合、連番サフィックスを付与して衝突を回避する。
+        ファイル名の拡張子は維持される。
+
+        Args:
+            dest_dir: 出力先ディレクトリのパス
+            filename: 元のファイル名
+
+        Returns:
+            出力ディレクトリ内で一意なファイルパス
+        """
+        dest_path = dest_dir / filename
+
+        if not dest_path.exists():
+            return dest_path
+
+        stem = dest_path.stem
+        suffix = dest_path.suffix
+
+        counter = 1
+        while True:
+            new_filename = f"{stem}_{counter}{suffix}"
+            new_path = dest_dir / new_filename
+            if not new_path.exists():
+                return new_path
+            counter += 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -600,3 +600,160 @@ def test_cli_recursive_search_finds_images_in_subdirectories(
     # picker.select を呼び出すことを検証すれば十分
     # （すでに picker.select の単体テストで再帰検索の挙動を検証しているため）
     assert mock_game_screen_picker.select.called
+
+
+# ============================================================================
+# Tests for Duplicate Filename Handling (2 tests)
+# ============================================================================
+
+
+def test_cli_handles_duplicate_filenames_with_suffix(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    mock_image_quality_analyzer: MagicMock,
+    mock_game_screen_picker: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """同名ファイルが存在する場合にサフィックスを付与して上書きを回避することを検証.
+
+    Given:
+        - 別々のフォルダに同名ファイル（image.jpg）が存在
+        - 出力ディレクトリを指定
+        - 2つの画像が選択される
+    When:
+        - CLIを `-c` オプションで実行
+    Then:
+        - 1つ目は image.jpg、2つ目は image_1.jpg として保存される
+        - 両方のファイルが出力ディレクトリに存在する
+    """
+    # Arrange
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    folder1 = input_dir / "folder1"
+    folder1.mkdir()
+    folder2 = input_dir / "folder2"
+    folder2.mkdir()
+
+    # 同名ファイルを別フォルダに作成
+    img1 = folder1 / "image.jpg"
+    img2 = folder2 / "image.jpg"
+    img1.touch()
+    img2.touch()
+
+    output_dir = tmp_path / "output"
+
+    # 選択結果を設定（同名ファイルを含む）
+    results = [
+        ImageMetrics(
+            path=str(img1),
+            raw_metrics={"blur_score": 100.0},
+            normalized_metrics={"blur_score": 0.9},
+            semantic_score=0.8,
+            total_score=95.0,
+            features=np.random.rand(64),
+        ),
+        ImageMetrics(
+            path=str(img2),
+            raw_metrics={"blur_score": 90.0},
+            normalized_metrics={"blur_score": 0.85},
+            semantic_score=0.75,
+            total_score=85.0,
+            features=np.random.rand(64),
+        ),
+    ]
+    mock_game_screen_picker.select.return_value = results
+
+    monkeypatch.setattr(
+        "sys.argv", ["main.py", str(input_dir), "-c", str(output_dir), "-r"]
+    )
+    monkeypatch.setattr(
+        "src.main.ImageQualityAnalyzer", lambda *_: mock_image_quality_analyzer
+    )
+    monkeypatch.setattr("src.main.GameScreenPicker", lambda *_: mock_game_screen_picker)
+
+    # Act
+    from src.main import main
+
+    main()
+
+    # Assert
+    captured = capsys.readouterr()
+    # 成功メッセージが表示される
+    assert "2 枚を" in captured.out
+    assert str(output_dir) in captured.out
+    # 両方のファイルが出力ディレクトリに存在する
+    assert (output_dir / "image.jpg").exists()
+    assert (output_dir / "image_1.jpg").exists()
+    # 異なるファイルであることを確認（サイズが同じだがパスが異なる）
+    assert (output_dir / "image.jpg") != (output_dir / "image_1.jpg")
+
+
+def test_cli_handles_multiple_duplicate_filenames_with_increasing_suffixes(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    mock_image_quality_analyzer: MagicMock,
+    mock_game_screen_picker: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """複数の同名ファイルが存在する場合に連番でサフィックスを付与することを検証.
+
+    Given:
+        - 複数のフォルダに同名ファイル（screenshot.png）が存在
+        - 出力ディレクトリを指定
+        - 3つの画像が選択される
+    When:
+        - CLIを `-c` オプションで実行
+    Then:
+        - screenshot.png, screenshot_1.png, screenshot_2.png として保存される
+        - 3つのファイル全てが出力ディレクトリに存在する
+    """
+    # Arrange
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    for i in range(3):
+        folder = input_dir / f"folder{i}"
+        folder.mkdir()
+        (folder / "screenshot.png").touch()
+
+    output_dir = tmp_path / "output"
+
+    # 選択結果を設定（3つの同名ファイルを含む）
+    results = []
+    for i in range(3):
+        img_path = input_dir / f"folder{i}" / "screenshot.png"
+        results.append(
+            ImageMetrics(
+                path=str(img_path),
+                raw_metrics={"blur_score": 100.0 - i * 10},
+                normalized_metrics={"blur_score": 0.9 - i * 0.1},
+                semantic_score=0.8 - i * 0.05,
+                total_score=95.0 - i * 5,
+                features=np.random.rand(64),
+            )
+        )
+    mock_game_screen_picker.select.return_value = results
+
+    monkeypatch.setattr(
+        "sys.argv", ["main.py", str(input_dir), "-c", str(output_dir), "-r"]
+    )
+    monkeypatch.setattr(
+        "src.main.ImageQualityAnalyzer", lambda *_: mock_image_quality_analyzer
+    )
+    monkeypatch.setattr("src.main.GameScreenPicker", lambda *_: mock_game_screen_picker)
+
+    # Act
+    from src.main import main
+
+    main()
+
+    # Assert
+    captured = capsys.readouterr()
+    # 成功メッセージが表示される
+    assert "3 枚を" in captured.out
+    # 3つのファイル全てが出力ディレクトリに存在する
+    assert (output_dir / "screenshot.png").exists()
+    assert (output_dir / "screenshot_1.png").exists()
+    assert (output_dir / "screenshot_2.png").exists()
+    # 出力ディレクトリには3つのPNGファイルのみが存在
+    png_files = list(output_dir.glob("*.png"))
+    assert len(png_files) == 3

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for utils package."""

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -1,0 +1,521 @@
+"""file_utils.pyの単体テスト.
+
+このテストモジュールは以下のベストプラクティスに従っています：
+1. 純粋関数としての動作を検証（ファイルシステム操作なしでテスト可能）
+2. AAAパターン（Arrange, Act, Assert）を使用
+3. 明確な日本語コメントでテスト意図を説明
+4. 拡張子維持、エッジケース、特殊文字、境界値を網羅
+"""
+
+from pathlib import Path
+
+
+from src.utils.file_utils import FileUtils
+
+
+# ============================================================================
+# 基本機能のテスト（3件）
+# ============================================================================
+
+
+def test_returns_original_path_when_no_duplicate(
+    tmp_path: Path,
+) -> None:
+    """重複ファイルが存在しない場合、元のファイル名を返すことを検証.
+
+    Given:
+        - 空の出力ディレクトリ
+        - 任意のファイル名
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - 元のファイル名がそのまま返される
+    """
+    # Arrange
+    filename = "image.jpg"
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / filename
+    assert result.name == filename
+
+
+def test_adds_suffix_when_duplicate_exists(
+    tmp_path: Path,
+) -> None:
+    """同名ファイルが存在する場合、連番サフィックスを付与することを検証.
+
+    Given:
+        - 出力ディレクトリに同名ファイルが存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - _1サフィックス付きのファイル名が返される
+    """
+    # Arrange
+    filename = "image.jpg"
+    (tmp_path / filename).touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / "image_1.jpg"
+    assert result.name == "image_1.jpg"
+
+
+def test_increments_suffix_for_multiple_duplicates(
+    tmp_path: Path,
+) -> None:
+    """複数の重複ファイルが存在する場合、連番をインクリメントすることを検証.
+
+    Given:
+        - image.jpg, image_1.jpg, image_2.jpg が存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - image_3.jpg が返される
+    """
+    # Arrange
+    filename = "image.jpg"
+    (tmp_path / filename).touch()
+    (tmp_path / "image_1.jpg").touch()
+    (tmp_path / "image_2.jpg").touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / "image_3.jpg"
+    assert result.name == "image_3.jpg"
+
+
+# ============================================================================
+# 拡張子維持のテスト（4件）
+# ============================================================================
+
+
+def test_preserves_common_image_extensions(
+    tmp_path: Path,
+) -> None:
+    """一般的な画像形式の拡張子を維持することを検証.
+
+    Given:
+        - 異なる拡張子の重複ファイルが存在
+    When:
+        - 各拡張子でget_unique_destinationを実行
+    Then:
+        - 拡張子が正しく維持される
+    """
+    # Arrange
+    extensions = [".jpg", ".png", ".gif", ".webp", ".bmp"]
+    for ext in extensions:
+        (tmp_path / f"image{ext}").touch()
+
+    # Act & Assert
+    for ext in extensions:
+        result = FileUtils.get_unique_destination(tmp_path, f"image{ext}")
+        assert result == tmp_path / f"image_1{ext}"
+        assert result.suffix == ext
+
+
+def test_handles_double_extensions(
+    tmp_path: Path,
+) -> None:
+    """複数拡張子を持つファイル名を正しく処理することを検証.
+
+    Given:
+        - .tar.gz のような複数拡張子のファイルが存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - 拡張子が正しく維持される（stemはarchive.tar、suffixは.gzとして処理）
+    """
+    # Arrange
+    filename = "archive.tar.gz"
+    (tmp_path / filename).touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    # Path.suffix は最後の拡張子のみを返すため、archive.tarがstem、.gzがsuffixになる
+    assert result == tmp_path / "archive.tar_1.gz"
+    assert result.suffix == ".gz"
+
+
+def test_handles_files_without_extension(
+    tmp_path: Path,
+) -> None:
+    """拡張子なしのファイルを正しく処理することを検証.
+
+    Given:
+        - 拡張子なしのファイルが存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - stemと空のsuffixで正しく処理される
+    """
+    # Arrange
+    filename = "README"
+    (tmp_path / filename).touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / "README_1"
+    assert result.suffix == ""
+
+
+def test_handles_dot_at_start_of_filename(
+    tmp_path: Path,
+) -> None:
+    """ドットで始まるファイル名を正しく処理することを検証.
+
+    Given:
+        - .gitignore のようなドットで始まるファイルが存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - 正しくサフィックスが付与される
+    """
+    # Arrange
+    filename = ".gitignore"
+    (tmp_path / filename).touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / ".gitignore_1"
+    assert result.suffix == ""
+
+
+# ============================================================================
+# エッジケースのテスト（7件）
+# ============================================================================
+
+
+def test_handles_filename_with_existing_underscore(
+    tmp_path: Path,
+) -> None:
+    """既にアンダースコアを含むファイル名を正しく処理することを検証.
+
+    Given:
+        - image_test.jpg のようなファイルが存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - image_test_1.jpg が返される（stemはimage_test_1）
+    """
+    # Arrange
+    filename = "image_test.jpg"
+    (tmp_path / filename).touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / "image_test_1.jpg"
+    # サフィックスが付与された後のstemは image_test_1 になる
+    assert result.stem == "image_test_1"
+
+
+def test_handles_filename_with_trailing_numbers(
+    tmp_path: Path,
+) -> None:
+    """末尾に数字を含むファイル名を正しく処理することを検証.
+
+    Given:
+        - image2.jpg のような末尾数字のファイルが存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - image2_1.jpg が返される
+    """
+    # Arrange
+    filename = "image2.jpg"
+    (tmp_path / filename).touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / "image2_1.jpg"
+
+
+def test_handles_gaps_in_existing_numbered_files(
+    tmp_path: Path,
+) -> None:
+    """既存の連番にギャップがある場合、次の有効な番号を使用することを検証.
+
+    Given:
+        - image.jpg と image_5.jpg のみが存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - image_1.jpg が返される（ギャップを埋めるのではなく、連続的にインクリメント）
+    """
+    # Arrange
+    filename = "image.jpg"
+    (tmp_path / filename).touch()
+    (tmp_path / "image_5.jpg").touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / "image_1.jpg"
+
+
+def test_handles_non_consecutive_duplicates(
+    tmp_path: Path,
+) -> None:
+    """非連続的な重複ファイルが存在する場合、適切な番号を選択することを検証.
+
+    Given:
+        - image.jpg, image_1.jpg, image_3.jpg が存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - image_2.jpg が返される（次の有効な連番）
+    """
+    # Arrange
+    filename = "image.jpg"
+    (tmp_path / filename).touch()
+    (tmp_path / "image_1.jpg").touch()
+    (tmp_path / "image_3.jpg").touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / "image_2.jpg"
+
+
+def test_handles_very_long_filename(
+    tmp_path: Path,
+) -> None:
+    """非常に長いファイル名を正しく処理することを検証.
+
+    Given:
+        - 長いファイル名の重複が存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - サフィックスが正しく付与される
+    """
+    # Arrange
+    filename = "a" * 200 + ".jpg"
+    (tmp_path / filename).touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result.stem.startswith("a" * 200)
+    assert result.stem.endswith("_1")
+    assert result.suffix == ".jpg"
+
+
+def test_handles_only_stem_no_suffix(
+    tmp_path: Path,
+) -> None:
+    """ステムのみで拡張子がないファイルを正しく処理することを検証.
+
+    Given:
+        - 拡張子なしのファイルが存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - _1サフィックスがステムに直接付与される
+    """
+    # Arrange
+    filename = "myfile"
+    (tmp_path / filename).touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / "myfile_1"
+
+
+def test_handles_only_suffix_no_stem(
+    tmp_path: Path,
+) -> None:
+    """ステムがなく拡張子のみのファイルを正しく処理することを検証.
+
+    Given:
+        - .gitignore のような拡張子のみのファイルが存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - 正しくサフィックスが付与される
+    """
+    # Arrange
+    filename = ".hidden"
+    (tmp_path / filename).touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / ".hidden_1"
+
+
+# ============================================================================
+# 特殊文字のテスト（3件）
+# ============================================================================
+
+
+def test_handles_japanese_filename(
+    tmp_path: Path,
+) -> None:
+    """日本語を含むファイル名を正しく処理することを検証.
+
+    Given:
+        - 日本語を含むファイル名の重複が存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - 正しくサフィックスが付与される
+    """
+    # Arrange
+    filename = "画像ファイル.jpg"
+    (tmp_path / filename).touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / "画像ファイル_1.jpg"
+
+
+def test_handles_special_characters_in_filename(
+    tmp_path: Path,
+) -> None:
+    """特殊文字を含むファイル名を正しく処理することを検証.
+
+    Given:
+        - 特殊文字（スペース、括弧など）を含むファイル名が存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - 正しくサフィックスが付与される
+    """
+    # Arrange
+    filename = "image (copy).jpg"
+    (tmp_path / filename).touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / "image (copy)_1.jpg"
+
+
+def test_handles_spaces_in_filename(
+    tmp_path: Path,
+) -> None:
+    """スペースを含むファイル名を正しく処理することを検証.
+
+    Given:
+        - スペースを含むファイル名の重複が存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - 正しくサフィックスが付与される
+    """
+    # Arrange
+    filename = "my image file.jpg"
+    (tmp_path / filename).touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / "my image file_1.jpg"
+
+
+# ============================================================================
+# 境界値のテスト（3件）
+# ============================================================================
+
+
+def test_handles_zero_existing_files(
+    tmp_path: Path,
+) -> None:
+    """既存ファイルが0件の場合、元のファイル名を返すことを検証.
+
+    Given:
+        - 空の出力ディレクトリ
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - 元のファイル名が返される
+    """
+    # Arrange
+    filename = "test.jpg"
+    # ディレクトリは空
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / filename
+
+
+def test_handles_many_duplicate_files(
+    tmp_path: Path,
+) -> None:
+    """多数の重複ファイルが存在する場合、適切な番号を選択することを検証.
+
+    Given:
+        - image.jpg から image_99.jpg までが存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - image_100.jpg が返される
+    """
+    # Arrange
+    filename = "image.jpg"
+    (tmp_path / filename).touch()
+    for i in range(1, 100):
+        (tmp_path / f"image_{i}.jpg").touch()
+
+    # Act
+    result = FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    assert result == tmp_path / "image_100.jpg"
+
+
+def test_does_not_modify_existing_files(
+    tmp_path: Path,
+) -> None:
+    """既存のファイルが変更されないことを検証.
+
+    Given:
+        - 既存ファイルが存在
+    When:
+        - get_unique_destinationを実行
+    Then:
+        - 既存ファイルが変更されていない
+    """
+    # Arrange
+    filename = "image.jpg"
+    existing_file = tmp_path / filename
+    existing_file.touch()
+    original_stat = existing_file.stat()
+
+    # Act
+    FileUtils.get_unique_destination(tmp_path, filename)
+
+    # Assert
+    # 既存ファイルが変更されていない（統計情報が同じ）
+    new_stat = existing_file.stat()
+    assert original_stat.st_size == new_stat.st_size


### PR DESCRIPTION
## 概要
- `FileUtils`クラスを新規追加し、静的メソッド`get_unique_destination`を実装
- `main.py`のコピー処理に統合し、同名ファイルの上書きを自動的に回避
- 包括的なテストを追加（20件の単体テスト + 2件の統合テスト）

## 主な変更
### 新規ファイル
- `src/utils/file_utils.py`: FileUtilsクラスの実装
- `src/utils/__init__.py`: Utilsパッケージのエクスポート定義
- `tests/utils/test_file_utils.py`: FileUtilsの単体テスト（20件）
- `tests/utils/__init__.py`: テストパッケージの初期化

### 変更ファイル
- `src/main.py`: FileUtilsを活用してファイルコピー時の重複回避を実装
- `src/__init__.py`: FileUtilsをパブリックAPIにエクスポート
- `tests/test_main.py`: 重複ファイル名のハンドリングを検証する統合テストを追加
- `README.md`: 動作しない直接実行手順を削除（ドキュメント修正）

## 機能詳細
### FileUtils.get_unique_destination()
- 出力ディレクトリ内で一意なファイルパスを生成
- 同名ファイルが存在する場合、`_1`, `_2`, ... の連番サフィックスを付与
- 拡張子を維持し、日本語ファイル名や特殊文字にも対応

## テスト
- 単体テスト: 20件（基本機能、拡張子維持、エッジケース、特殊文字、境界値）
- 統合テスト: 2件（同名ファイル、複数の同名ファイルのコピー処理）
- 全テスト通過: 69件

## 設計パターン
- `MetricNormalizer`と同様の静的ユーティリティクラスパターンを採用
- 状態を持たない純粋関数として実装
- コードベースの組織構造と整合性のある設計

## チェックリスト
- [x] 全テストが通過（`uv run task test`）
- [x] lintingエラーなし
- [x] 既存機能の維持