### PR TITLE
perf: CLIPテキスト埋め込みキャッシュによる大量画像分析時の処理速度改善

### DIFF
--- a/src/analyzers/image_quality_analyzer.py
+++ b/src/analyzers/image_quality_analyzer.py
@@ -26,6 +26,19 @@ class ImageQualityAnalyzer:
         self.processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.model.to(self.device)
+        # テキスト埋め込みの事前計算とキャッシュ
+        self._target_text = "epic game scenery"
+        self._text_embeddings = self._precompute_text_embeddings()
+
+    def _precompute_text_embeddings(self) -> torch.Tensor:
+        """テキスト埋め込みを事前計算してキャッシュする."""
+        with torch.no_grad():
+            inputs = self.processor(
+                text=[self._target_text],
+                return_tensors="pt",
+                padding=True,
+            ).to(self.device)
+            return self.model.get_text_features(**inputs)  # type: ignore[no-any-return]
 
     def _extract_diversity_features(self, img: np.ndarray) -> np.ndarray:
         """見た目の特徴を抽出（色と構造）."""
@@ -87,12 +100,15 @@ class ImageQualityAnalyzer:
         """CLIPモデルを使用してセマンティックスコアを計算する."""
         with torch.no_grad():
             inputs = self.processor(
-                text=["epic game scenery"],
                 images=pil_img,
                 return_tensors="pt",
                 padding=True,
             ).to(self.device)
-            return float(self.model(**inputs).logits_per_image[0][0]) / 100.0
+            image_features = self.model.get_image_features(**inputs)
+
+            # キャッシュされたテキスト埋め込みを使用
+            logits = torch.matmul(image_features, self._text_embeddings.T)
+            return float(logits[0][0]) / 100.0
 
     def _calculate_total_score(
         self, raw: dict[str, float], norm: dict[str, float], semantic: float

--- a/tests/analyzers/test_image_quality_analyzer.py
+++ b/tests/analyzers/test_image_quality_analyzer.py
@@ -38,11 +38,27 @@ def mock_clip_model() -> Generator[MagicMock, None, None]:
     """
     with patch("transformers.CLIPModel.from_pretrained") as mock:
         model = MagicMock()
-        # 一貫したテストのために固定されたlogit値を返す
+
+        # get_text_features用のモック（テキスト埋め込み）
+        # 実際のテンソルを返すように修正
+        text_features = torch.tensor([[1.0]])
+
+        # get_image_features用のモック（画像埋め込み）
+        # matmulで使用できるように実際のテンソルを返す
+        image_features = torch.tensor([[25.0]])  # logits計算用のダミー値
+
+        # メソッドをモック
+        model.get_text_features = MagicMock(return_value=text_features)
+        model.get_image_features = MagicMock(return_value=image_features)
+
+        # .to()メソッドと既存の__call__もモック
+        model.to = MagicMock(return_value=model)
+
+        # 既存の呼び出し形式のモック（後方互換性）
         mock_output = MagicMock()
         mock_output.logits_per_image = torch.tensor([[25.0]])
         model.return_value = mock_output
-        model.to = MagicMock(return_value=model)
+
         mock.return_value = model
         yield mock
 


### PR DESCRIPTION
## 概要

ImageQualityAnalyzerの初期化時に固定テキスト`"epic game scenery"`の埋め込みを事前計算してキャッシュするように変更しました。これにより、大量の画像分析時にテキスト埋め込みの再計算を回避し、処理速度を改善します。

## 変更内容

### `src/analyzers/image_quality_analyzer.py`

- **`__init__`メソッド**: テキスト埋め込みの事前計算とキャッシュを追加
  - `self._target_text = "epic game scenery"` で固定テキストを保持
  - `self._text_embeddings = self._precompute_text_embeddings()` で埋め込みをキャッシュ

- **`_precompute_text_embeddings`メソッド（新規）**: テキスト埋め込みを事前計算してキャッシュ

- **`_calculate_semantic_score`メソッド**: 修正前は画像ごとにテキストをprocessorに通していたが、キャッシュされた埋め込みを使用するように変更
  - 修正前: `processor(text=["epic game scenery"], images=pil_img, ...)`
  - 修正後: `processor(images=pil_img, ...)` + キャッシュされた `self._text_embeddings` を使用

### `tests/analyzers/test_image_quality_analyzer.py`

- **`mock_clip_model`フィクスチャ**: 新しい `get_text_features` と `get_image_features` メソッドのモックを追加

## 期待される効果

- **1000枚の画像分析で、テキスト埋め込みの計算が1回だけになり、999回分の計算を削減**
- **処理時間の短縮**（特に大量画像時）
- **メモリ使用量の削減**（テキスト埋め込みの再計算なし）

## テスト計画

- [x] 既存テストの実行
- [x] すべてのテストがパスすることを確認 (78 tests passed)

```bash
uv run task test
```