### PR TITLE
fix: 入力フォルダのバリデーションを追加し誤指定時にエラーを表示するように修正

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -39,6 +39,13 @@ class Main:
         """CLIを実行する."""
         parsed_args = self._parse_arguments()
 
+        # 入力フォルダのバリデーション
+        input_path = Path(parsed_args.input)
+        if not input_path.exists():
+            raise FileNotFoundError(f"入力フォルダが存在しません: {parsed_args.input}")
+        if not input_path.is_dir():
+            raise NotADirectoryError(f"指定パスはフォルダではありません: {parsed_args.input}")
+
         # 依存関係の遅延初期化（引数パース後にジャンルが決まるため）
         if self._analyzer is None:
             self._analyzer = ImageQualityAnalyzer(parsed_args.genre)

--- a/src/main.py
+++ b/src/main.py
@@ -44,7 +44,9 @@ class Main:
         if not input_path.exists():
             raise FileNotFoundError(f"入力フォルダが存在しません: {parsed_args.input}")
         if not input_path.is_dir():
-            raise NotADirectoryError(f"指定パスはフォルダではありません: {parsed_args.input}")
+            raise NotADirectoryError(
+                f"指定パスはフォルダではありません: {parsed_args.input}"
+            )
 
         # 依存関係の遅延初期化（引数パース後にジャンルが決まるため）
         if self._analyzer is None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -321,6 +321,7 @@ def test_cli_handles_empty_input_directory(
 
     # Act
     from src.main import Main
+
     Main().run()
 
     # Assert
@@ -348,6 +349,7 @@ def test_cli_exits_with_error_for_nonexistent_input_directory(
 
     # Act & Assert
     from src.main import Main
+
     with pytest.raises(FileNotFoundError) as exc_info:
         Main().run()
 
@@ -375,6 +377,7 @@ def test_cli_exits_with_error_when_file_instead_of_directory(
 
     # Act & Assert
     from src.main import Main
+
     with pytest.raises(NotADirectoryError) as exc_info:
         Main().run()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -297,46 +297,89 @@ def test_cli_copies_selected_images_to_output_directory(
 # ============================================================================
 
 
-@pytest.mark.parametrize(
-    "input_dir_func",
-    [
-        lambda tmp_path: str(tmp_path / "empty"),
-        lambda _: "/nonexistent/directory/that/does/not/exist",
-    ],
-)
-def test_cli_handles_empty_and_nonexistent_input_directories(
+def test_cli_handles_empty_input_directory(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
     mock_game_screen_picker: MagicMock,
     tmp_path: Path,
-    input_dir_func: Callable[[Path], str],
 ) -> None:
-    """空のディレクトリと存在しないディレクトリが正しく処理されること.
+    """空のディレクトリが正しく処理されること.
 
     Given:
-        - 空の入力ディレクトリ、または存在しない入力ディレクトリパスがある
+        - 空の入力ディレクトリがある
     When:
         - CLIが実行される
     Then:
         - プログラムがクラッシュせず、0件の結果が適切に表示されること
     """
     # Arrange
-    input_dir = input_dir_func(tmp_path)
-    if "empty" in input_dir:
-        Path(input_dir).mkdir()
+    input_dir = str(tmp_path / "empty")
+    Path(input_dir).mkdir()
     mock_game_screen_picker.select.return_value = []
 
     monkeypatch.setattr("sys.argv", ["main.py", input_dir])
 
     # Act
     from src.main import Main
-
     Main().run()
 
     # Assert
     captured = capsys.readouterr()
     assert "選択された画像一覧" in captured.out
     assert "Score:" not in captured.out  # 0件
+
+
+def test_cli_exits_with_error_for_nonexistent_input_directory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """存在しないディレクトリを指定した場合にエラーが発生すること.
+
+    Given:
+        - 存在しない入力ディレクトリパスがある
+    When:
+        - CLIが実行される
+    Then:
+        - FileNotFoundErrorが発生すること
+        - エラーメッセージにパスが含まれること
+    """
+    # Arrange
+    input_dir = "/nonexistent/directory/that/does/not/exist"
+    monkeypatch.setattr("sys.argv", ["main.py", input_dir])
+
+    # Act & Assert
+    from src.main import Main
+    with pytest.raises(FileNotFoundError) as exc_info:
+        Main().run()
+
+    assert input_dir in str(exc_info.value)
+    assert "入力フォルダが存在しません" in str(exc_info.value)
+
+
+def test_cli_exits_with_error_when_file_instead_of_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """ファイルパスを指定した場合にエラーが発生すること.
+
+    Given:
+        - ファイルパスがある
+    When:
+        - CLIが実行される
+    Then:
+        - NotADirectoryErrorが発生すること
+    """
+    # Arrange
+    test_file = tmp_path / "image.jpg"
+    test_file.touch()
+    monkeypatch.setattr("sys.argv", ["main.py", str(test_file)])
+
+    # Act & Assert
+    from src.main import Main
+    with pytest.raises(NotADirectoryError) as exc_info:
+        Main().run()
+
+    assert str(test_file) in str(exc_info.value)
+    assert "フォルダではありません" in str(exc_info.value)
 
 
 # ============================================================================


### PR DESCRIPTION
## 概要
ユーザーが存在しないフォルダパスを指定した場合、何もエラー表示されず空結果で終了してしまう問題を修正しました。適切なバリデーションとエラーメッセージを追加し、ユーザーが入力ミスに気づけるようにしました。

## 変更内容
- `Main.run()` メソッドの先頭で入力フォルダのバリデーションを追加
  - 存在しないパス: `FileNotFoundError`
  - ファイルを指定: `NotADirectoryError`
- テストをパラメータ化テストから3つの独立したテストに分割
  - 空ディレクトリの正常処理
  - 存在しないディレクトリのエラー
  - ファイルパス指定時のエラー

## 動作確認
```bash
# 存在しないフォルダ → エラー
uv run python -m src.main /nonexistent/folder
# FileNotFoundError: 入力フォルダが存在しません: /nonexistent/folder

# ファイル指定 → エラー
uv run python -m src.main /path/to/image.jpg
# NotADirectoryError: 指定パスはフォルダではありません: /path/to/image.jpg

# 空フォルダ → 正常終了（0件）
uv run python -m src.main /tmp/empty_folder
# 正常に「選択された画像一覧」のみ表示
```

## テスト
- ✅ すべての単体テストがパス (10/10)
- ✅ 画面選択ピッカーのテストも維持