### PR TITLE
perf: 類似度計算を事前正規化とnp.dotに置き換えて処理速度を向上

### DIFF
--- a/src/services/screen_picker.py
+++ b/src/services/screen_picker.py
@@ -3,7 +3,8 @@
 from pathlib import Path
 from typing import List
 import random
-from sklearn.metrics.pairwise import cosine_similarity
+
+import numpy as np
 
 from ..analyzers.image_quality_analyzer import ImageQualityAnalyzer
 from ..models.image_metrics import ImageMetrics
@@ -81,24 +82,33 @@ class GameScreenPicker:
         m = max(num * 5, 200)
         candidates = all_results[:m]
 
-        selected: List[ImageMetrics] = []
+        # 特徴量を事前にL2正規化（コサイン類似度 = 内積になる）
+        # 正規化されたベクトル同士の内積はコサイン類似度と等価
+        normalized_features = [
+            c.features / np.linalg.norm(c.features) for c in candidates
+        ]
 
-        for candidate in candidates:
+        selected: List[ImageMetrics] = []
+        selected_features: List[np.ndarray] = []
+
+        for idx, candidate in enumerate(candidates):
             if len(selected) >= num:
                 break
 
+            candidate_feat = normalized_features[idx]
+
             # 既に選ばれた画像たちと「見た目」を比較
+            # 事前正規化済みなので np.dot だけでコサイン類似度を計算可能
             is_similar = False
-            for s in selected:
-                sim = cosine_similarity(
-                    candidate.features.reshape(1, -1), s.features.reshape(1, -1)
-                )[0][0]
+            for s_feat in selected_features:
+                sim = np.dot(candidate_feat, s_feat)
                 if sim > similarity_threshold:
                     is_similar = True
                     break
 
             if not is_similar:
                 selected.append(candidate)
+                selected_features.append(candidate_feat)
 
         return selected
 


### PR DESCRIPTION
## 概要
sklearnの`cosine_similarity`呼び出しを、特徴量の事前L2正規化と`np.dot`による内積計算に置き換え、処理速度を向上させました。

## 変更内容
- `sklearn.metrics.pairwise.cosine_similarity`の使用を削除
- 特徴量を事前にL2正規化
- ループ内の類似度計算を`np.dot`に置き換え（正規化済みベクトルの内積＝コサイン類似度）

## 効果
候補画像数が多い場合、sklearn関数の呼び出しオーバーヘッドが削減され、処理速度が向上します。

## テスト計画
- [x] 既存の50個のテスト全てがパスすることを確認