### PR TITLE
feat: 類似判定特徴にCLIP埋め込みを追加してHSV特徴と結合

### DIFF
--- a/src/analyzers/image_quality_analyzer.py
+++ b/src/analyzers/image_quality_analyzer.py
@@ -2,7 +2,7 @@
 
 import contextlib
 import logging
-from typing import Optional, List, Tuple
+from typing import Optional, List
 
 from concurrent.futures import ThreadPoolExecutor
 import numpy as np
@@ -19,9 +19,7 @@ from .metric_normalizer import MetricNormalizer
 logger = logging.getLogger(__name__)
 
 # 型エイリアス（行長制限対応）
-_PreprocessResult = Tuple[
-    Optional[Image.Image], Optional[dict[str, float]], Optional[np.ndarray]
-]
+_PreprocessResult = Optional[Image.Image]
 
 
 class ImageQualityAnalyzer:
@@ -54,25 +52,79 @@ class ImageQualityAnalyzer:
             ).to(self.device)
             return self.model.get_text_features(**inputs)  # type: ignore[no-any-return]
 
-    def _extract_diversity_features(self, img: np.ndarray) -> np.ndarray:
-        """見た目の特徴を抽出（色と構造）."""
+    def _extract_hsv_features(self, img: np.ndarray) -> np.ndarray:
+        """HSV色空間のヒストグラム特徴を抽出する.
+
+        Returns:
+            正規化されたHSVヒストグラム特徴（64次元）
+        """
         small = cv2.resize(img, (128, 128))
         hsv = cv2.cvtColor(small, cv2.COLOR_BGR2HSV)
         hist = cv2.calcHist([hsv], [0, 1], None, [8, 8], [0, 180, 0, 256])
         return cv2.normalize(hist, hist).flatten()
+
+    def _extract_clip_features(self, pil_img: Image.Image) -> np.ndarray:
+        """CLIP画像埋め込みを抽出する.
+
+        Args:
+            pil_img: PIL画像（RGB形式）
+
+        Returns:
+            正規化されたCLIP画像埋め込み（512次元）
+        """
+        with torch.inference_mode():
+            inputs = self.processor(
+                images=pil_img,
+                return_tensors="pt",
+                padding=True,
+            ).to(self.device)
+            image_features = self.model.get_image_features(**inputs)
+            # L2正規化して返す
+            features = image_features[0].cpu().numpy()
+            return features / np.linalg.norm(features)  # type: ignore[no-any-return]
+
+    def _extract_combined_features(
+        self, img: np.ndarray, clip_features: np.ndarray
+    ) -> np.ndarray:
+        """HSV特徴とCLIP特徴を結合する.
+
+        Args:
+            img: OpenCV画像（BGR形式）
+            clip_features: CLIP画像埋め込み（512次元、正規化済み）
+
+        Returns:
+            結合された特徴ベクトル（576次元）
+        """
+        hsv_features = self._extract_hsv_features(img)
+        # L2正規化（既に正規化されているが、安全のため再正規化）
+        hsv_normalized = hsv_features / np.linalg.norm(hsv_features)
+        # 結合
+        return np.concatenate([hsv_normalized, clip_features])
 
     def analyze(self, path: str) -> Optional[ImageMetrics]:
         """画像を解析して品質スコアを計算する."""
         try:
             # PILで1回だけ読み込み、ファイル記述子のリークを防止
             with Image.open(path) as pil_img:
-                # OpenCV形式（BGR）に変換
-                img = cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
+                # RGBモードに変換（必要な場合）
+                if pil_img.mode != "RGB":
+                    pil_img_rgb: Image.Image = pil_img.convert("RGB")
+                    pil_img_copy = pil_img_rgb.copy()
+                else:
+                    pil_img_copy = pil_img.copy()
 
-                features = self._extract_diversity_features(img)
+                # OpenCV形式（BGR）に変換
+                img = cv2.cvtColor(np.array(pil_img_copy), cv2.COLOR_RGB2BGR)
+
+                # CLIP特徴を抽出
+                clip_features = self._extract_clip_features(pil_img_copy)
+
+                # HSV特徴とCLIP特徴を結合
+                features = self._extract_combined_features(img, clip_features)
+
                 raw = self._calculate_raw_metrics(img)
                 norm = MetricNormalizer.normalize_all(raw)
-                semantic = self._calculate_semantic_score(pil_img)
+                semantic = self._calculate_semantic_score(pil_img_copy)
                 total = self._calculate_total_score(raw, norm, semantic)
 
                 return ImageMetrics(path, raw, norm, semantic, total, features)
@@ -177,35 +229,19 @@ class ImageQualityAnalyzer:
             chunk_end = min(chunk_start + chunk_size, len(paths))
             chunk_paths = paths[chunk_start:chunk_end]
 
-            # ステージ1: チャンク単位でI/O + CV前処理を並列実行
-            preprocessed = self._load_and_preprocess_images(chunk_paths)
-
-            # PIL画像とメトリクスを分離
-            pil_images: List[Optional[Image.Image]] = []
-            raw_metrics_list: List[Optional[dict[str, float]]] = []
-            features_list: List[Optional[np.ndarray]] = []
-
-            for pil_img, raw, features in preprocessed:
-                pil_images.append(pil_img)
-                raw_metrics_list.append(raw)
-                features_list.append(features)
+            # ステージ1: チャンク単位でI/O + 前処理を並列実行
+            pil_images = self._load_and_preprocess_images(chunk_paths)
 
             # ステージ2: チャンク単位でバッチCLIP推論を実行
-            semantic_scores = self._calculate_semantic_scores_batch(
+            clip_features_list = self._calculate_clip_features_batch(
                 pil_images, initial_batch_size=batch_size
             )
 
             # ステージ3: チャンク単位で結果を構築
-            for i, (path, pil_img, raw, features) in enumerate(
-                zip(chunk_paths, pil_images, raw_metrics_list, features_list)
+            for i, (path, pil_img, clip_features) in enumerate(
+                zip(chunk_paths, pil_images, clip_features_list)
             ):
-                if pil_img is None or raw is None or features is None:
-                    results.append(None)
-                    continue
-
-                # semantic_scoresがNoneの場合もスキップ
-                semantic_score = semantic_scores[i]
-                if semantic_score is None:
+                if pil_img is None or clip_features is None:
                     results.append(None)
                     continue
 
@@ -213,11 +249,22 @@ class ImageQualityAnalyzer:
                     print(f"解析済み: {chunk_start + i}/{len(paths)}")
 
                 try:
+                    # OpenCV形式（BGR）に変換
+                    img = cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
+
+                    # 生メトリクスを計算
+                    raw = self._calculate_raw_metrics(img)
+
+                    # HSV特徴とCLIP特徴を結合
+                    features = self._extract_combined_features(img, clip_features)
+
+                    # 正規化メトリクスとセマンティックスコアを計算
                     norm = MetricNormalizer.normalize_all(raw)
-                    total = self._calculate_total_score(raw, norm, semantic_score)
+                    semantic = self._calculate_semantic_score(pil_img)
+                    total = self._calculate_total_score(raw, norm, semantic)
 
                     results.append(
-                        ImageMetrics(path, raw, norm, semantic_score, total, features)
+                        ImageMetrics(path, raw, norm, semantic, total, features)
                     )
                 except self._get_expected_errors() as e:
                     logger.warning(
@@ -227,30 +274,23 @@ class ImageQualityAnalyzer:
                     results.append(None)
 
             # チャンク処理完了後にメモリを解放
-            del (
-                preprocessed,
-                pil_images,
-                raw_metrics_list,
-                features_list,
-                semantic_scores,
-            )
+            del pil_images, clip_features_list
 
         return results
 
     def _load_and_preprocess_images(
         self, paths: List[str], max_workers: Optional[int] = None
     ) -> List[_PreprocessResult]:
-        """複数のパスからPIL画像を読み込み、OpenCV前処理まで並列実行する.
+        """複数のパスからPIL画像を読み込み、前処理まで並列実行する.
 
-        I/O（画像読み込み）とCPU-bound処理（OpenCV前処理）をThreadPoolExecutorで並列化.
+        I/O（画像読み込み）とCPU-bound処理（RGB変換）をThreadPoolExecutorで並列化.
 
         Args:
             paths: 画像ファイルパスのリスト
             max_workers: スレッドプールの最大ワーカー数（Noneで自動設定）
 
         Returns:
-            タプルのリスト: (PIL画像, 生メトリクス, 多様性特徴)
-            失敗したパスは (None, None, None)
+            PIL画像のリスト（失敗したパスはNone）
         """
 
         def process_single(path: str) -> _PreprocessResult:
@@ -261,23 +301,12 @@ class ImageQualityAnalyzer:
                     # RGBモードに変換（必要な場合）
                     if img_file.mode != "RGB":
                         pil_img: Image.Image = img_file.convert("RGB")
-                        rgb_img = pil_img.copy()
+                        return pil_img.copy()
                     else:
-                        rgb_img = img_file.copy()
-
-                # OpenCV形式（BGR）に変換
-                img = cv2.cvtColor(np.array(rgb_img), cv2.COLOR_RGB2BGR)
-
-                # 多様性特徴を抽出
-                features = self._extract_diversity_features(img)
-
-                # 生メトリクスを計算
-                raw = self._calculate_raw_metrics(img)
-
-                return rgb_img, raw, features
+                        return img_file.copy()
 
             except (FileNotFoundError, UnidentifiedImageError, OSError, ValueError):
-                return None, None, None
+                return None
 
         # ThreadPoolExecutorで並列処理
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -285,12 +314,12 @@ class ImageQualityAnalyzer:
 
         return results
 
-    def _calculate_semantic_scores_batch(
+    def _calculate_clip_features_batch(
         self,
         pil_images: List[Optional[Image.Image]],
         initial_batch_size: int = 32,
-    ) -> List[Optional[float]]:
-        """複数のPIL画像に対してCLIP推論をバッチ実行する.
+    ) -> List[Optional[np.ndarray]]:
+        """複数のPIL画像に対してCLIP推論をバッチ実行して特徴を抽出.
 
         OOM対策（失敗したバッチのみ再試行）:
         - initial_batch_sizeから開始（デフォルト32）
@@ -304,7 +333,7 @@ class ImageQualityAnalyzer:
             initial_batch_size: 初期バッチサイズ
 
         Returns:
-            セマンティックスコアのリスト（失敗した画像はNone）
+            CLIP画像埋め込みのリスト（512次元、正規化済み、失敗した画像はNone）
         """
         # 有効な画像のインデックスと画像を収集
         valid_indices = [i for i, img in enumerate(pil_images) if img is not None]
@@ -315,7 +344,7 @@ class ImageQualityAnalyzer:
             return [None] * len(pil_images)
 
         # 結果を格納する配列（初期値はNone）
-        results: List[Optional[float]] = [None] * len(pil_images)
+        results: List[Optional[np.ndarray]] = [None] * len(pil_images)
 
         # 現在のバッチサイズ
         current_batch_size = initial_batch_size
@@ -343,14 +372,17 @@ class ImageQualityAnalyzer:
                     ).to(self.device)
                     image_features = self.model.get_image_features(**inputs)
 
-                    # キャッシュされたテキスト埋め込みを使用
-                    logits = torch.matmul(image_features, self._text_embeddings.T)
-                    batch_scores = (logits[:, 0] / 100.0).cpu().tolist()
+                    # L2正規化してNumPy配列に変換
+                    batch_features = []
+                    for j in range(image_features.shape[0]):
+                        features = image_features[j].cpu().numpy()
+                        normalized = features / np.linalg.norm(features)
+                        batch_features.append(normalized)
 
                 # 結果を元のインデックスにマッピング
-                for j, score in enumerate(batch_scores):
+                for j, features in enumerate(batch_features):
                     original_idx = valid_indices[batch_start + j]
-                    results[original_idx] = score
+                    results[original_idx] = features
 
                 # バッチ処理成功、次へ進む
                 i = batch_end

--- a/tests/analyzers/test_image_quality_analyzer.py
+++ b/tests/analyzers/test_image_quality_analyzer.py
@@ -231,7 +231,8 @@ def test_analyzes_images_with_various_formats_and_properties(
     # Assert
     assert result is not None
     # すべての画像はリサイズされるため、特徴ベクトルサイズは一貫している
-    assert result.features.shape == (64,)
+    # HSV特徴（64次元）+ CLIP特徴（512次元）= 576次元
+    assert result.features.shape == (576,)
     # 暗い画像の場合は輝度ペナルティが適用される
     if check_dark_penalty:
         assert result.raw_metrics["brightness"] < 40
@@ -482,3 +483,161 @@ def test_analyze_batch_retries_only_failed_batches_on_oom(
     assert batch_sizes_seen[1] == 2
     # 3番目の呼び出しはバッチサイズ1（OOM後のリトライ）
     assert batch_sizes_seen[2] == 1
+
+
+def test_extract_hsv_features_returns_correct_shape(
+    sample_image_path: str,
+) -> None:
+    """HSV特徴抽出が正しい形状の特徴ベクトルを返すこと.
+
+    Given:
+        - アナライザインスタンスがある
+        - 有効なテスト画像がある
+    When:
+        - HSV特徴が抽出される
+    Then:
+        - 64次元の特徴ベクトルが返されること
+        - 特徴が正規化されていること
+    """
+    # Arrange
+    import cv2
+    from PIL import Image
+
+    analyzer = ImageQualityAnalyzer()
+    with Image.open(sample_image_path) as pil_img:
+        img = cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
+
+    # Act
+    hsv_features = analyzer._extract_hsv_features(img)
+
+    # Assert
+    assert hsv_features.shape == (64,)
+    # 正規化されている（L2ノルムが1に近い）
+    assert np.abs(np.linalg.norm(hsv_features) - 1.0) < 0.01
+
+
+def test_extract_clip_features_returns_correct_shape(
+    sample_image_path: str,
+) -> None:
+    """CLIP特徴抽出が正しい形状の特徴ベクトルを返すこと.
+
+    Given:
+        - アナライザインスタンスがある
+        - 有効なテスト画像がある
+    When:
+        - CLIP特徴が抽出される
+    Then:
+        - 512次元の特徴ベクトルが返されること
+        - 特徴がL2正規化されていること
+    """
+    # Arrange
+    from PIL import Image
+
+    analyzer = ImageQualityAnalyzer()
+    with Image.open(sample_image_path) as pil_img:
+        if pil_img.mode != "RGB":
+            pil_img_rgb = pil_img.convert("RGB").copy()
+        else:
+            pil_img_rgb = pil_img.copy()
+
+    # Act
+    clip_features = analyzer._extract_clip_features(pil_img_rgb)
+
+    # Assert
+    assert clip_features.shape == (512,)
+    # L2正規化されている（ノルムが1に近い）
+    assert np.abs(np.linalg.norm(clip_features) - 1.0) < 0.01
+
+
+def test_extract_combined_features_concatenates_hsv_and_clip(
+    sample_image_path: str,
+) -> None:
+    """結合特徴抽出がHSV特徴とCLIP特徴を正しく結合すること.
+
+    Given:
+        - アナライザインスタンスがある
+        - 有効なテスト画像がある
+    When:
+        - 結合特徴が抽出される
+    Then:
+        - 576次元の特徴ベクトルが返されること（64 + 512）
+        - 前半64次元がHSV特徴であること
+        - 後半512次元がCLIP特徴であること
+    """
+    # Arrange
+    import cv2
+    from PIL import Image
+
+    analyzer = ImageQualityAnalyzer()
+    with Image.open(sample_image_path) as pil_img:
+        if pil_img.mode != "RGB":
+            pil_img_rgb = pil_img.convert("RGB").copy()
+        else:
+            pil_img_rgb = pil_img.copy()
+        img = cv2.cvtColor(np.array(pil_img_rgb), cv2.COLOR_RGB2BGR)
+
+    clip_features = analyzer._extract_clip_features(pil_img_rgb)
+
+    # Act
+    combined_features = analyzer._extract_combined_features(img, clip_features)
+
+    # Assert
+    assert combined_features.shape == (576,)
+    # 前半64次元がHSV特徴
+    hsv_part = combined_features[:64]
+    # 後半512次元がCLIP特徴
+    clip_part = combined_features[64:]
+
+    # それぞれが正規化されている
+    assert np.abs(np.linalg.norm(hsv_part) - 1.0) < 0.01
+    assert np.abs(np.linalg.norm(clip_part) - 1.0) < 0.01
+
+
+def test_analyze_uses_combined_features_for_similarity(
+    sample_image_path: str,
+) -> None:
+    """analyzeメソッドが結合特徴を使用していること.
+
+    Given:
+        - アナライザインスタンスがある
+        - 有効なテスト画像がある
+    When:
+        - 画像が分析される
+    Then:
+        - 結合特徴（576次元）が使用されていること
+        - 特徴ベクトルの前半がHSV特徴であること
+        - 特徴ベクトルの後半がCLIP特徴であること
+    """
+    # Arrange
+    import cv2
+    from PIL import Image
+
+    analyzer = ImageQualityAnalyzer()
+
+    # Act
+    result = analyzer.analyze(sample_image_path)
+
+    # Assert
+    assert result is not None
+    assert result.features.shape == (576,)
+
+    # HSV特徴とCLIP特徴が正しく結合されていることを検証
+    with Image.open(sample_image_path) as pil_img:
+        if pil_img.mode != "RGB":
+            pil_img_rgb = pil_img.convert("RGB").copy()
+        else:
+            pil_img_rgb = pil_img.copy()
+        img = cv2.cvtColor(np.array(pil_img_rgb), cv2.COLOR_RGB2BGR)
+
+    # 個別の特徴を抽出して比較
+    expected_hsv = analyzer._extract_hsv_features(img)
+    expected_hsv_normalized = expected_hsv / np.linalg.norm(expected_hsv)
+    expected_clip = analyzer._extract_clip_features(pil_img_rgb)
+
+    # 結合特徴の前半64次元はHSV特徴（正規化済み）
+    actual_hsv = result.features[:64]
+    assert np.allclose(actual_hsv, expected_hsv_normalized, atol=1e-5)
+
+    # 結合特徴の後半512次元はCLIP特徴
+    actual_clip = result.features[64:]
+    assert np.allclose(actual_clip, expected_clip, atol=1e-5)


### PR DESCRIPTION
## 概要

HSV特徴（64次元）とCLIP特徴（512次元）を結合した576次元の特徴ベクトルを使用するように変更しました。これにより、色味が似ているだけでシーンが異なる画像の誤判定を低減します。

## 変更内容

### メソッド追加
- `_extract_hsv_features`: HSV色空間のヒストグラム特徴を抽出（64次元）
- `_extract_clip_features`: CLIP画像埋め込みを抽出（512次元）
- `_extract_combined_features`: HSV特徴とCLIP特徴を結合（576次元）

### メソッド変更
- `_calculate_semantic_scores_batch` → `_calculate_clip_features_batch`: スコアではなくCLIP特徴ベクトルを返すように変更
- `_load_and_preprocess_images`: PIL画像のみを返すように簡素化
- `analyze` / `analyze_batch`: 結合特徴（576次元）を使用するように更新

## テスト

- 既存テスト: 特徴ベクトルの次元数チェックを64→576に更新
- 新規テスト追加（4件）:
  - `test_extract_hsv_features_returns_correct_shape`
  - `test_extract_clip_features_returns_correct_shape`
  - `test_extract_combined_features_concatenates_hsv_and_clip`
  - `test_analyze_uses_combined_features_for_similarity`

## 検証

すべてのテストが通過しています（63 passed）

## 関連issue

なし