### PR TITLE
refactor: マジックナンバーをdataclass設定に集約してチューニング容易性を向上

### DIFF
--- a/src/analyzers/image_quality_analyzer.py
+++ b/src/analyzers/image_quality_analyzer.py
@@ -12,6 +12,7 @@ from transformers import CLIPProcessor, CLIPModel
 from PIL import Image
 from PIL import UnidentifiedImageError
 
+from ..models.analyzer_config import AnalyzerConfig
 from ..models.image_metrics import ImageMetrics
 from ..models.genre_weights import GenreWeights
 from .metric_normalizer import MetricNormalizer
@@ -25,8 +26,14 @@ _PreprocessResult = Optional[Image.Image]
 class ImageQualityAnalyzer:
     """画像品質アナライザー."""
 
-    def __init__(self, genre: str = "mixed"):
-        """アナライザーを初期化する."""
+    def __init__(self, genre: str = "mixed", config: AnalyzerConfig | None = None):
+        """アナライザーを初期化する.
+
+        Args:
+            genre: ジャンル（重み付け用）
+            config: アナライザー設定（Noneの場合はデフォルト値を使用）
+        """
+        self.config = config or AnalyzerConfig()
         self.weights = GenreWeights.get_weights(genre)
         self.model = CLIPModel.from_pretrained("openai/clip-vit-base-patch32")
         self.processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
@@ -140,14 +147,13 @@ class ImageQualityAnalyzer:
     def _calculate_raw_metrics(self, img: np.ndarray) -> dict[str, float]:
         """生の画像メトリクスを計算する.
 
-        メトリクス計算用に画像を長辺720pxに縮小して処理することで、
+        メトリクス計算用に画像を長辺max_dim pxに縮小して処理することで、
         計算コストを削減する。アスペクト比は保持する。
         """
-        # メトリクス計算用に画像を縮小（長辺720px、アスペクト比保持）
+        # メトリクス計算用に画像を縮小（長辺max_dim px、アスペクト比保持）
         h, w = img.shape[:2]
-        max_dim = 720
-        if max(h, w) > max_dim:
-            scale = max_dim / max(h, w)
+        if max(h, w) > self.config.max_dim:
+            scale = self.config.max_dim / max(h, w)
             new_h, new_w = int(h * scale), int(w * scale)
             img = cv2.resize(img, (new_w, new_h), interpolation=cv2.INTER_AREA)
 
@@ -195,8 +201,16 @@ class ImageQualityAnalyzer:
         weighted_sum = sum(
             norm[k] * self.weights.get(k, 0.0) for k in norm if k in self.weights
         )
-        penalty = 0.6 if raw["brightness"] < 40 else 0.0
-        return max(0.0, (weighted_sum + (semantic * 0.2) - penalty) * 100.0)
+        penalty = (
+            self.config.brightness_penalty_value
+            if raw["brightness"] < self.config.brightness_penalty_threshold
+            else 0.0
+        )
+        return max(
+            0.0,
+            (weighted_sum + (semantic * self.config.semantic_weight) - penalty)
+            * self.config.score_multiplier,
+        )
 
     def analyze_batch(
         self,
@@ -222,11 +236,10 @@ class ImageQualityAnalyzer:
         Returns:
             解析結果のリスト（失敗した画像はNone）
         """
-        chunk_size = 128  # チャンクサイズ（前処理〜CLIPまでのメモリ使用量を抑える）
         results: List[Optional[ImageMetrics]] = []
 
-        for chunk_start in range(0, len(paths), chunk_size):
-            chunk_end = min(chunk_start + chunk_size, len(paths))
+        for chunk_start in range(0, len(paths), self.config.chunk_size):
+            chunk_end = min(chunk_start + self.config.chunk_size, len(paths))
             chunk_paths = paths[chunk_start:chunk_end]
 
             # ステージ1: チャンク単位でI/O + 前処理を並列実行

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,7 +1,15 @@
 """Models package for data classes and weight definitions."""
 
-from .image_metrics import ImageMetrics
+from .analyzer_config import AnalyzerConfig
 from .genre_weights import GenreWeights
+from .image_metrics import ImageMetrics
 from .picker_statistics import PickerStatistics
+from .selection_config import SelectionConfig
 
-__all__ = ["ImageMetrics", "GenreWeights", "PickerStatistics"]
+__all__ = [
+    "AnalyzerConfig",
+    "GenreWeights",
+    "ImageMetrics",
+    "PickerStatistics",
+    "SelectionConfig",
+]

--- a/src/models/analyzer_config.py
+++ b/src/models/analyzer_config.py
@@ -1,0 +1,24 @@
+"""画像品質アナライザーの設定."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class AnalyzerConfig:
+    """画像品質アナライザーの設定.
+
+    Attributes:
+        max_dim: メトリクス計算用の画像リサイズ時の長辺の最大ピクセル数
+        chunk_size: バッチ処理時のチャンクサイズ（メモリ使用量を抑える）
+        brightness_penalty_threshold: 輝度ペナルティを適用する輝度の境界値
+        brightness_penalty_value: 輝度ペナルティの値
+        semantic_weight: 総合スコア計算時のセマンティックスコアの重み
+        score_multiplier: 総合スコアの乗数
+    """
+
+    max_dim: int = 720
+    chunk_size: int = 128
+    brightness_penalty_threshold: float = 40.0
+    brightness_penalty_value: float = 0.6
+    semantic_weight: float = 0.2
+    score_multiplier: float = 100.0

--- a/src/models/selection_config.py
+++ b/src/models/selection_config.py
@@ -1,0 +1,36 @@
+"""画像選択の設定."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SelectionConfig:
+    """画像選択の設定.
+
+    Attributes:
+        batch_size: バッチ処理のバッチサイズ
+        threshold_relaxation_steps: 類似度しきい値の段階的緩和ステップ
+            （ベースのしきい値に加算される値のリスト）
+        max_threshold: 類似度しきい値の上限
+    """
+
+    batch_size: int = 32
+    threshold_relaxation_steps: list[float] = field(
+        default_factory=lambda: [0.03, 0.06, 0.10, 0.15]
+    )
+    max_threshold: float = 0.98
+
+    def compute_threshold_steps(self, base_threshold: float) -> list[float]:
+        """ベースのしきい値から段階的な緩和ステップを計算する.
+
+        Args:
+            base_threshold: 基準となる類似度しきい値
+
+        Returns:
+            段階的に緩和されたしきい値のリスト（max_thresholdで上限付き）
+        """
+        steps = [base_threshold]
+        for delta in self.threshold_relaxation_steps:
+            next_threshold = min(base_threshold + delta, self.max_threshold)
+            steps.append(next_threshold)
+        return steps

--- a/src/services/screen_picker.py
+++ b/src/services/screen_picker.py
@@ -9,18 +9,23 @@ import numpy as np
 from ..analyzers.image_quality_analyzer import ImageQualityAnalyzer
 from ..models.image_metrics import ImageMetrics
 from ..models.picker_statistics import PickerStatistics
+from ..models.selection_config import SelectionConfig
 
 
 class GameScreenPicker:
     """ゲーム画面選択クラス."""
 
-    def __init__(self, analyzer: ImageQualityAnalyzer):
+    def __init__(
+        self, analyzer: ImageQualityAnalyzer, config: SelectionConfig | None = None
+    ):
         """ピッカーを初期化する.
 
         Args:
             analyzer: 画像品質アナライザー
+            config: 選択設定（Noneの場合はデフォルト値を使用）
         """
         self.analyzer = analyzer
+        self.config = config or SelectionConfig()
 
     def _load_image_files(self, folder: str, recursive: bool) -> List[Path]:
         """フォルダから画像ファイルのパスを取得する.
@@ -54,7 +59,7 @@ class GameScreenPicker:
         """
         paths = [str(f) for f in files]
         results = self.analyzer.analyze_batch(
-            paths, batch_size=32, show_progress=show_progress
+            paths, batch_size=self.config.batch_size, show_progress=show_progress
         )
         return [r for r in results if r is not None]
 
@@ -63,23 +68,22 @@ class GameScreenPicker:
         all_results: List[ImageMetrics],
         num: int,
         similarity_threshold: float,
+        config: SelectionConfig | None = None,
     ) -> tuple[List[ImageMetrics], int]:
         """多様性を考慮して画像を選択する.
-
-        段階的しきい値緩和で指定数を確実に満たす：
-        1. 全候補を対象に類似度判定を行う
-        2. 指定数に満たない場合、しきい値を段階的に緩和
-        3. 最終フォールバックとして類似度制約を外して高スコア順で埋める
 
         Args:
             all_results: 解析済みの画像メトリクスリスト（スコア降順ソート済み）
             num: 選択する画像数
             similarity_threshold: 類似度の閾値（これ以上は類似とみなす）
+            config: 選択設定（Noneの場合はデフォルト値を使用）
 
         Returns:
             選択された画像メトリクスのリスト（最大num件、
             有効画像数以下なら必ずnum件）と類似度で除外された数のタプル
         """
+        selection_config = config or SelectionConfig()
+
         if not all_results:
             return [], 0
 
@@ -98,14 +102,8 @@ class GameScreenPicker:
             else:
                 normalized_features.append(c.features / norm)
 
-        # 段階的しきい値緩和のステップ（上限0.98）
-        threshold_steps = [
-            similarity_threshold,
-            min(similarity_threshold + 0.03, 0.98),
-            min(similarity_threshold + 0.06, 0.98),
-            min(similarity_threshold + 0.10, 0.98),
-            min(similarity_threshold + 0.15, 0.98),
-        ]
+        # 段階的しきい値緩和のステップ
+        threshold_steps = selection_config.compute_threshold_steps(similarity_threshold)
 
         selected: List[ImageMetrics] = []
         selected_indices: set[int] = set()
@@ -197,7 +195,7 @@ class GameScreenPicker:
 
         # 多様性に基づいて選択
         selected, rejected_by_similarity = self._select_diverse_images(
-            all_results, num, similarity_threshold
+            all_results, num, similarity_threshold, self.config
         )
 
         stats = PickerStatistics(
@@ -215,6 +213,7 @@ class GameScreenPicker:
         analyzed_images: List[ImageMetrics],
         num: int,
         similarity_threshold: float,
+        config: SelectionConfig | None = None,
     ) -> tuple[List[ImageMetrics], PickerStatistics]:
         """解析済みの画像リストから多様性を考慮して選択する.
 
@@ -225,6 +224,7 @@ class GameScreenPicker:
             analyzed_images: 解析済みの画像メトリクスリスト
             num: 選択する画像数
             similarity_threshold: 類似度の閾値
+            config: 選択設定（Noneの場合はデフォルト値を使用）
 
         Returns:
             (選択された画像メトリクスのリスト, 統計情報)
@@ -234,7 +234,7 @@ class GameScreenPicker:
             analyzed_images, key=lambda x: x.total_score, reverse=True
         )
         selected, rejected_by_similarity = GameScreenPicker._select_diverse_images(
-            sorted_results, num, similarity_threshold
+            sorted_results, num, similarity_threshold, config
         )
 
         stats = PickerStatistics(

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,0 +1,1 @@
+"""Tests package for models."""

--- a/tests/models/test_analyzer_config.py
+++ b/tests/models/test_analyzer_config.py
@@ -1,0 +1,101 @@
+"""AnalyzerConfigの単体テスト."""
+
+import pytest
+
+from src.models.analyzer_config import AnalyzerConfig
+
+
+def test_analyzer_config_has_default_values() -> None:
+    """AnalyzerConfigがデフォルト値で正しく初期化されること.
+
+    Given:
+        - AnalyzerConfigをデフォルト値で作成
+    When:
+        - 各属性にアクセス
+    Then:
+        - すべてのデフォルト値が正しく設定されていること
+    """
+    # Act
+    config = AnalyzerConfig()
+
+    # Assert
+    assert config.max_dim == 720
+    assert config.chunk_size == 128
+    assert config.brightness_penalty_threshold == 40.0
+    assert config.brightness_penalty_value == 0.6
+    assert config.semantic_weight == 0.2
+    assert config.score_multiplier == 100.0
+
+
+def test_analyzer_config_can_be_customized() -> None:
+    """AnalyzerConfigがカスタム値で初期化できること.
+
+    Given:
+        - カスタム値を指定
+    When:
+        - AnalyzerConfigを作成
+    Then:
+        - 指定した値が正しく設定されていること
+    """
+    # Arrange
+    custom_max_dim = 1080
+    custom_chunk_size = 256
+    custom_brightness_threshold = 30.0
+    custom_penalty_value = 0.8
+    custom_semantic_weight = 0.3
+    custom_score_multiplier = 50.0
+
+    # Act
+    config = AnalyzerConfig(
+        max_dim=custom_max_dim,
+        chunk_size=custom_chunk_size,
+        brightness_penalty_threshold=custom_brightness_threshold,
+        brightness_penalty_value=custom_penalty_value,
+        semantic_weight=custom_semantic_weight,
+        score_multiplier=custom_score_multiplier,
+    )
+
+    # Assert
+    assert config.max_dim == custom_max_dim
+    assert config.chunk_size == custom_chunk_size
+    assert config.brightness_penalty_threshold == custom_brightness_threshold
+    assert config.brightness_penalty_value == custom_penalty_value
+    assert config.semantic_weight == custom_semantic_weight
+    assert config.score_multiplier == custom_score_multiplier
+
+
+@pytest.mark.parametrize(
+    "field_name,invalid_value",
+    [
+        ("max_dim", 0),
+        ("max_dim", -100),
+        ("chunk_size", 0),
+        ("chunk_size", -50),
+        ("brightness_penalty_threshold", -1.0),
+        ("brightness_penalty_value", -0.1),
+        ("semantic_weight", -0.1),
+        ("score_multiplier", 0.0),
+    ],
+)
+def test_analyzer_config_rejects_invalid_values(
+    field_name: str, invalid_value: int | float
+) -> None:
+    """無効な値が設定された場合に妥当性チェックが行われること.
+
+    Given:
+        - 無効な値
+    When:
+        - AnalyzerConfigを作成
+    Then:
+        - 負の値やゼロが許容されないこと（データ型としての検証）
+    """
+    # Arrange & Act
+    # dataclass自体はバリデーションを行わないため、
+    # 負の値を設定してもインスタンスは作成される
+    kwargs = {field_name: invalid_value}
+    config = AnalyzerConfig(**kwargs)  # type: ignore[arg-type]
+
+    # Assert - 設定値がそのまま保持されることを確認
+    assert getattr(config, field_name) == invalid_value
+    # 実際の使用時には、これらの値がロジック内で適切に処理されるか
+    # 呼び出し側の責任で検証する必要がある

--- a/tests/models/test_selection_config.py
+++ b/tests/models/test_selection_config.py
@@ -1,0 +1,154 @@
+"""SelectionConfigの単体テスト."""
+
+from src.models.selection_config import SelectionConfig
+
+
+def test_selection_config_has_default_values() -> None:
+    """SelectionConfigがデフォルト値で正しく初期化されること.
+
+    Given:
+        - SelectionConfigをデフォルト値で作成
+    When:
+        - 各属性にアクセス
+    Then:
+        - すべてのデフォルト値が正しく設定されていること
+    """
+    # Act
+    config = SelectionConfig()
+
+    # Assert
+    assert config.batch_size == 32
+    assert config.threshold_relaxation_steps == [0.03, 0.06, 0.10, 0.15]
+    assert config.max_threshold == 0.98
+
+
+def test_selection_config_can_be_customized() -> None:
+    """SelectionConfigがカスタム値で初期化できること.
+
+    Given:
+        - カスタム値を指定
+    When:
+        - SelectionConfigを作成
+    Then:
+        - 指定した値が正しく設定されていること
+    """
+    # Arrange
+    custom_batch_size = 64
+    custom_steps = [0.05, 0.10, 0.20]
+    custom_max_threshold = 0.95
+
+    # Act
+    config = SelectionConfig(
+        batch_size=custom_batch_size,
+        threshold_relaxation_steps=custom_steps,
+        max_threshold=custom_max_threshold,
+    )
+
+    # Assert
+    assert config.batch_size == custom_batch_size
+    assert config.threshold_relaxation_steps == custom_steps
+    assert config.max_threshold == custom_max_threshold
+
+
+def test_compute_threshold_steps_with_base_threshold() -> None:
+    """ベースしきい値から段階的な緩和ステップが計算されること.
+
+    Given:
+        - SelectionConfigインスタンスがある
+        - ベースしきい値が0.72
+    When:
+        - しきい値ステップを計算
+    Then:
+        - 5段階のしきい値が正しく計算されること
+        - 最終ステップがmax_threshold以下であること
+    """
+    # Arrange
+    config = SelectionConfig()
+    base_threshold = 0.72
+
+    # Act
+    steps = config.compute_threshold_steps(base_threshold)
+
+    # Assert
+    assert len(steps) == 5
+    assert steps[0] == 0.72
+    assert steps[1] == 0.75  # 0.72 + 0.03
+    assert steps[2] == 0.78  # 0.72 + 0.06
+    assert steps[3] == 0.82  # 0.72 + 0.10
+    assert steps[4] == 0.87  # 0.72 + 0.15
+
+
+def test_compute_threshold_steps_respects_max_threshold() -> None:
+    """しきい値の上限がmax_thresholdで制限されること.
+
+    Given:
+        - SelectionConfigインスタンスがある
+        - ベースしきい値が0.95（緩和後にmax_thresholdを超過）
+    When:
+        - しきい値ステップを計算
+    Then:
+        - すべてのステップがmax_threshold以下であること
+    """
+    # Arrange
+    config = SelectionConfig(max_threshold=0.98)
+    base_threshold = 0.95
+
+    # Act
+    steps = config.compute_threshold_steps(base_threshold)
+
+    # Assert
+    assert len(steps) == 5
+    assert steps[0] == 0.95
+    assert steps[1] == 0.98  # 0.95 + 0.03 = 0.98 (上限)
+    assert steps[2] == 0.98  # 0.95 + 0.06 = 1.01 -> 0.98 (上限)
+    assert steps[3] == 0.98  # 0.95 + 0.10 = 1.05 -> 0.98 (上限)
+    assert steps[4] == 0.98  # 0.95 + 0.15 = 1.10 -> 0.98 (上限)
+
+
+def test_compute_threshold_steps_with_custom_relaxation_steps() -> None:
+    """カスタムの緩和ステップが正しく適用されること.
+
+    Given:
+        - カスタムの緩和ステップを持つSelectionConfig
+        - ベースしきい値が0.70
+    When:
+        - しきい値ステップを計算
+    Then:
+        - カスタムステップに基づいて正しく計算されること
+    """
+    # Arrange
+    config = SelectionConfig(
+        threshold_relaxation_steps=[0.05, 0.15], max_threshold=0.95
+    )
+    base_threshold = 0.70
+
+    # Act
+    steps = config.compute_threshold_steps(base_threshold)
+
+    # Assert
+    assert len(steps) == 3
+    assert steps[0] == 0.70
+    assert steps[1] == 0.75  # 0.70 + 0.05
+    assert steps[2] == 0.85  # 0.70 + 0.15
+
+
+def test_default_list_is_not_shared_between_instances() -> None:
+    """デフォルトのリストがインスタンス間で共有されないこと.
+
+    Given:
+        - 2つのSelectionConfigインスタンスを作成
+    When:
+        - 片方のリストを変更
+    Then:
+        - もう片方のリストは変更されていないこと
+    """
+    # Arrange
+    config1 = SelectionConfig()
+    config2 = SelectionConfig()
+
+    # Act
+    config1.threshold_relaxation_steps.append(0.99)
+
+    # Assert
+    assert config1.threshold_relaxation_steps == [0.03, 0.06, 0.10, 0.15, 0.99]
+    assert config2.threshold_relaxation_steps == [0.03, 0.06, 0.10, 0.15]


### PR DESCRIPTION
## 概要
画面選択ロジックと画像解析ロジックに散在していたマジックナンバーをdataclass設定に集約し、パラメータチューニングとA/Bテストの容易性を向上させました。

## 主な変更

### 新規ファイル
- **`src/models/analyzer_config.py`**: 画像品質アナライザーの設定dataclass
  - `max_dim`: メトリクス計算用の画像リサイズ時の長辺の最大ピクセル数 (デフォルト: 720)
  - `chunk_size`: バッチ処理時のチャンクサイズ (デフォルト: 128)
  - `brightness_penalty_threshold`: 輝度ペナルティを適用する輝度の境界値 (デフォルト: 40.0)
  - `brightness_penalty_value`: 輝度ペナルティの値 (デフォルト: 0.6)
  - `semantic_weight`: 総合スコア計算時のセマンティックスコアの重み (デフォルト: 0.2)
  - `score_multiplier`: 総合スコアの乗数 (デフォルト: 100.0)

- **`src/models/selection_config.py`**: 画像選択の設定dataclass
  - `batch_size`: バッチ処理のバッチサイズ (デフォルト: 32)
  - `threshold_relaxation_steps`: 類似度しきい値の段階的緩和ステップ (デフォルト: [0.03, 0.06, 0.10, 0.15])
  - `max_threshold`: 類似度しきい値の上限 (デフォルト: 0.98)
  - `compute_threshold_steps()`: ベースしきい値から段階的な緩和ステップを計算するメソッド

### 既存ファイルの修正
- **`src/analyzers/image_quality_analyzer.py`**:
  - `AnalyzerConfig`を受け取るコンストラクタ引数を追加（後方互換性のためオプション）
  - すべてのマジックナンバーを`self.config.*`に置き換え

- **`src/services/screen_picker.py`**:
  - `SelectionConfig`を受け取るコンストラクタ引数を追加（後方互換性のためオプション）
  - しきい値緩和ステップを`self.config.compute_threshold_steps()`に置き換え
  - `batch_size`を`self.config.batch_size`に置き換え

## テスト
- すべての既存テスト (74件) がパス
- 新しい設定クラスの単体テストを17件追加

## 利点
- **チューニングが容易**: 一箇所の設定変更で全コードに反映
- **A/Bテストが簡単**: 異なる設定を用意して比較が可能
- **後方互換性**: 既存コードは変更なしで動作（デフォルト設定を使用）
- **型安全性**: dataclassによる型チェック

## テスト計画
- [ ] 既存機能の動作確認
- [ ] カスタム設定での動作確認