### PR TITLE
fix: test_batch_pipelineの誤ったアサーションを修正して回帰検知を有効化

### DIFF
--- a/tests/analyzers/test_batch_pipeline.py
+++ b/tests/analyzers/test_batch_pipeline.py
@@ -273,7 +273,7 @@ def test_process_batch_processes_various_image_formats(
     # Assert
     assert len(results) == 2
     # 少なくとも1つの画像が処理されている
-    assert any(r is not None for r in paths)
+    assert any(r is not None for r in results)
     for result in results:
         if result is None:
             continue


### PR DESCRIPTION
## Summary
- `test_process_batch_processes_various_image_formats` テストの誤ったアサーションを修正
- `paths` 変数（文字列リスト）に対するチェックを `results` 変数に変更

## Problem
`assert any(r is not None for r in paths)` というアサーションは、`paths` が文字列のリストであるため常に `True` となり、実際の処理結果が検査できていませんでした。これでは回帰を検知できない状態でした。

## Solution
`paths` → `results` に修正し、実際の処理結果を検査するようにしました。

## Test plan
- [x] すべてのテストがパスすることを確認（pytest: 10 passed）
- [x] 修正したアサーションが実際に `results` を検査していることを確認