### PR TITLE
refactor: ImageQualityAnalyzerの画像二重読み込みを解消しI/O負荷を50%削減

### DIFF
--- a/src/analyzers/image_quality_analyzer.py
+++ b/src/analyzers/image_quality_analyzer.py
@@ -37,17 +37,18 @@ class ImageQualityAnalyzer:
     def analyze(self, path: str) -> Optional[ImageMetrics]:
         """画像を解析して品質スコアを計算する."""
         try:
-            img = cv2.imread(path)
-            if img is None:
-                return None
+            # PILで1回だけ読み込み、ファイル記述子のリークを防止
+            with Image.open(path) as pil_img:
+                # OpenCV形式（BGR）に変換
+                img = cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
 
-            features = self._extract_diversity_features(img)
-            raw = self._calculate_raw_metrics(img)
-            norm = MetricNormalizer.normalize_all(raw)
-            semantic = self._calculate_semantic_score(path)
-            total = self._calculate_total_score(raw, norm, semantic)
+                features = self._extract_diversity_features(img)
+                raw = self._calculate_raw_metrics(img)
+                norm = MetricNormalizer.normalize_all(raw)
+                semantic = self._calculate_semantic_score(pil_img)
+                total = self._calculate_total_score(raw, norm, semantic)
 
-            return ImageMetrics(path, raw, norm, semantic, total, features)
+                return ImageMetrics(path, raw, norm, semantic, total, features)
         except self._get_expected_errors() as e:
             logger.warning(
                 f"画像分析をスキップしました: {path}, 理由: {type(e).__name__}: {e}"
@@ -83,17 +84,16 @@ class ImageQualityAnalyzer:
             * 1000,
         }
 
-    def _calculate_semantic_score(self, path: str) -> float:
+    def _calculate_semantic_score(self, pil_img: Image.Image) -> float:
         """CLIPモデルを使用してセマンティックスコアを計算する."""
         with torch.no_grad():
-            with Image.open(path) as pil_img:
-                inputs = self.processor(
-                    text=["epic game scenery"],
-                    images=pil_img,
-                    return_tensors="pt",
-                    padding=True,
-                ).to(self.device)
-                return float(self.model(**inputs).logits_per_image[0][0]) / 100.0
+            inputs = self.processor(
+                text=["epic game scenery"],
+                images=pil_img,
+                return_tensors="pt",
+                padding=True,
+            ).to(self.device)
+            return float(self.model(**inputs).logits_per_image[0][0]) / 100.0
 
     def _calculate_total_score(
         self, raw: dict[str, float], norm: dict[str, float], semantic: float


### PR DESCRIPTION
## 概要
画像分析処理において、同じファイルを2回読み込む無駄を解消し、パフォーマンスを改善しました。

## 変更内容

### 対象ファイル
- `src/analyzers/image_quality_analyzer.py`

### 変更詳細

**修正前:**
- `cv2.imread()` で1回目の読み込み
- `Image.open()` で2回目の読み込み

**修正後:**
- `Image.open()` で1回だけ読み込み
- PIL画像を `cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)` でOpenCV形式（BGR）に変換

### 技術的詳細
- PIL ImageはRGB形式、OpenCVはBGR形式であるため、色空間の変換が必要
- `with Image.open()` を使用し、ファイル記述子のリークを防止
- 既存のエラーハンドリング（`_get_expected_errors()`）を維持

## テスト結果
```
65 passed in 49.50s
```
すべてのテストがパスしました。

## 期待される効果
- 画像読み込み回数: 2回 → 1回（50%削減）
- I/O負荷の軽減
- 大量の画像処理時のパフォーマンス改善