### PR TITLE
fix: 特徴ベクトルのゼロノルム時に正規化処理を安全化

### DIFF
--- a/src/services/screen_picker.py
+++ b/src/services/screen_picker.py
@@ -84,9 +84,15 @@ class GameScreenPicker:
 
         # 特徴量を事前にL2正規化（コサイン類似度 = 内積になる）
         # 正規化されたベクトル同士の内積はコサイン類似度と等価
-        normalized_features = [
-            c.features / np.linalg.norm(c.features) for c in candidates
-        ]
+        eps = 1e-8
+        normalized_features = []
+        for c in candidates:
+            norm = np.linalg.norm(c.features)
+            if norm < eps:
+                # ゼロノルムの場合はゼロベクトルとして扱う
+                normalized_features.append(np.zeros_like(c.features))
+            else:
+                normalized_features.append(c.features / norm)
 
         selected: List[ImageMetrics] = []
         selected_features: List[np.ndarray] = []

--- a/tests/services/test_screen_picker.py
+++ b/tests/services/test_screen_picker.py
@@ -39,7 +39,12 @@ def _create_features_with_similarity(
         指定された類似度を持つ新しい特徴ベクトル
     """
     # ベースを正規化
-    base_normalized = base_features / np.linalg.norm(base_features)
+    eps = 1e-8
+    norm = np.linalg.norm(base_features)
+    if norm < eps:
+        base_normalized = base_features  # ゼロベクトルの場合はそのまま使用
+    else:
+        base_normalized = base_features / norm
 
     # 直交成分の大きさを計算: sqrt(1 - cos^2)
     orthogonal_norm = np.sqrt(max(0, 1 - target_similarity**2))


### PR DESCRIPTION
## 概要
L2正規化処理において、ノルムがゼロまたは非常に小さい場合のゼロ除算による数値的不安定さを防止する安全化を実装しました。

## 変更内容
- `src/services/screen_picker.py`: 正規化処理に `eps = 1e-8` の閾値チェックを追加し、ノルムが閾値未満の場合はゼロベクトルとして扱う
- `tests/services/test_screen_picker.py`: テストヘルパー関数にも同様の安全化を適用

## テスト
- 全59件のテストがパスすることを確認