### PR TITLE
feat: 乱数シード指定で再現可能な選択結果を得る--seedオプションを追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -56,7 +56,7 @@ class Main:
         if self._picker is None:
             seed = parsed_args.seed
             rng = random.Random(seed) if seed is not None else None
-            self._picker = GameScreenPicker(self._analyzer, rng)
+            self._picker = GameScreenPicker(self._analyzer, rng=rng)
 
         best, stats = self._picker.select(
             parsed_args.input,

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 """game_screen_pick - 高精度・コンテンツ多様性重視選択ツール."""
 
 import argparse
+import random
 import shutil
 from pathlib import Path
 from typing import List
@@ -53,7 +54,9 @@ class Main:
         if self._analyzer is None:
             self._analyzer = ImageQualityAnalyzer(parsed_args.genre)
         if self._picker is None:
-            self._picker = GameScreenPicker(self._analyzer)
+            seed = parsed_args.seed
+            rng = random.Random(seed) if seed is not None else None
+            self._picker = GameScreenPicker(self._analyzer, rng)
 
         best, stats = self._picker.select(
             parsed_args.input,
@@ -142,6 +145,12 @@ class Main:
         )
         parser.add_argument(
             "-r", "--recursive", action="store_true", help="サブフォルダも検索"
+        )
+        parser.add_argument(
+            "--seed",
+            type=int,
+            default=None,
+            help="乱数シード（再現可能な結果を得るために指定）",
         )
         return parser.parse_args(self.args)
 

--- a/src/services/screen_picker.py
+++ b/src/services/screen_picker.py
@@ -1,7 +1,7 @@
 """Game screen picker for diverse image selection."""
 
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 import random
 
 import numpy as np
@@ -14,13 +14,17 @@ from ..models.picker_statistics import PickerStatistics
 class GameScreenPicker:
     """ゲーム画面選択クラス."""
 
-    def __init__(self, analyzer: ImageQualityAnalyzer):
+    def __init__(
+        self, analyzer: ImageQualityAnalyzer, rng: Optional[random.Random] = None
+    ):
         """ピッカーを初期化する.
 
         Args:
             analyzer: 画像品質アナライザー
+            rng: 乱数生成器（Noneの場合はデフォルトのRandomを使用）
         """
         self.analyzer = analyzer
+        self._rng = rng or random.Random()
 
     def _load_image_files(self, folder: str, recursive: bool) -> List[Path]:
         """フォルダから画像ファイルのパスを取得する.
@@ -182,7 +186,7 @@ class GameScreenPicker:
         total_files = len(files)
 
         # ランダムにシャッフル（フォルダやファイル名のバイアスを破壊）
-        random.shuffle(files)
+        self._rng.shuffle(files)
 
         if show_progress:
             print(f"合計 {total_files} 枚を解析中...")

--- a/tests/services/test_screen_picker.py
+++ b/tests/services/test_screen_picker.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+import random
 
 from src.analyzers.image_quality_analyzer import ImageQualityAnalyzer
 from src.models.image_metrics import ImageMetrics
@@ -492,3 +493,202 @@ def test_gradual_threshold_relaxation_and_fallback_for_similar_images() -> None:
     # スコア順になっているはず
     scores = [m.total_score for m in result]
     assert scores == sorted(scores, reverse=True)
+
+
+def test_same_seed_produces_same_results(
+    mock_analyzer: MagicMock,
+) -> None:
+    """同じシードを指定した場合、同じ選択結果が得られること.
+
+    Given:
+        - 10個の画像ファイルを持つフォルダ
+        - 同じシード値で初期化された2つのピッカー
+    When:
+        - 両方のピッカーで5つの画像を選択
+    Then:
+        - 同じファイルが同じ順序で選択されること
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as temp_dir:
+        for i in range(10):
+            Path(temp_dir, f"image{i}.jpg").touch()
+
+        # モックアナライザを設定
+        def mock_analyze_batch(
+            paths: List[str],
+            batch_size: int = 32,  # noqa: ARG001
+            show_progress: bool = False,  # noqa: ARG001
+        ) -> List[ImageMetrics | None]:
+            results: List[ImageMetrics | None] = []
+            for path in paths:
+                idx = int(path.split("image")[-1].split(".")[0])
+                np.random.seed(idx)
+                results.append(
+                    ImageMetrics(
+                        path=path,
+                        raw_metrics={"blur_score": 100 - idx * 5},
+                        normalized_metrics={"blur_score": 1.0 - idx * 0.05},
+                        semantic_score=0.8,
+                        total_score=100 - idx * 5,
+                        features=np.random.rand(128),
+                    )
+                )
+            return results
+
+        mock_analyzer.analyze_batch = mock_analyze_batch
+
+        # 同じシードで2つのピッカーを作成
+        seed = 42
+        picker1 = GameScreenPicker(mock_analyzer, random.Random(seed))
+        picker2 = GameScreenPicker(mock_analyzer, random.Random(seed))
+
+        # Act
+        result1, _ = picker1.select(
+            folder=temp_dir,
+            num=5,
+            similarity_threshold=0.8,
+            recursive=False,
+            show_progress=False,
+        )
+        result2, _ = picker2.select(
+            folder=temp_dir,
+            num=5,
+            similarity_threshold=0.8,
+            recursive=False,
+            show_progress=False,
+        )
+
+        # Assert
+        # 同じパスが同じ順序で選択されているはず
+        paths1 = [m.path for m in result1]
+        paths2 = [m.path for m in result2]
+        assert paths1 == paths2
+
+
+def test_different_seeds_produce_different_results(
+    mock_analyzer: MagicMock,
+) -> None:
+    """異なるシードを指定した場合、異なる選択結果が得られること.
+
+    Given:
+        - 20個の同スコアの画像ファイルを持つフォルダ
+        - 異なるシード値で初期化された2つのピッカー
+    When:
+        - 両方のピッカーで10つの画像を選択
+    Then:
+        - 異なるファイルが選択されること（同スコアで順序がランダムなため）
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # 20個の画像を作成（十分な数を用意することでランダム性の影響を大きくする）
+        for i in range(20):
+            Path(temp_dir, f"image{i}.jpg").touch()
+
+        # モックアナライザを設定 - 全て同じスコアにする
+        def mock_analyze_batch(
+            paths: List[str],
+            batch_size: int = 32,  # noqa: ARG001
+            show_progress: bool = False,  # noqa: ARG001
+        ) -> List[ImageMetrics | None]:
+            results: List[ImageMetrics | None] = []
+            for path in paths:
+                idx = int(path.split("image")[-1].split(".")[0])
+                # それぞれの画像に異なる特徴ベクトルを割り当てる
+                np.random.seed(idx + 1000)  # 異なるシードで特徴を生成
+                results.append(
+                    ImageMetrics(
+                        path=path,
+                        raw_metrics={"blur_score": 100.0},
+                        normalized_metrics={"blur_score": 1.0},
+                        semantic_score=0.8,
+                        total_score=100.0,  # 全て同じスコア
+                        features=np.random.rand(128),  # 異なる特徴
+                    )
+                )
+            return results
+
+        mock_analyzer.analyze_batch = mock_analyze_batch
+
+        # 異なるシードで2つのピッカーを作成
+        picker1 = GameScreenPicker(mock_analyzer, random.Random(42))
+        picker2 = GameScreenPicker(mock_analyzer, random.Random(123))
+
+        # Act
+        result1, _ = picker1.select(
+            folder=temp_dir,
+            num=10,
+            similarity_threshold=0.8,
+            recursive=False,
+            show_progress=False,
+        )
+        result2, _ = picker2.select(
+            folder=temp_dir,
+            num=10,
+            similarity_threshold=0.8,
+            recursive=False,
+            show_progress=False,
+        )
+
+        # Assert
+        # 異なるパスが選択されているはず（全て同じスコアなのでシャッフル順序に依存）
+        paths1 = [m.path for m in result1]
+        paths2 = [m.path for m in result2]
+        assert paths1 != paths2
+
+
+def test_picker_without_rng_still_works(
+    mock_analyzer: MagicMock,
+) -> None:
+    """RNGを指定しない場合、デフォルトの乱数生成器が使用されること.
+
+    Given:
+        - モックアナライザ
+        - RNGを指定せずに作成されたピッカー
+    When:
+        - 画像を選択
+    Then:
+        - 正常に選択が完了すること
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as temp_dir:
+        for i in range(5):
+            Path(temp_dir, f"image{i}.jpg").touch()
+
+        def mock_analyze_batch(
+            paths: List[str],
+            batch_size: int = 32,  # noqa: ARG001
+            show_progress: bool = False,  # noqa: ARG001
+        ) -> List[ImageMetrics | None]:
+            results: List[ImageMetrics | None] = []
+            for path in paths:
+                idx = int(path.split("image")[-1].split(".")[0])
+                np.random.seed(idx)
+                results.append(
+                    ImageMetrics(
+                        path=path,
+                        raw_metrics={"blur_score": 100 - idx * 10},
+                        normalized_metrics={"blur_score": 1.0 - idx * 0.1},
+                        semantic_score=0.8,
+                        total_score=100 - idx * 10,
+                        features=np.random.rand(128),
+                    )
+                )
+            return results
+
+        mock_analyzer.analyze_batch = mock_analyze_batch
+        picker = GameScreenPicker(mock_analyzer)  # RNGなし
+
+        # Act
+        result, stats = picker.select(
+            folder=temp_dir,
+            num=3,
+            similarity_threshold=0.8,
+            recursive=False,
+            show_progress=False,
+        )
+
+        # Assert
+        assert isinstance(stats, PickerStatistics)
+        assert len(result) <= 3
+        assert stats.total_files == 5
+        assert stats.analyzed_ok == 5

--- a/tests/services/test_screen_picker.py
+++ b/tests/services/test_screen_picker.py
@@ -20,6 +20,7 @@ import random
 
 from src.analyzers.image_quality_analyzer import ImageQualityAnalyzer
 from src.models.image_metrics import ImageMetrics
+from src.models.picker_statistics import PickerStatistics
 from src.services.screen_picker import GameScreenPicker
 
 
@@ -527,8 +528,8 @@ def test_same_seed_produces_same_results(
 
         # 同じシードで2つのピッカーを作成
         seed = 42
-        picker1 = GameScreenPicker(mock_analyzer, random.Random(seed))
-        picker2 = GameScreenPicker(mock_analyzer, random.Random(seed))
+        picker1 = GameScreenPicker(mock_analyzer, rng=random.Random(seed))
+        picker2 = GameScreenPicker(mock_analyzer, rng=random.Random(seed))
 
         # Act
         result1, _ = picker1.select(
@@ -598,8 +599,8 @@ def test_different_seeds_produce_different_results(
         mock_analyzer.analyze_batch = mock_analyze_batch
 
         # 異なるシードで2つのピッカーを作成
-        picker1 = GameScreenPicker(mock_analyzer, random.Random(42))
-        picker2 = GameScreenPicker(mock_analyzer, random.Random(123))
+        picker1 = GameScreenPicker(mock_analyzer, rng=random.Random(42))
+        picker2 = GameScreenPicker(mock_analyzer, rng=random.Random(123))
 
         # Act
         result1, _ = picker1.select(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -483,3 +483,51 @@ def test_cli_validates_num_and_similarity_arguments(
         Main().run()
     captured = capsys.readouterr()
     assert error_message in captured.err
+
+
+def test_cli_accepts_seed_argument(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    mock_game_screen_picker: MagicMock,
+    test_image_directory: str,
+    sample_image_metrics_factory: Callable[[str, float], ImageMetrics],
+) -> None:
+    """--seed 引数が正しく処理されること.
+
+    Given:
+        - 有効な入力ディレクトリが存在する
+        - --seed 引数が指定されている
+    When:
+        - CLIが --seed オプションで実行される
+    Then:
+        - プログラムが正常に完了すること
+        - 結果が正しく表示されること
+    """
+    # Arrange
+    seed_value = 42
+    img_path = Path(test_image_directory) / "image0.jpg"
+    img_path.touch()
+    results = [sample_image_metrics_factory(str(img_path), 95.0)]
+    stats = PickerStatistics(
+        total_files=5,
+        analyzed_ok=5,
+        analyzed_fail=0,
+        rejected_by_similarity=4,
+        selected_count=1,
+    )
+    mock_game_screen_picker.select.return_value = (results, stats)
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["main.py", test_image_directory, "-n", "5", "--seed", str(seed_value)],
+    )
+
+    # Act
+    from src.main import Main
+
+    Main().run()
+
+    # Assert
+    captured = capsys.readouterr()
+    assert "選択された画像一覧" in captured.out
+    assert captured.out.count("Score:") == 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -79,9 +79,11 @@ def setup_main_mocks(
 ) -> None:
     """すべてのテストで必要なモック設定を自動的に適用する."""
     monkeypatch.setattr(
-        "src.main.ImageQualityAnalyzer", lambda *_: mock_image_quality_analyzer
+        "src.main.ImageQualityAnalyzer", lambda *_, **__: mock_image_quality_analyzer
     )
-    monkeypatch.setattr("src.main.GameScreenPicker", lambda *_: mock_game_screen_picker)
+    monkeypatch.setattr(
+        "src.main.GameScreenPicker", lambda *_, **__: mock_game_screen_picker
+    )
 
 
 def test_cli_accepts_all_arguments(


### PR DESCRIPTION
## 概要

RNG（乱数生成器）の注入と `--seed` CLIオプションを追加し、選択処理の再現性を確保する機能を実装しました。

## 変更内容

### 機能追加
- `GameScreenPicker` で RNG を注入可能に（下位互換性維持）
- `--seed` オプションでシード値を指定可能に
  - 同じシードで実行すると常に同じ結果が得られる
  - 異なるシードで実行すると異なる結果が得られる
  - シードなしでは従来通りランダム

### ファイル変更
- `src/services/screen_picker.py`: RNG注入による再現性確保
- `src/main.py`: `--seed` CLIオプション追加
- `tests/services/test_screen_picker.py`: シード機能のテスト追加（3テスト）
  - 同じシードで同じ結果になることの検証
  - 異なるシードで異なる結果になることの検証
  - RNGなしでも動作することの検証
- `tests/test_main.py`: `--seed` 引数のテスト追加

## 検証

- ✅ 全68テストパス
- ✅ Lintチェックパス
- ✅ 下位互換性維持（既存動作に変更なし）

## 使用例

```bash
# 同じシードで同じ結果
game-screen-pick /path/to/images -n 5 --seed 42
game-screen-pick /path/to/images -n 5 --seed 42  # 結果が一致

# 異なるシードで異なる結果
game-screen-pick /path/to/images -n 5 --seed 123  # 結果が異なる

# シードなしでランダム（従来通り）
game-screen-pick /path/to/images -n 5
```