### PR TITLE
refactor: importスタイルを改善してパッケージの配布形式への依存を削減

### DIFF
--- a/src/analyzers/analyzer_pool.py
+++ b/src/analyzers/analyzer_pool.py
@@ -8,8 +8,8 @@ import os
 from multiprocessing.pool import Pool
 from typing import Any, List, Literal, Optional
 
-from src.analyzers.image_quality_analyzer import ImageQualityAnalyzer
-from src.models.image_metrics import ImageMetrics
+from .image_quality_analyzer import ImageQualityAnalyzer
+from ..models.image_metrics import ImageMetrics
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## 概要
パッケージ内のimportスタイルを絶対importから相対importに統一し、実行コンテキストへの依存を削除するリファクタリングを行いました。

## 主な変更

### analyzer_pool.pyのimport修正
- `from src.analyzers.image_quality_analyzer` → `from .image_quality_analyzer`
- `from src.models.image_metrics` → `from ..models.image_metrics`

### 既に含まれる改善（このブランチの先行コミット）
- analyzersパッケージの遅延import実装（CLI起動時の負荷軽減）
- バッチ解析時のCLIP推論二重実行の解消
- 段階的しきい値緩和時の類似画像再評価修正
- テストコードのリファクタリング

## メリット
- パッケージとしてインストールされた場合など、様々な配布形態で堅牢に動作
- 実行コンテキスト（`src`ディレクトリがPYTHONPATHにあるか）への依存が削減
- Pythonのベストプラクティス（パッケージ内では相対import）に準拠

## テスト
- 全58件のテストがパス
- Ruffによるリンティングも通過