### PR TITLE
fix: 段階的しきい値緩和時に類似画像が次ステップで再評価されるように修正

### DIFF
--- a/src/services/screen_picker.py
+++ b/src/services/screen_picker.py
@@ -138,7 +138,7 @@ class GameScreenPicker:
                     processed_indices.add(idx)
                 else:
                     rejected_count += 1
-                    processed_indices.add(idx)
+                    # rejected は次のしきい値で再評価させるため追加しない
 
             if len(selected) >= num:
                 break


### PR DESCRIPTION
## 概要
- `_select_diverse_images` メソッドで、類似度判定で rejected された画像が次のしきい値ステップで再評価されない問題を修正
- `rejected` 画像を `processed_indices` に追加しないように変更し、次ステップでの再評価を可能に

## 変更内容
- **ファイル**: `src/services/screen_picker.py`
- **変更**: rejected 時の `processed_indices.add(idx)` を削除
- **効果**: 段階的しきい値緩和が正しく動作し、指定数を確実に満たすようになる

## テスト計画
- [x] 全64件のユニットテストがパス