### PR TITLE
perf: バッチ解析時のCLIP推論二重実行を解消して計算済み特徴を再利用するように修正

### DIFF
--- a/src/analyzers/image_quality_analyzer.py
+++ b/src/analyzers/image_quality_analyzer.py
@@ -124,7 +124,7 @@ class ImageQualityAnalyzer:
 
                 raw = self._calculate_raw_metrics(img)
                 norm = MetricNormalizer.normalize_all(raw)
-                semantic = self._calculate_semantic_score(pil_img_copy)
+                semantic = self._calculate_semantic_score_from_features(clip_features)
                 total = self._calculate_total_score(raw, norm, semantic)
 
                 return ImageMetrics(path, raw, norm, semantic, total, features)
@@ -185,6 +185,26 @@ class ImageQualityAnalyzer:
             image_features = self.model.get_image_features(**inputs)
 
             # キャッシュされたテキスト埋め込みを使用
+            logits = torch.matmul(image_features, self._text_embeddings.T)
+            return float(logits[0][0]) / 100.0
+
+    def _calculate_semantic_score_from_features(
+        self, clip_features: np.ndarray
+    ) -> float:
+        """既に計算済みのCLIP特徴からセマンティックスコアを計算する.
+
+        Args:
+            clip_features: 正規化済みのCLIP画像特徴（512次元）
+
+        Returns:
+            セマンティックスコア
+        """
+        # NumPy配列をtorch.Tensorに変換
+        with torch.inference_mode():
+            image_features = (
+                torch.from_numpy(clip_features).unsqueeze(0).to(self.device)
+            )
+            # キャッシュされたテキスト埋め込みとの類似度を計算
             logits = torch.matmul(image_features, self._text_embeddings.T)
             return float(logits[0][0]) / 100.0
 
@@ -260,7 +280,9 @@ class ImageQualityAnalyzer:
 
                     # 正規化メトリクスとセマンティックスコアを計算
                     norm = MetricNormalizer.normalize_all(raw)
-                    semantic = self._calculate_semantic_score(pil_img)
+                    semantic = self._calculate_semantic_score_from_features(
+                        clip_features
+                    )
                     total = self._calculate_total_score(raw, norm, semantic)
 
                     results.append(


### PR DESCRIPTION
## 概要
バッチ解析と単一解析でCLIP推論が二重実行されていた問題を修正し、計算済みのCLIP特徴を再利用するように変更しました。

## 変更内容
- `_calculate_semantic_score_from_features` メソッドを追加
  - 既に計算済みのCLIP特徴からセマンティックスコアを計算
  - NumPy配列をTensorに変換してキャッシュ済みテキスト埋め込みと類似度計算
- `analyze` メソッドで `_calculate_semantic_score` の代わりに新メソッドを使用
- `analyze_batch` メソッドでも同様に新メソッドを使用

## 効果
- CLIP推論が1回のみ実行されるようになり、処理速度が大幅に向上

## テスト計画
- [x] 既存テスト64件すべてパス
- [x] バッチ処理と単一処理で同じ結果が得られることを確認