### PR TITLE
fix: -nオプションの未達を解消して段階的しきい値緩和で指定数を確実に返すように修正

### DIFF
--- a/src/services/screen_picker.py
+++ b/src/services/screen_picker.py
@@ -65,9 +65,10 @@ class GameScreenPicker:
     ) -> List[ImageMetrics]:
         """多様性を考慮して画像を選択する.
 
-        2段階選抜方式で性能を最適化：
-        1. まず品質スコア上位M件に絞る（M = max(num*5, 200)）
-        2. その上位M件の中で類似度判定を行う
+        段階的しきい値緩和で指定数を確実に満たす：
+        1. 全候補を対象に類似度判定を行う
+        2. 指定数に満たない場合、しきい値を段階的に緩和
+        3. 最終フォールバックとして類似度制約を外して高スコア順で埋める
 
         Args:
             all_results: 解析済みの画像メトリクスリスト（スコア降順ソート済み）
@@ -75,40 +76,70 @@ class GameScreenPicker:
             similarity_threshold: 類似度の閾値（これ以上は類似とみなす）
 
         Returns:
-            選択された画像メトリクスのリスト
+            選択された画像メトリクスのリスト（最大num件、有効画像数以下なら必ずnum件）
         """
-        # 2段階選抜：まず上位M件に絞る
-        # Mの値は取得数の5倍か200の大きい方（多様性確保のため）
-        m = max(num * 5, 200)
-        candidates = all_results[:m]
+        if not all_results:
+            return []
+
+        # 全候補を対象にする（固定上位M件の制限を廃止）
+        candidates = all_results
 
         # 特徴量を事前にL2正規化（コサイン類似度 = 内積になる）
-        # 正規化されたベクトル同士の内積はコサイン類似度と等価
         normalized_features = [
             c.features / np.linalg.norm(c.features) for c in candidates
         ]
 
-        selected: List[ImageMetrics] = []
-        selected_features: List[np.ndarray] = []
+        # 段階的しきい値緩和のステップ（上限0.98）
+        threshold_steps = [
+            similarity_threshold,
+            min(similarity_threshold + 0.03, 0.98),
+            min(similarity_threshold + 0.06, 0.98),
+            min(similarity_threshold + 0.10, 0.98),
+            min(similarity_threshold + 0.15, 0.98),
+        ]
 
-        for idx, candidate in enumerate(candidates):
+        selected: List[ImageMetrics] = []
+        selected_indices: set[int] = set()
+
+        # 各しきい値で選択を試行
+        for threshold in threshold_steps:
             if len(selected) >= num:
                 break
 
-            candidate_feat = normalized_features[idx]
-
-            # 既に選ばれた画像たちと「見た目」を比較
-            # 事前正規化済みなので np.dot だけでコサイン類似度を計算可能
-            is_similar = False
-            for s_feat in selected_features:
-                sim = np.dot(candidate_feat, s_feat)
-                if sim > similarity_threshold:
-                    is_similar = True
+            for idx, candidate in enumerate(candidates):
+                if len(selected) >= num:
                     break
 
-            if not is_similar:
-                selected.append(candidate)
-                selected_features.append(candidate_feat)
+                if idx in selected_indices:
+                    continue
+
+                candidate_feat = normalized_features[idx]
+
+                # 既に選ばれた画像たちと「見た目」を比較
+                is_similar = False
+                for sel_idx in selected_indices:
+                    sel_feat = normalized_features[sel_idx]
+                    sim = np.dot(candidate_feat, sel_feat)
+                    if sim > threshold:
+                        is_similar = True
+                        break
+
+                if not is_similar:
+                    selected.append(candidate)
+                    selected_indices.add(idx)
+
+        # 最終フォールバック：まだ不足する場合は未選択の高スコア順で埋める
+        # （類似度制約を外す）
+        if len(selected) < num:
+            for idx, candidate in enumerate(candidates):
+                if len(selected) >= num:
+                    break
+                if idx not in selected_indices:
+                    selected.append(candidate)
+                    selected_indices.add(idx)
+
+        # スコア順でソートして返す
+        selected.sort(key=lambda x: x.total_score, reverse=True)
 
         return selected
 

--- a/tests/services/test_screen_picker.py
+++ b/tests/services/test_screen_picker.py
@@ -414,3 +414,84 @@ def test_selecting_gracefully_handles_files_that_fail_to_analyze(
         # Assert
         # 奇数インデックスの画像のみ有効（image1, image3）
         assert len(result) <= 2
+
+
+def test_always_returns_requested_number_when_enough_unique_images_exist(
+    sample_image_metrics: List[ImageMetrics],
+) -> None:
+    """十分な数の一意な画像が存在する場合、常に要求数を返すこと.
+
+    Given:
+        - 5つの分析済み画像（一部類似）
+    When:
+        - 高い類似度閾値（0.9）で5つの画像を選択
+    Then:
+        - 類似画像はフィルタリングされるが、指定数を満たすために
+          段階的しきい値緩和と最終フォールバックにより5件が返されること
+    """
+    # Arrange
+    num_to_select = 5
+    similarity_threshold = 0.9
+
+    # Act
+    result = GameScreenPicker.select_from_analyzed(
+        sample_image_metrics, num_to_select, similarity_threshold
+    )
+
+    # Assert
+    # 5枚要求して5枚存在するので、必ず5枚返されるはず
+    assert len(result) == 5
+    # スコア順になっているはず
+    scores = [m.total_score for m in result]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_gradual_threshold_relaxation_and_fallback_for_similar_images() -> None:
+    """類似した画像ばかりの場合、しきい値緩和と最終フォールバックが機能すること.
+
+    Given:
+        - 10枚の非常に類似した画像（0.97-0.99の類似度）
+        - 類似度閾値0.9
+    When:
+        - 10枚の画像を選択
+    Then:
+        - 段階的しきい値緩和により可能な限り多様性を確保しつつ
+          最終的に10枚全てが返されること
+    """
+    # Arrange
+    np.random.seed(42)
+
+    # ベース特徴ベクトル
+    base_features = np.random.rand(128)
+
+    # 0.97-0.99の類似度を持つ10枚の画像を生成
+    similar_images: List[ImageMetrics] = []
+    for i in range(10):
+        # 0.97-0.99の類似度で生成
+        target_sim = 0.97 + (i % 3) * 0.01  # 0.97, 0.98, 0.99を繰り返し
+        similar_features = _create_features_with_similarity(base_features, target_sim)
+        similar_images.append(
+            ImageMetrics(
+                path=f"/fake/path/similar{i}.jpg",
+                raw_metrics={"blur_score": 100.0 - i},
+                normalized_metrics={"blur_score": 0.9},
+                semantic_score=0.8,
+                total_score=100.0 - i,
+                features=similar_features,
+            )
+        )
+
+    num_to_select = 10
+    similarity_threshold = 0.9
+
+    # Act
+    result = GameScreenPicker.select_from_analyzed(
+        similar_images, num_to_select, similarity_threshold
+    )
+
+    # Assert
+    # 10枚要求して10枚存在するので、必ず10枚返されるはず
+    assert len(result) == 10
+    # スコア順になっているはず
+    scores = [m.total_score for m in result]
+    assert scores == sorted(scores, reverse=True)


### PR DESCRIPTION
## 概要
`-n` オプションで指定した数を満たせない問題を解消しました。固定上位 M=max(num*5,200) の制限を廃止し、段階的しきい値緩和と最終フォールバックを実装して、有効画像数以下なら必ず指定数を返すようにしました。

## 主な変更

### screen_picker.py
- **固定上位M件の制限を廃止**: 全候補を対象に類似度判定を行うように変更
- **段階的しきい値緩和**: 指定数に満たない場合、しきい値を段階的に緩和
  - base → +0.03 → +0.06 → +0.10 → +0.15（上限0.98）
- **最終フォールバック**: それでも不足する場合は類似度制約を外して高スコア順で埋める
- **スコア順ソート**: 結果を必ずスコア降順で返すように変更

### テスト追加
- `test_always_returns_requested_number_when_enough_unique_images_exist` - 有効画像数以下の要求で必ず指定数を返すことを確認
- `test_gradual_threshold_relaxation_and_fallback_for_similar_images` - 類似画像ばかりの場合の段階的しきい値緩和と最終フォールバックを確認

## テスト計画
- [x] 既存のテストが全てパスすること
- [x] 新規テストで段階的しきい値緩和の動作を確認すること
- [x] 新規テストで最終フォールバックの動作を確認すること
- [x] 指定数を必ず返すことを確認すること