### PR TITLE
fix: dramatic_scoreの分母をピクセル数に修正

### DIFF
--- a/src/analyzers/image_quality_analyzer.py
+++ b/src/analyzers/image_quality_analyzer.py
@@ -62,7 +62,6 @@ class ImageQualityAnalyzer:
         gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
         hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
         gray_size = gray.size
-        img_size = img.size
         gray_mean = np.mean(gray)
         kernel = np.array([[-1, 0, 1], [-2, 0, 2], [-1, 0, 1]])
 
@@ -78,7 +77,7 @@ class ImageQualityAnalyzer:
             "action_intensity": np.std(cv2.filter2D(gray, -1, kernel)),
             "visual_balance": max(0, 100 - abs(gray_mean - 128) * 0.5),
             "dramatic_score": (
-                np.sum((hsv[:, :, 1] > 180) & (hsv[:, :, 2] > 180)) / img_size
+                np.sum((hsv[:, :, 1] > 180) & (hsv[:, :, 2] > 180)) / gray_size
             )
             * 1000,
         }


### PR DESCRIPTION
## 概要
`dramatic_score` の計算式で、分母がチャネル込みの全要素数になっていた問題を修正しました。

## 変更内容
- `img.size`（高さ×幅×チャネル数）を `gray.size`（高さ×幅、ピクセル数）に変更
- RGB画像の場合、これまではチャネル数3で割っていたため、正しいピクセル割合の1/3になっていました
- 未使用になった `img_size` 変数を削除

## 影響範囲
- `src/analyzers/image_quality_analyzer.py`
  - `dramatic_score` の計算式
  - `img_size` 変数の削除

## テスト
- リンティングチェック: パス
- ユニットテスト65件: 全件パス