### PR TITLE
perf: CVメトリクス計算で画像を縮小して処理速度を向上

### DIFF
--- a/src/analyzers/image_quality_analyzer.py
+++ b/src/analyzers/image_quality_analyzer.py
@@ -79,7 +79,19 @@ class ImageQualityAnalyzer:
             raise
 
     def _calculate_raw_metrics(self, img: np.ndarray) -> dict[str, float]:
-        """生の画像メトリクスを計算する."""
+        """生の画像メトリクスを計算する.
+
+        メトリクス計算用に画像を長辺720pxに縮小して処理することで、
+        計算コストを削減する。アスペクト比は保持する。
+        """
+        # メトリクス計算用に画像を縮小（長辺720px、アスペクト比保持）
+        h, w = img.shape[:2]
+        max_dim = 720
+        if max(h, w) > max_dim:
+            scale = max_dim / max(h, w)
+            new_h, new_w = int(h * scale), int(w * scale)
+            img = cv2.resize(img, (new_w, new_h), interpolation=cv2.INTER_AREA)
+
         gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
         hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
         gray_size = gray.size


### PR DESCRIPTION
## 概要
CVメトリクス計算を画像縮小で高速化します。

## 変更内容
- メトリクス計算用に画像を長辺720pxに縮小して処理
- アスペクト比を保持
- INTER_AREA補間で品質を維持

## 効果
- フル解像度計算によるCPU負荷を大幅に削減
- 1920x1080程度の画像で約6倍の計算削減（面積比）
- 品質劣化は閾値調整で吸収可能（既存テスト全件パス）

## テスト
- 全54件のテストがパス済み