### PR TITLE
config: 類似度しきい値のデフォルト値を0.72に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ uv run game-screen-pick <入力フォルダ> [オプション]
 - `-c <フォルダ>`, `--copy-to <フォルダ>`: 選択した画像をコピーする出力フォルダ
 - `-n <数値>`, `--num <数値>`: 選択枚数 (デフォルト: 10)
 - `-g <ジャンル>`, `--genre <ジャンル>`: ゲームジャンル (2d_rpg, 3d_rpg, fps, tps, 2d_action, 2d_shooting, 3d_action, puzzle, racing, strategy, adventure, mixed)
-- `-s <数値>`, `--similarity <数値>`: 類似度しきい値 (デフォルト: 0.82)
+- `-s <数値>`, `--similarity <数値>`: 類似度しきい値 (デフォルト: 0.72)
 - `-r`, `--recursive`: サブフォルダも検索
 
 ### 使用例

--- a/src/main.py
+++ b/src/main.py
@@ -136,7 +136,7 @@ class Main:
             "-s",
             "--similarity",
             type=self._validate_similarity_range,
-            default=0.82,
+            default=0.72,
             help="類似度しきい値(0.7~0.85推奨)",
         )
         parser.add_argument(


### PR DESCRIPTION
## 概要
- `--similarity` オプションのデフォルト値を 0.82 から 0.72 に変更
- README.md のドキュメントも併せて更新

## 変更内容
- 類似度しきい値のデフォルトを下げることで、より多様な画像を選択可能に

## テスト計画
- [x] 既存テスト（57件）がすべてパスすることを確認