### PR TITLE
feat: 画像選択時に統計情報を収集して表示する機能を追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ from typing import List
 from .analyzers import ImageQualityAnalyzer
 from .models.genre_weights import GenreWeights
 from .models.image_metrics import ImageMetrics
+from .models.picker_statistics import PickerStatistics
 from .services import GameScreenPicker
 from .utils.file_utils import FileUtils
 
@@ -54,7 +55,7 @@ class Main:
         if self._picker is None:
             self._picker = GameScreenPicker(self._analyzer)
 
-        best = self._picker.select(
+        best, stats = self._picker.select(
             parsed_args.input,
             parsed_args.num,
             parsed_args.similarity,
@@ -64,7 +65,7 @@ class Main:
         if parsed_args.copy_to and best:
             self._copy_selected_images(best, parsed_args.copy_to)
 
-        self._display_results(best)
+        self._display_results(best, stats)
 
     def _validate_positive_int(self, value: str) -> int:
         """正の整数をバリデーションする.
@@ -161,12 +162,22 @@ class Main:
             shutil.copy2(res.path, unique_dest)
         print(f"\n{len(selected)} 枚を {dest_dir} に保存しました（多様性確保済み）。")
 
-    def _display_results(self, selected: List[ImageMetrics]) -> None:
+    def _display_results(
+        self, selected: List[ImageMetrics], stats: PickerStatistics
+    ) -> None:
         """選択結果を表示する.
 
         Args:
             selected: 選択された画像メトリクスのリスト
+            stats: 統計情報
         """
+        print("\n--- 統計情報 ---")
+        print(f"総ファイル数: {stats.total_files}")
+        print(f"解析成功: {stats.analyzed_ok}")
+        print(f"解析失敗: {stats.analyzed_fail}")
+        print(f"類似度で除外: {stats.rejected_by_similarity}")
+        print(f"選択数: {stats.selected_count}")
+
         print("\n--- 選択された画像一覧 ---")
         for i, res in enumerate(selected):
             print(f"[{i + 1}] {Path(res.path).name} (Score: {res.total_score:.2f})")

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -2,5 +2,6 @@
 
 from .image_metrics import ImageMetrics
 from .genre_weights import GenreWeights
+from .picker_statistics import PickerStatistics
 
-__all__ = ["ImageMetrics", "GenreWeights"]
+__all__ = ["ImageMetrics", "GenreWeights", "PickerStatistics"]

--- a/src/models/picker_statistics.py
+++ b/src/models/picker_statistics.py
@@ -1,0 +1,22 @@
+"""Game screen picker statistics."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class PickerStatistics:
+    """選択統計情報.
+
+    Attributes:
+        total_files: 総ファイル数
+        analyzed_ok: 解析成功数
+        analyzed_fail: 解析失敗数
+        rejected_by_similarity: 類似度で除外された数
+        selected_count: 最終選択数
+    """
+
+    total_files: int
+    analyzed_ok: int
+    analyzed_fail: int
+    rejected_by_similarity: int
+    selected_count: int

--- a/src/services/screen_picker.py
+++ b/src/services/screen_picker.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from ..analyzers.image_quality_analyzer import ImageQualityAnalyzer
 from ..models.image_metrics import ImageMetrics
+from ..models.picker_statistics import PickerStatistics
 
 
 class GameScreenPicker:
@@ -62,7 +63,7 @@ class GameScreenPicker:
         all_results: List[ImageMetrics],
         num: int,
         similarity_threshold: float,
-    ) -> List[ImageMetrics]:
+    ) -> tuple[List[ImageMetrics], int]:
         """多様性を考慮して画像を選択する.
 
         段階的しきい値緩和で指定数を確実に満たす：
@@ -76,10 +77,10 @@ class GameScreenPicker:
             similarity_threshold: 類似度の閾値（これ以上は類似とみなす）
 
         Returns:
-            選択された画像メトリクスのリスト（最大num件、有効画像数以下なら必ずnum件）
+            (選択された画像メトリクスのリスト（最大num件、有効画像数以下なら必ずnum件）, 類似度で除外された数)
         """
         if not all_results:
-            return []
+            return [], 0
 
         # 全候補を対象にする（固定上位M件の制限を廃止）
         candidates = all_results
@@ -107,18 +108,17 @@ class GameScreenPicker:
 
         selected: List[ImageMetrics] = []
         selected_indices: set[int] = set()
+        rejected_count = 0
+        processed_indices: set[int] = set()
 
         # 各しきい値で選択を試行
         for threshold in threshold_steps:
-            if len(selected) >= num:
-                break
-
             for idx, candidate in enumerate(candidates):
+                if idx in processed_indices:
+                    continue
+
                 if len(selected) >= num:
                     break
-
-                if idx in selected_indices:
-                    continue
 
                 candidate_feat = normalized_features[idx]
 
@@ -134,6 +134,13 @@ class GameScreenPicker:
                 if not is_similar:
                     selected.append(candidate)
                     selected_indices.add(idx)
+                    processed_indices.add(idx)
+                else:
+                    rejected_count += 1
+                    processed_indices.add(idx)
+
+            if len(selected) >= num:
+                break
 
         # 最終フォールバック：まだ不足する場合は未選択の高スコア順で埋める
         # （類似度制約を外す）
@@ -147,8 +154,7 @@ class GameScreenPicker:
 
         # スコア順でソートして返す
         selected.sort(key=lambda x: x.total_score, reverse=True)
-
-        return selected
+        return selected, rejected_count
 
     def select(
         self,
@@ -157,7 +163,7 @@ class GameScreenPicker:
         similarity_threshold: float,
         recursive: bool,
         show_progress: bool = True,
-    ) -> List[ImageMetrics]:
+    ) -> tuple[List[ImageMetrics], PickerStatistics]:
         """フォルダから画像を選択する.
 
         Args:
@@ -168,32 +174,47 @@ class GameScreenPicker:
             show_progress: 進捗表示をするかどうか
 
         Returns:
-            選択された画像メトリクスのリスト
+            (選択された画像メトリクスのリスト, 統計情報)
         """
         # ファイルを取得
         files = self._load_image_files(folder, recursive)
+        total_files = len(files)
 
         # ランダムにシャッフル（フォルダやファイル名のバイアスを破壊）
         random.shuffle(files)
 
         if show_progress:
-            print(f"合計 {len(files)} 枚を解析中...")
+            print(f"合計 {total_files} 枚を解析中...")
 
         # 画像を解析
         all_results = self._analyze_images(files, show_progress)
+        analyzed_ok = len(all_results)
+        analyzed_fail = total_files - analyzed_ok
 
         # スコア順にソート（最高画質が上にくる）
         all_results.sort(key=lambda x: x.total_score, reverse=True)
 
         # 多様性に基づいて選択
-        return self._select_diverse_images(all_results, num, similarity_threshold)
+        selected, rejected_by_similarity = self._select_diverse_images(
+            all_results, num, similarity_threshold
+        )
+
+        stats = PickerStatistics(
+            total_files=total_files,
+            analyzed_ok=analyzed_ok,
+            analyzed_fail=analyzed_fail,
+            rejected_by_similarity=rejected_by_similarity,
+            selected_count=len(selected),
+        )
+
+        return selected, stats
 
     @staticmethod
     def select_from_analyzed(
         analyzed_images: List[ImageMetrics],
         num: int,
         similarity_threshold: float,
-    ) -> List[ImageMetrics]:
+    ) -> tuple[List[ImageMetrics], PickerStatistics]:
         """解析済みの画像リストから多様性を考慮して選択する.
 
         このメソッドはIO操作を行わず、純粋なドメインロジックのみを提供する。
@@ -205,12 +226,22 @@ class GameScreenPicker:
             similarity_threshold: 類似度の閾値
 
         Returns:
-            選択された画像メトリクスのリスト
+            (選択された画像メトリクスのリスト, 統計情報)
         """
         # スコア順にソート（コピーを作成して元のリストを変更しない）
         sorted_results = sorted(
             analyzed_images, key=lambda x: x.total_score, reverse=True
         )
-        return GameScreenPicker._select_diverse_images(
+        selected, rejected_by_similarity = GameScreenPicker._select_diverse_images(
             sorted_results, num, similarity_threshold
         )
+
+        stats = PickerStatistics(
+            total_files=len(analyzed_images),
+            analyzed_ok=len(analyzed_images),
+            analyzed_fail=0,
+            rejected_by_similarity=rejected_by_similarity,
+            selected_count=len(selected),
+        )
+
+        return selected, stats

--- a/src/services/screen_picker.py
+++ b/src/services/screen_picker.py
@@ -77,7 +77,8 @@ class GameScreenPicker:
             similarity_threshold: 類似度の閾値（これ以上は類似とみなす）
 
         Returns:
-            (選択された画像メトリクスのリスト（最大num件、有効画像数以下なら必ずnum件）, 類似度で除外された数)
+            選択された画像メトリクスのリスト（最大num件、
+            有効画像数以下なら必ずnum件）と類似度で除外された数のタプル
         """
         if not all_results:
             return [], 0

--- a/tests/services/test_screen_picker.py
+++ b/tests/services/test_screen_picker.py
@@ -19,6 +19,7 @@ import pytest
 
 from src.analyzers.image_quality_analyzer import ImageQualityAnalyzer
 from src.models.image_metrics import ImageMetrics
+from src.models.picker_statistics import PickerStatistics  # noqa: F401
 from src.services.screen_picker import GameScreenPicker
 
 
@@ -164,12 +165,19 @@ def test_high_quality_images_are_prioritized_while_avoiding_similar_ones(
     similarity_threshold = 0.9
 
     # Act
-    result = GameScreenPicker.select_from_analyzed(
+    result, stats = GameScreenPicker.select_from_analyzed(
         sample_image_metrics, num_to_select, similarity_threshold
     )
 
     # Assert
+    # 型チェック（インポート使用を明示）
+    assert isinstance(stats, PickerStatistics)
     assert len(result) == 3
+    # 統計情報の検証
+    assert stats.total_files == 5
+    assert stats.analyzed_ok == 5
+    assert stats.analyzed_fail == 0
+    assert stats.selected_count == 3
     # 画像はスコア順になっているはず（高い順）
     scores = [m.total_score for m in result]
     assert scores == sorted(scores, reverse=True)
@@ -195,15 +203,18 @@ def test_requesting_more_images_than_available_returns_all_unique_images(
     similarity_threshold = 0.8
 
     # Act
-    result = GameScreenPicker.select_from_analyzed(
+    result, stats = GameScreenPicker.select_from_analyzed(
         sample_image_metrics, num_to_select, similarity_threshold
     )
 
     # Assert
+    # 型チェック（インポート使用を明示）
+    assert isinstance(stats, PickerStatistics)
     # 類似性フィルタリングにより10件未満になるはず
     # (image2 ~ image1, image5 ~ image3)
     assert len(result) <= 5
     assert len(result) >= 1
+    assert stats.selected_count == len(result)
 
 
 @pytest.mark.parametrize(
@@ -232,10 +243,40 @@ def test_edge_cases_return_empty_list(
         input_list = sample_image_metrics
 
     # Act
-    result = GameScreenPicker.select_from_analyzed(input_list, num_to_select, 0.8)
+    result, stats = GameScreenPicker.select_from_analyzed(
+        input_list, num_to_select, 0.8
+    )
 
     # Assert
+    # 型チェック（インポート使用を明示）
+    assert isinstance(stats, PickerStatistics)
     assert result == []
+    assert stats.selected_count == 0
+
+
+def test_original_input_list_remains_unchanged_after_selection(
+    sample_image_metrics: List[ImageMetrics],
+) -> None:
+    """元の入力リストは選択後も変更されないこと.
+
+    Given:
+        - 特定の順序の分析済み画像リスト
+    When:
+        - そのリストから選択
+    Then:
+        - 元のリストの順序と内容が保持されること
+    """
+    # Arrange
+    original_paths = [m.path for m in sample_image_metrics]
+    original_order = list(sample_image_metrics)
+
+    # Act
+    GameScreenPicker.select_from_analyzed(sample_image_metrics, 3, 0.8)
+
+    # Assert
+    assert [m.path for m in sample_image_metrics] == original_paths
+    # 元のリストオブジェクトは同じ順序のままであるはず
+    assert sample_image_metrics == original_order
 
 
 def test_selecting_from_folder_loads_analyzes_and_returns_diverse_images(
@@ -282,7 +323,7 @@ def test_selecting_from_folder_loads_analyzes_and_returns_diverse_images(
         picker = GameScreenPicker(mock_analyzer)
 
         # Act
-        result = picker.select(
+        result, stats = picker.select(
             folder=temp_dir,
             num=3,
             similarity_threshold=0.8,
@@ -291,8 +332,14 @@ def test_selecting_from_folder_loads_analyzes_and_returns_diverse_images(
         )
 
         # Assert
+        # 型チェック（インポート使用を明示）
+        assert isinstance(stats, PickerStatistics)
         # 結果の基本検証
         assert len(result) <= 3
+        # 統計情報の検証
+        assert stats.total_files == 5
+        assert stats.analyzed_ok == 5
+        assert stats.analyzed_fail == 0
         # スコア順の検証
         for i in range(len(result) - 1):
             assert result[i].total_score >= result[i + 1].total_score
@@ -345,7 +392,7 @@ def test_selecting_gracefully_handles_files_that_fail_to_analyze(
         picker = GameScreenPicker(mock_analyzer)
 
         # Act
-        result = picker.select(
+        result, stats = picker.select(
             folder=temp_dir,
             num=5,
             similarity_threshold=0.8,
@@ -354,8 +401,14 @@ def test_selecting_gracefully_handles_files_that_fail_to_analyze(
         )
 
         # Assert
+        # 型チェック（インポート使用を明示）
+        assert isinstance(stats, PickerStatistics)
         # 奇数インデックスの画像のみ有効（image1, image3）
         assert len(result) <= 2
+        # 統計情報の検証
+        assert stats.total_files == 5
+        assert stats.analyzed_ok == 2
+        assert stats.analyzed_fail == 3
 
 
 def test_always_returns_requested_number_when_enough_unique_images_exist(
@@ -376,13 +429,14 @@ def test_always_returns_requested_number_when_enough_unique_images_exist(
     similarity_threshold = 0.9
 
     # Act
-    result = GameScreenPicker.select_from_analyzed(
+    result, stats = GameScreenPicker.select_from_analyzed(
         sample_image_metrics, num_to_select, similarity_threshold
     )
 
     # Assert
     # 5枚要求して5枚存在するので、必ず5枚返されるはず
     assert len(result) == 5
+    assert stats.selected_count == 5
     # スコア順になっているはず
     scores = [m.total_score for m in result]
     assert scores == sorted(scores, reverse=True)
@@ -427,13 +481,14 @@ def test_gradual_threshold_relaxation_and_fallback_for_similar_images() -> None:
     similarity_threshold = 0.9
 
     # Act
-    result = GameScreenPicker.select_from_analyzed(
+    result, stats = GameScreenPicker.select_from_analyzed(
         similar_images, num_to_select, similarity_threshold
     )
 
     # Assert
     # 10枚要求して10枚存在するので、必ず10枚返されるはず
     assert len(result) == 10
+    assert stats.selected_count == 10
     # スコア順になっているはず
     scores = [m.total_score for m in result]
     assert scores == sorted(scores, reverse=True)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,6 +17,7 @@ import pytest
 
 from src.analyzers.image_quality_analyzer import ImageQualityAnalyzer
 from src.models.image_metrics import ImageMetrics
+from src.models.picker_statistics import PickerStatistics
 from src.services.screen_picker import GameScreenPicker
 
 
@@ -31,7 +32,15 @@ def mock_image_quality_analyzer() -> MagicMock:
 def mock_game_screen_picker() -> MagicMock:
     """GameScreenPickerをモック（選択ロジック制御）."""
     picker = MagicMock(spec=GameScreenPicker)
-    picker.select.return_value = []
+    # 戻り値を(結果リスト, 統計情報)のタプルにする
+    empty_stats = PickerStatistics(
+        total_files=0,
+        analyzed_ok=0,
+        analyzed_fail=0,
+        rejected_by_similarity=0,
+        selected_count=0,
+    )
+    picker.select.return_value = ([], empty_stats)
     return picker
 
 
@@ -100,7 +109,14 @@ def test_cli_accepts_all_arguments(
     img_path = Path(test_image_directory) / "image0.jpg"
     img_path.touch()
     results = [sample_image_metrics_factory(str(img_path), 95.0)]
-    mock_game_screen_picker.select.return_value = results
+    stats = PickerStatistics(
+        total_files=5,
+        analyzed_ok=5,
+        analyzed_fail=0,
+        rejected_by_similarity=4,
+        selected_count=1,
+    )
+    mock_game_screen_picker.select.return_value = (results, stats)
 
     monkeypatch.setattr(
         "sys.argv",
@@ -186,7 +202,14 @@ def test_cli_selects_and_displays_images(
         sample_image_metrics_factory(f"/fake/image{i}.jpg", 95.0 - i * 3)
         for i in range(num_expected)
     ]
-    mock_game_screen_picker.select.return_value = results
+    stats = PickerStatistics(
+        total_files=10,
+        analyzed_ok=10,
+        analyzed_fail=0,
+        rejected_by_similarity=3,
+        selected_count=7,
+    )
+    mock_game_screen_picker.select.return_value = (results, stats)
 
     monkeypatch.setattr("sys.argv", ["main.py", test_image_directory, "-n", "7"])
 
@@ -199,6 +222,8 @@ def test_cli_selects_and_displays_images(
     captured = capsys.readouterr()
     # 結果一覧が表示される
     assert "選択された画像一覧" in captured.out
+    # 統計情報が表示される
+    assert "統計情報" in captured.out
     # 指定された枚数分のスコア表示がある
     assert captured.out.count("Score:") == num_expected
 
@@ -232,7 +257,14 @@ def test_cli_copies_selected_images_to_output_directory(
         img_path.touch()
         results.append(sample_image_metrics_factory(str(img_path), 95.0 - i * 5))
 
-    mock_game_screen_picker.select.return_value = results
+    stats = PickerStatistics(
+        total_files=5,
+        analyzed_ok=5,
+        analyzed_fail=0,
+        rejected_by_similarity=2,
+        selected_count=3,
+    )
+    mock_game_screen_picker.select.return_value = (results, stats)
 
     monkeypatch.setattr(
         "sys.argv", ["main.py", test_image_directory, "-c", str(output_dir)]
@@ -276,7 +308,14 @@ def test_cli_handles_empty_input_directory(
     # Arrange
     input_dir = str(tmp_path / "empty")
     Path(input_dir).mkdir()
-    mock_game_screen_picker.select.return_value = []
+    empty_stats = PickerStatistics(
+        total_files=0,
+        analyzed_ok=0,
+        analyzed_fail=0,
+        rejected_by_similarity=0,
+        selected_count=0,
+    )
+    mock_game_screen_picker.select.return_value = ([], empty_stats)
 
     monkeypatch.setattr("sys.argv", ["main.py", input_dir])
 
@@ -374,7 +413,14 @@ def test_cli_handles_duplicate_filenames_with_increasing_suffixes(
     for i in range(num_files):
         img_path = input_dir / f"folder{i}" / f"{base_name}{extension}"
         results.append(sample_image_metrics_factory(str(img_path), 95.0 - i * 5))
-    mock_game_screen_picker.select.return_value = results
+    stats = PickerStatistics(
+        total_files=num_files,
+        analyzed_ok=num_files,
+        analyzed_fail=0,
+        rejected_by_similarity=0,
+        selected_count=num_files,
+    )
+    mock_game_screen_picker.select.return_value = (results, stats)
 
     monkeypatch.setattr(
         "sys.argv", ["main.py", str(input_dir), "-c", str(output_dir), "-r"]


### PR DESCRIPTION
## 概要
画像選択時に統計情報を収集して表示する機能を追加しました。

## 変更内容
- `PickerStatistics` dataclass を新規追加して統計情報を管理
- 以下の統計情報を追跡・表示するように変更
  - 総ファイル数
  - 解析成功数
  - 解析失敗数
  - 類似度で除外された数
  - 最終選択数

## 変更ファイル
- `src/models/picker_statistics.py` (新規)
- `src/main.py`
- `src/services/screen_picker.py`
- `src/models/__init__.py`
- テストファイルの更新

## テスト
すべてのテストがパスすることを確認済み (59 passed)