### PR TITLE
perf: OOM発生時に失敗したバッチのみを再試行して無駄な計算を削減

### DIFF
--- a/src/analyzers/image_quality_analyzer.py
+++ b/src/analyzers/image_quality_analyzer.py
@@ -292,9 +292,10 @@ class ImageQualityAnalyzer:
     ) -> List[Optional[float]]:
         """複数のPIL画像に対してCLIP推論をバッチ実行する.
 
-        OOM対策:
+        OOM対策（失敗したバッチのみ再試行）:
         - initial_batch_sizeから開始（デフォルト32）
-        - torch.cuda.OutOfMemoryError発生時にバッチサイズを半分にしてリトライ
+        - torch.cuda.OutOfMemoryError発生時に失敗したバッチのみを分割してリトライ
+        - 未処理のバッチは縮小されたバッチサイズで処理
         - 最小バッチサイズ1まで試行（32→16→8→4→2→1）
         - それでも失敗した画像はNoneとして返す
 
@@ -316,53 +317,58 @@ class ImageQualityAnalyzer:
         # 結果を格納する配列（初期値はNone）
         results: List[Optional[float]] = [None] * len(pil_images)
 
-        # バッチサイズをinitial_batch_sizeから開始
+        # 現在のバッチサイズ
         current_batch_size = initial_batch_size
 
-        # バッチ処理
-        while current_batch_size >= 1:
+        # 処理位置を追跡
+        i = 0
+        while i < len(valid_images):
+            # 現在のバッチを取得
+            batch_start = i
+            batch_end = min(i + current_batch_size, len(valid_images))
+            batch: List[Image.Image] = valid_images[batch_start:batch_end]
+
             try:
-                for i in range(0, len(valid_images), current_batch_size):
-                    batch: List[Image.Image] = valid_images[i : i + current_batch_size]
+                # GPUの場合はautocastでfp16推論を使用（高速化）
+                autocast_context = (
+                    torch.autocast(device_type="cuda", dtype=torch.float16)
+                    if self.device == "cuda"
+                    else contextlib.nullcontext()
+                )
+                with autocast_context, torch.inference_mode():
+                    inputs = self.processor(
+                        images=batch,
+                        return_tensors="pt",
+                        padding=True,
+                    ).to(self.device)
+                    image_features = self.model.get_image_features(**inputs)
 
-                    # GPUの場合はautocastでfp16推論を使用（高速化）
-                    autocast_context = (
-                        torch.autocast(device_type="cuda", dtype=torch.float16)
-                        if self.device == "cuda"
-                        else contextlib.nullcontext()
-                    )
-                    with autocast_context, torch.inference_mode():
-                        inputs = self.processor(
-                            images=batch,
-                            return_tensors="pt",
-                            padding=True,
-                        ).to(self.device)
-                        image_features = self.model.get_image_features(**inputs)
+                    # キャッシュされたテキスト埋め込みを使用
+                    logits = torch.matmul(image_features, self._text_embeddings.T)
+                    batch_scores = (logits[:, 0] / 100.0).cpu().tolist()
 
-                        # キャッシュされたテキスト埋め込みを使用
-                        logits = torch.matmul(image_features, self._text_embeddings.T)
-                        batch_scores = (logits[:, 0] / 100.0).cpu().tolist()
+                # 結果を元のインデックスにマッピング
+                for j, score in enumerate(batch_scores):
+                    original_idx = valid_indices[batch_start + j]
+                    results[original_idx] = score
 
-                    # 結果を元のインデックスにマッピング
-                    for j, score in enumerate(batch_scores):
-                        results[valid_indices[i + j]] = score
-
-                # 成功したらループを抜ける
-                break
+                # バッチ処理成功、次へ進む
+                i = batch_end
 
             except torch.cuda.OutOfMemoryError:
                 # バッチサイズを半分にしてリトライ
-                current_batch_size = current_batch_size // 2
-                # まだリトライ余地があれば警告
-                if current_batch_size >= 1:
+                new_batch_size = current_batch_size // 2
+                if new_batch_size >= 1:
                     logger.warning(
-                        f"CUDA OOM発生。バッチサイズを{current_batch_size}"
-                        "に縮小してリトライします。"
+                        f"CUDA OOM発生（位置{batch_start}/{len(valid_images)}）。"
+                        f"バッチサイズを{new_batch_size}に縮小してリトライします。"
                     )
+                    current_batch_size = new_batch_size
+                    # i は変更せず、同じ位置から小さいバッチサイズでリトライ
                 else:
                     logger.error(
-                        "バッチサイズ1でもOOMが発生しました。"
-                        "一部画像の処理をスキップします。"
+                        f"バッチサイズ1でもOOMが発生しました（位置{batch_start}）。"
+                        "残りの画像の処理をスキップします。"
                     )
                     # 処理済みの結果は残すが、未処理の画像はNoneのまま
                     break

--- a/tests/analyzers/test_image_quality_analyzer.py
+++ b/tests/analyzers/test_image_quality_analyzer.py
@@ -405,3 +405,80 @@ def test_analyze_batch_falls_back_on_oom(
     assert isinstance(results[0], ImageMetrics)
     # バッチサイズ縮小のために少なくとも2回呼び出されている
     assert call_count[0] >= 2
+
+
+def test_analyze_batch_retries_only_failed_batches_on_oom(
+    sample_image_path: str,
+    png_image_path: str,
+    small_image_path: str,
+    dark_image_path: str,
+) -> None:
+    """OOM発生時に失敗したバッチのみが再試行されること.
+
+    Given:
+        - アナライザインスタンスがある
+        - 複数の有効なテスト画像がある
+        - 2番目のバッチでCUDA OOMが発生する状況
+    When:
+        - バッチ処理で分析される（バッチサイズ2）
+    Then:
+        - 最初のバッチの結果が保持されること
+        - 失敗したバッチのみが縮小されて再試行されること
+        - すべての有効な画像の結果が返されること
+    """
+    # Arrange
+    analyzer = ImageQualityAnalyzer()
+    paths = [sample_image_path, png_image_path, small_image_path, dark_image_path]
+    batch_size = 2  # 2画像ずつ処理
+
+    # Act & Assert
+    # 2番目の呼び出しでOOMを発生させる
+    original_model = analyzer.model
+    call_count = [0]
+    batch_sizes_seen: list[int] = []
+
+    def mock_get_image_features_with_oom(**kwargs: object) -> torch.Tensor:
+        call_count[0] += 1
+
+        # pixel_values から実際のバッチサイズを取得
+        inputs = kwargs.get("pixel_values")
+        if inputs is not None and isinstance(inputs, torch.Tensor):
+            actual_batch_size = inputs.shape[0]
+        else:
+            actual_batch_size = 1  # フォールバック
+
+        batch_sizes_seen.append(actual_batch_size)
+
+        # 2番目の呼び出し（バッチ2）でOOMを発生
+        if call_count[0] == 2:
+            raise torch.cuda.OutOfMemoryError()
+
+        # 該当するバッチサイズのテンソルを返す
+        return torch.randn(actual_batch_size, 512)
+
+    with patch.object(
+        original_model,
+        "get_image_features",
+        side_effect=mock_get_image_features_with_oom,
+    ):
+        results = analyzer.analyze_batch(paths, batch_size=batch_size)
+
+    # Assert - すべての画像が処理されている
+    assert len(results) == 4
+    for result in results:
+        assert result is not None
+        assert isinstance(result, ImageMetrics)
+
+    # 呼び出しパターンを検証:
+    # 1. 最初のバッチ(サイズ2)が正常処理
+    # 2. 2番目のバッチ(サイズ2)でOOM発生
+    # 3. バッチサイズ1でリトライ
+    # 4. バッチサイズ1で残りを処理
+    assert len(batch_sizes_seen) >= 3
+
+    # 最初の呼び出しはバッチサイズ2
+    assert batch_sizes_seen[0] == 2
+    # 2番目の呼び出しもバッチサイズ2（ここでOOM）
+    assert batch_sizes_seen[1] == 2
+    # 3番目の呼び出しはバッチサイズ1（OOM後のリトライ）
+    assert batch_sizes_seen[2] == 1


### PR DESCRIPTION
## 概要
OOM発生時に失敗したバッチのみを分割再試行する方式に改善し、境界付近での無駄な再計算を削減しました。

## 変更内容
- `_calculate_semantic_scores_batch` メソッドをリファクタリング
- **Before**: OOM発生時にバッチサイズを縮小して全画像を先頭から処理し直す
- **After**: 失敗したバッチのみを分割して再試行し、処理済みバッチの結果は保持

## 効果
- 境界付近（例: 100枚中90枚目でOOM）での無駄な再計算を削減
- OOM発生時の処理劣化を抑制

## テスト
- `test_analyze_batch_retries_only_failed_batches_on_oom` を追加
- 51 tests passed