### PR TITLE
fix: L2正規化のゼロ割れ耐性を統一して異常入力時の挙動を安定化

### DIFF
--- a/src/analyzers/image_quality_analyzer.py
+++ b/src/analyzers/image_quality_analyzer.py
@@ -22,6 +22,22 @@ logger = logging.getLogger(__name__)
 _PreprocessResult = Optional[Image.Image]
 
 
+def _safe_l2_normalize(vec: np.ndarray, eps: float = 1e-8) -> np.ndarray:
+    """ゼロ割れ安全なL2正規化を行う.
+
+    Args:
+        vec: 正規化するベクトル
+        eps: ゼロ割れ防止用の微小値
+
+    Returns:
+        L2正規化されたベクトル（元のノルムが0の場合はゼロベクトル）
+    """
+    norm = float(np.linalg.norm(vec))
+    if norm < eps:
+        return np.zeros_like(vec)
+    return vec / norm
+
+
 class ImageQualityAnalyzer:
     """画像品質アナライザー."""
 
@@ -81,7 +97,7 @@ class ImageQualityAnalyzer:
             image_features = self.model.get_image_features(**inputs)
             # L2正規化して返す
             features = image_features[0].cpu().numpy()
-            return features / np.linalg.norm(features)  # type: ignore[no-any-return]
+            return _safe_l2_normalize(features)
 
     def _extract_combined_features(
         self, img: np.ndarray, clip_features: np.ndarray
@@ -97,7 +113,7 @@ class ImageQualityAnalyzer:
         """
         hsv_features = self._extract_hsv_features(img)
         # L2正規化（既に正規化されているが、安全のため再正規化）
-        hsv_normalized = hsv_features / np.linalg.norm(hsv_features)
+        hsv_normalized = _safe_l2_normalize(hsv_features)
         # 結合
         return np.concatenate([hsv_normalized, clip_features])
 
@@ -376,7 +392,7 @@ class ImageQualityAnalyzer:
                     batch_features = []
                     for j in range(image_features.shape[0]):
                         features = image_features[j].cpu().numpy()
-                        normalized = features / np.linalg.norm(features)
+                        normalized = _safe_l2_normalize(features)
                         batch_features.append(normalized)
 
                 # 結果を元のインデックスにマッピング

--- a/tests/analyzers/test_image_quality_analyzer.py
+++ b/tests/analyzers/test_image_quality_analyzer.py
@@ -17,7 +17,10 @@ import numpy as np
 import pytest
 import torch
 
-from src.analyzers.image_quality_analyzer import ImageQualityAnalyzer
+from src.analyzers.image_quality_analyzer import (
+    ImageQualityAnalyzer,
+    _safe_l2_normalize,
+)
 from src.models.image_metrics import ImageMetrics
 
 
@@ -506,7 +509,7 @@ def test_analyze_uses_combined_features_for_similarity(
 
     # 個別の特徴を抽出して比較
     expected_hsv = analyzer._extract_hsv_features(img)
-    expected_hsv_normalized = expected_hsv / np.linalg.norm(expected_hsv)
+    expected_hsv_normalized = _safe_l2_normalize(expected_hsv)
     expected_clip = analyzer._extract_clip_features(pil_img_rgb)
 
     # 結合特徴の前半64次元はHSV特徴（正規化済み）
@@ -516,3 +519,47 @@ def test_analyze_uses_combined_features_for_similarity(
     # 結合特徴の後半512次元はCLIP特徴
     actual_clip = result.features[64:]
     assert np.allclose(actual_clip, expected_clip, atol=1e-5)
+
+
+def test_safe_l2_normalize_returns_zeros_for_zero_vector() -> None:
+    """ゼロベクトルが正規化されること.
+
+    Given:
+        - ゼロベクトルがある
+    When:
+        - _safe_l2_normalizeで正規化される
+    Then:
+        - ゼロベクトルが返されること（NaNではない）
+    """
+    # Arrange
+    zero_vec = np.array([0.0, 0.0, 0.0])
+
+    # Act
+    result = _safe_l2_normalize(zero_vec)
+
+    # Assert
+    assert result.shape == zero_vec.shape
+    assert np.all(result == 0.0)
+    assert not np.any(np.isnan(result))
+
+
+def test_safe_l2_normalize_normalizes_nonzero_vector() -> None:
+    """非ゼロベクトルが正しく正規化されること.
+
+    Given:
+        - 非ゼロベクトルがある
+    When:
+        - _safe_l2_normalizeで正規化される
+    Then:
+        - L2ノルムが1になること
+    """
+    # Arrange
+    vec = np.array([3.0, 4.0])  # ノルム = 5
+
+    # Act
+    result = _safe_l2_normalize(vec)
+
+    # Assert
+    expected_norm = 1.0
+    actual_norm = np.linalg.norm(result)
+    assert actual_norm == pytest.approx(expected_norm)


### PR DESCRIPTION
## 概要
L2正規化処理において、`np.linalg.norm()`が0のときにNaNが発生する問題を解消しました。安全な正規化関数 `_safe_l2_normalize()` を追加し、全ての正規化処理で統一的に使用するように修正しました。

## 主な変更
- **ヘルパー関数の追加**: `_safe_l2_normalize()` を実装
  - ノルムが0の場合はゼロベクトルを返す（NaNにならない）
  - `eps` パラメータでゼロ判定の閾値を調整可能
- **正規化処理の置換**: 以下3箇所で `_safe_l2_normalize()` を使用するように変更
  - `_extract_clip_features()` - CLIP特徴の正規化
  - `_extract_combined_features()` - HSV特徴の正規化
  - `_calculate_clip_features_batch()` - バッチ処理内の正規化
- **テストの追加**: `_safe_l2_normalize()` の単体テストを2件追加
  - ゼロベクトルが正しく処理されることの検証
  - 非ゼロベクトルが正しく正規化されることの検証

## テスト計画
- [x] 既存の16件のテストがすべてパスすること
- [x] 追加した2件のテストがパスすること
- [x] 型チェック（mypy）がパスすること
- [x] Lintチェックがパスすること

## 関連問題
- 異常入力時（ベクトルのノルムが0）の挙動が不安定だった問題を解消
- NaNが発生する可能性があった箇所をすべて安全な実装に統一