### PR TITLE
fix: CLIエントリポイントのTypeErrorを修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [project.scripts]
-game-screen-pick = "src.main:Main.run"
+game-screen-pick = "src.main:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/main.py
+++ b/src/main.py
@@ -172,5 +172,13 @@ class Main:
             print(f"[{i + 1}] {Path(res.path).name} (Score: {res.total_score:.2f})")
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """CLIエントリポイント関数.
+
+    pyproject.tomlの[project.scripts]から呼び出される。
+    """
     Main().run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要

CLI実行時に発生していた `TypeError: Main.run() missing 1 required positional argument: 'self'` を修正しました。

## 変更内容

- **src/main.py**: エントリポイント用の `main()` 関数を追加
- **pyproject.toml**: エントリポイントを `src.main:Main.run` から `src.main:main` に変更

## 原因

Pythonのエントリポイントはモジュールレベルの関数を指定する必要がありますが、
`Main.run()` はインスタンスメソッドであったため、CLIから直接呼び出すことができませんでした。

## テスト計画

- [x] CLI `--help` が正常に動作することを確認
- [x] 既存の78件のテストが全てパスすることを確認（後方互換性維持）