### PR TITLE
perf: analyzersパッケージのimportを遅延ロードに変更してCLI起動時の負荷を軽減

### DIFF
--- a/src/analyzers/__init__.py
+++ b/src/analyzers/__init__.py
@@ -1,11 +1,45 @@
-"""Analyzers package for image analysis and metric normalization."""
+"""Analyzers package for image analysis and metric normalization.
 
-from .metric_normalizer import MetricNormalizer
-from .image_quality_analyzer import ImageQualityAnalyzer
-from .analyzer_pool import ImageQualityAnalyzerPool
+This package uses lazy imports to reduce import overhead.
+Modules are only loaded when their attributes are accessed.
+"""
+
+from typing import Any
 
 __all__ = [
     "MetricNormalizer",
     "ImageQualityAnalyzer",
     "ImageQualityAnalyzerPool",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy import for submodules to reduce startup overhead.
+
+    This function is called when an attribute is not found in the module's
+    __dict__, allowing us to defer importing heavy modules until they are
+    actually needed.
+
+    Args:
+        name: The attribute name being accessed
+
+    Returns:
+        The requested module/class
+
+    Raises:
+        AttributeError: If the requested name is not in __all__
+    """
+    if name == "MetricNormalizer":
+        from .metric_normalizer import MetricNormalizer
+
+        return MetricNormalizer
+    if name == "ImageQualityAnalyzer":
+        from .image_quality_analyzer import ImageQualityAnalyzer
+
+        return ImageQualityAnalyzer
+    if name == "ImageQualityAnalyzerPool":
+        from .analyzer_pool import ImageQualityAnalyzerPool
+
+        return ImageQualityAnalyzerPool
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## 概要
`analyzers` パッケージの `__init__.py` で即時 import していたモジュールを遅延インポート（lazy import）に変更しました。

## 変更内容
- `__getattr__` 関数を実装して、属性アクセス時にのみ必要なモジュールを読み込むように変更
- `ImageQualityAnalyzer` だけを import する場合に `analyzer_pool` が読み込まれないように最適化

## 効果
- CLI 起動時の import 負荷を軽減
- 必要なクラス/モジュールのみが読み込まれるようになり、メモリ使用量の削減

## テスト
- 全テスト（58件）がパスすることを確認