### PR TITLE
feat: AnalyzerConfigとSelectionConfigに__post_init__で設定値バリデーションを追加

### DIFF
--- a/src/models/analyzer_config.py
+++ b/src/models/analyzer_config.py
@@ -22,3 +22,34 @@ class AnalyzerConfig:
     brightness_penalty_value: float = 0.6
     semantic_weight: float = 0.2
     score_multiplier: float = 100.0
+
+    def __post_init__(self) -> None:
+        """設定値の妥当性を検証する."""
+        if self.max_dim <= 0:
+            msg = f"max_dimは正の整数である必要があります: {self.max_dim}"
+            raise ValueError(msg)
+        if self.chunk_size <= 0:
+            msg = f"chunk_sizeは正の整数である必要があります: {self.chunk_size}"
+            raise ValueError(msg)
+        if self.brightness_penalty_threshold < 0:
+            msg = (
+                "brightness_penalty_thresholdは非負の値である必要があります: "
+                f"{self.brightness_penalty_threshold}"
+            )
+            raise ValueError(msg)
+        if self.brightness_penalty_value < 0:
+            msg = (
+                "brightness_penalty_valueは非負の値である必要があります: "
+                f"{self.brightness_penalty_value}"
+            )
+            raise ValueError(msg)
+        if self.semantic_weight < 0:
+            msg = (
+                f"semantic_weightは非負の値である必要があります: {self.semantic_weight}"
+            )
+            raise ValueError(msg)
+        if self.score_multiplier <= 0:
+            msg = (
+                f"score_multiplierは正の値である必要があります: {self.score_multiplier}"
+            )
+            raise ValueError(msg)

--- a/src/models/selection_config.py
+++ b/src/models/selection_config.py
@@ -20,6 +20,24 @@ class SelectionConfig:
     )
     max_threshold: float = 0.98
 
+    def __post_init__(self) -> None:
+        """設定値の妥当性を検証する."""
+        if self.batch_size <= 0:
+            msg = f"batch_sizeは正の整数である必要があります: {self.batch_size}"
+            raise ValueError(msg)
+
+        if not (0 <= self.max_threshold <= 1):
+            msg = f"max_thresholdは0以上1以下である必要があります: {self.max_threshold}"
+            raise ValueError(msg)
+
+        for i, step in enumerate(self.threshold_relaxation_steps):
+            if step < 0:
+                msg = (
+                    f"threshold_relaxation_steps[{i}]は非負の値である必要があります: "
+                    f"{step}"
+                )
+                raise ValueError(msg)
+
     def compute_threshold_steps(self, base_threshold: float) -> list[float]:
         """ベースのしきい値から段階的な緩和ステップを計算する.
 

--- a/tests/models/test_analyzer_config.py
+++ b/tests/models/test_analyzer_config.py
@@ -80,22 +80,18 @@ def test_analyzer_config_can_be_customized() -> None:
 def test_analyzer_config_rejects_invalid_values(
     field_name: str, invalid_value: int | float
 ) -> None:
-    """無効な値が設定された場合に妥当性チェックが行われること.
+    """無効な値が設定された場合に例外が発生すること.
 
     Given:
         - 無効な値
     When:
         - AnalyzerConfigを作成
     Then:
-        - 負の値やゼロが許容されないこと（データ型としての検証）
+        - ValueErrorがスローされること
     """
-    # Arrange & Act
-    # dataclass自体はバリデーションを行わないため、
-    # 負の値を設定してもインスタンスは作成される
+    # Arrange
     kwargs = {field_name: invalid_value}
-    config = AnalyzerConfig(**kwargs)  # type: ignore[arg-type]
 
-    # Assert - 設定値がそのまま保持されることを確認
-    assert getattr(config, field_name) == invalid_value
-    # 実際の使用時には、これらの値がロジック内で適切に処理されるか
-    # 呼び出し側の責任で検証する必要がある
+    # Act & Assert
+    with pytest.raises(ValueError):
+        AnalyzerConfig(**kwargs)  # type: ignore[arg-type]

--- a/tests/models/test_selection_config.py
+++ b/tests/models/test_selection_config.py
@@ -1,5 +1,7 @@
 """SelectionConfigの単体テスト."""
 
+import pytest
+
 from src.models.selection_config import SelectionConfig
 
 
@@ -152,3 +154,48 @@ def test_default_list_is_not_shared_between_instances() -> None:
     # Assert
     assert config1.threshold_relaxation_steps == [0.03, 0.06, 0.10, 0.15, 0.99]
     assert config2.threshold_relaxation_steps == [0.03, 0.06, 0.10, 0.15]
+
+
+@pytest.mark.parametrize(
+    "field_name,invalid_value",
+    [
+        ("batch_size", 0),
+        ("batch_size", -10),
+        ("max_threshold", -0.1),
+        ("max_threshold", 1.1),
+        ("max_threshold", 2.0),
+    ],
+)
+def test_selection_config_rejects_invalid_values(
+    field_name: str, invalid_value: int | float
+) -> None:
+    """無効な値が設定された場合に例外が発生すること.
+
+    Given:
+        - 無効な値
+    When:
+        - SelectionConfigを作成
+    Then:
+        - ValueErrorがスローされること
+    """
+    # Arrange
+    kwargs = {field_name: invalid_value}
+
+    # Act & Assert
+    with pytest.raises(ValueError):
+        SelectionConfig(**kwargs)  # type: ignore[arg-type]
+
+
+def test_selection_config_rejects_negative_relaxation_steps() -> None:
+    """threshold_relaxation_stepsに負の値が含まれる場合に例外が発生すること.
+
+    Given:
+        - 負の値を含むthreshold_relaxation_steps
+    When:
+        - SelectionConfigを作成
+    Then:
+        - ValueErrorがスローされること
+    """
+    # Arrange & Act & Assert
+    with pytest.raises(ValueError, match="threshold_relaxation_steps"):
+        SelectionConfig(threshold_relaxation_steps=[0.1, -0.05, 0.2])


### PR DESCRIPTION
## 概要
AnalyzerConfigとSelectionConfigのdataclassに`__post_init__`メソッドを追加し、設定値の妥当性検証を実装しました。

## 変更内容

### src/models/analyzer_config.py
- `__post_init__`メソッドを追加
- 以下のバリデーションを実装：
  - `max_dim > 0`
  - `chunk_size > 0`
  - `brightness_penalty_threshold >= 0`
  - `brightness_penalty_value >= 0`
  - `semantic_weight >= 0`
  - `score_multiplier > 0`

### src/models/selection_config.py
- `__post_init__`メソッドを追加
- 以下のバリデーションを実装：
  - `batch_size > 0`
  - `0 <= max_threshold <= 1`
  - `threshold_relaxation_steps`の全要素が非負

### テスト更新
- `test_analyzer_config.py`: 無効な値で`ValueError`がスローされることを確認するように変更
- `test_selection_config.py`: 無効な値に対するテストを追加

## テスト計画
- [x] すべてのユニットテストがパスすること（125 passed, 1 skipped）
- [x] リンティングチェックがパスすること