### PR TITLE
refactor: _safe_l2_normalizeの重複実装をVectorUtilsクラスに統合

### DIFF
--- a/src/analyzers/feature_extractor.py
+++ b/src/analyzers/feature_extractor.py
@@ -6,25 +6,10 @@ import cv2
 import numpy as np
 from PIL import Image
 
+from ..utils import VectorUtils
 from .clip_model_manager import CLIPModelManager
 
 logger = logging.getLogger(__name__)
-
-
-def _safe_l2_normalize(vec: np.ndarray, eps: float = 1e-8) -> np.ndarray:
-    """ゼロ割れ安全なL2正規化を行う.
-
-    Args:
-        vec: 正規化するベクトル
-        eps: ゼロ割れ防止用の微小値
-
-    Returns:
-        L2正規化されたベクトル（元のノルムが0の場合はゼロベクトル）
-    """
-    norm = float(np.linalg.norm(vec))
-    if norm < eps:
-        return np.zeros_like(vec)
-    return vec / norm
 
 
 class FeatureExtractor:
@@ -76,7 +61,7 @@ class FeatureExtractor:
             image_features = self.model_manager.model.get_image_features(**inputs)
             # L2正規化して返す
             features = image_features[0].cpu().numpy()
-            return _safe_l2_normalize(features)
+            return VectorUtils.safe_l2_normalize(features)
 
     def extract_combined_features(
         self, img: np.ndarray, clip_features: np.ndarray
@@ -92,7 +77,7 @@ class FeatureExtractor:
         """
         hsv_features = self.extract_hsv_features(img)
         # L2正規化（既に正規化されているが、安全のため再正規化）
-        hsv_normalized = _safe_l2_normalize(hsv_features)
+        hsv_normalized = VectorUtils.safe_l2_normalize(hsv_features)
         # 結合
         return np.concatenate([hsv_normalized, clip_features])
 
@@ -162,7 +147,7 @@ class FeatureExtractor:
                     batch_features = []
                     for j in range(image_features.shape[0]):
                         features = image_features[j].cpu().numpy()
-                        normalized = _safe_l2_normalize(features)
+                        normalized = VectorUtils.safe_l2_normalize(features)
                         batch_features.append(normalized)
 
                 # 結果を元のインデックスにマッピング

--- a/src/analyzers/image_quality_analyzer.py
+++ b/src/analyzers/image_quality_analyzer.py
@@ -18,22 +18,6 @@ from .metric_calculator import MetricCalculator
 logger = logging.getLogger(__name__)
 
 
-def _safe_l2_normalize(vec: np.ndarray, eps: float = 1e-8) -> np.ndarray:
-    """ゼロ割れ安全なL2正規化を行う.
-
-    Args:
-        vec: 正規化するベクトル
-        eps: ゼロ割れ防止用の微小値
-
-    Returns:
-        L2正規化されたベクトル（元のノルムが0の場合はゼロベクトル）
-    """
-    norm = float(np.linalg.norm(vec))
-    if norm < eps:
-        return np.zeros_like(vec)
-    return vec / norm
-
-
 class ImageQualityAnalyzer:
     """画像品質アナライザー（Facadeパターン）.
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,5 +1,6 @@
-"""Utils package for file operations."""
+"""Utils package for file operations and vector utilities."""
 
 from .file_utils import FileUtils
+from .vector_utils import VectorUtils
 
-__all__ = ["FileUtils"]
+__all__ = ["FileUtils", "VectorUtils"]

--- a/src/utils/vector_utils.py
+++ b/src/utils/vector_utils.py
@@ -1,0 +1,23 @@
+"""ベクトル操作ユーティリティ."""
+
+import numpy as np
+
+
+class VectorUtils:
+    """ベクトル操作に関するユーティリティクラス."""
+
+    @staticmethod
+    def safe_l2_normalize(vec: np.ndarray, eps: float = 1e-8) -> np.ndarray:
+        """ゼロ割れ安全なL2正規化を行う.
+
+        Args:
+            vec: 正規化するベクトル
+            eps: ゼロ割れ防止用の微小値
+
+        Returns:
+            L2正規化されたベクトル（元のノルムが0の場合はゼロベクトル）
+        """
+        norm = float(np.linalg.norm(vec))
+        if norm < eps:
+            return np.zeros_like(vec)
+        return vec / norm

--- a/tests/analyzers/test_feature_extractor.py
+++ b/tests/analyzers/test_feature_extractor.py
@@ -20,10 +20,8 @@ import torch
 from PIL import Image
 
 from src.analyzers.clip_model_manager import CLIPModelManager
-from src.analyzers.feature_extractor import (
-    FeatureExtractor,
-    _safe_l2_normalize,
-)
+from src.analyzers.feature_extractor import FeatureExtractor
+from src.utils import VectorUtils
 
 
 @pytest.fixture(autouse=True)
@@ -119,50 +117,6 @@ def feature_extractor() -> FeatureExtractor:
     """特徴抽出器のフィクスチャ."""
     model_manager = CLIPModelManager()
     return FeatureExtractor(model_manager)
-
-
-def test_safe_l2_normalize_returns_zeros_for_zero_vector() -> None:
-    """ゼロベクトルが正規化されること.
-
-    Given:
-        - ゼロベクトルがある
-    When:
-        - _safe_l2_normalizeで正規化される
-    Then:
-        - ゼロベクトルが返されること（NaNではない）
-    """
-    # Arrange
-    zero_vec = np.array([0.0, 0.0, 0.0])
-
-    # Act
-    result = _safe_l2_normalize(zero_vec)
-
-    # Assert
-    assert result.shape == zero_vec.shape
-    assert np.all(result == 0.0)
-    assert not np.any(np.isnan(result))
-
-
-def test_safe_l2_normalize_normalizes_nonzero_vector() -> None:
-    """非ゼロベクトルが正しく正規化されること.
-
-    Given:
-        - 非ゼロベクトルがある
-    When:
-        - _safe_l2_normalizeで正規化される
-    Then:
-        - L2ノルムが1になること
-    """
-    # Arrange
-    vec = np.array([3.0, 4.0])  # ノルム = 5
-
-    # Act
-    result = _safe_l2_normalize(vec)
-
-    # Assert
-    expected_norm = 1.0
-    actual_norm = np.linalg.norm(result)
-    assert actual_norm == pytest.approx(expected_norm)
 
 
 def test_extract_hsv_features_returns_correct_shape(
@@ -272,7 +226,7 @@ def test_extract_combined_features_contains_hsv_and_clip(
 
     # Assert
     # HSV特徴は正規化されているはず
-    hsv_normalized = _safe_l2_normalize(hsv_features)
+    hsv_normalized = VectorUtils.safe_l2_normalize(hsv_features)
     actual_hsv = combined_features[:64]
     assert np.allclose(actual_hsv, hsv_normalized, atol=1e-5)
 

--- a/tests/analyzers/test_image_quality_analyzer.py
+++ b/tests/analyzers/test_image_quality_analyzer.py
@@ -17,11 +17,9 @@ import numpy as np
 import pytest
 import torch
 
-from src.analyzers.image_quality_analyzer import (
-    ImageQualityAnalyzer,
-    _safe_l2_normalize,
-)
+from src.analyzers.image_quality_analyzer import ImageQualityAnalyzer
 from src.models.image_metrics import ImageMetrics
+from src.utils import VectorUtils
 
 
 @pytest.fixture(autouse=True)
@@ -566,7 +564,7 @@ def test_analyze_uses_combined_features_for_similarity(
 
     # 個別の特徴を抽出して比較
     expected_hsv = analyzer._extract_hsv_features(img)
-    expected_hsv_normalized = _safe_l2_normalize(expected_hsv)
+    expected_hsv_normalized = VectorUtils.safe_l2_normalize(expected_hsv)
     expected_clip = analyzer._extract_clip_features(pil_img_rgb)
 
     # 結合特徴の前半64次元はHSV特徴（正規化済み）
@@ -576,47 +574,3 @@ def test_analyze_uses_combined_features_for_similarity(
     # 結合特徴の後半512次元はCLIP特徴
     actual_clip = result.features[64:]
     assert np.allclose(actual_clip, expected_clip, atol=1e-5)
-
-
-def test_safe_l2_normalize_returns_zeros_for_zero_vector() -> None:
-    """ゼロベクトルが正規化されること.
-
-    Given:
-        - ゼロベクトルがある
-    When:
-        - _safe_l2_normalizeで正規化される
-    Then:
-        - ゼロベクトルが返されること（NaNではない）
-    """
-    # Arrange
-    zero_vec = np.array([0.0, 0.0, 0.0])
-
-    # Act
-    result = _safe_l2_normalize(zero_vec)
-
-    # Assert
-    assert result.shape == zero_vec.shape
-    assert np.all(result == 0.0)
-    assert not np.any(np.isnan(result))
-
-
-def test_safe_l2_normalize_normalizes_nonzero_vector() -> None:
-    """非ゼロベクトルが正しく正規化されること.
-
-    Given:
-        - 非ゼロベクトルがある
-    When:
-        - _safe_l2_normalizeで正規化される
-    Then:
-        - L2ノルムが1になること
-    """
-    # Arrange
-    vec = np.array([3.0, 4.0])  # ノルム = 5
-
-    # Act
-    result = _safe_l2_normalize(vec)
-
-    # Assert
-    expected_norm = 1.0
-    actual_norm = np.linalg.norm(result)
-    assert actual_norm == pytest.approx(expected_norm)

--- a/tests/test_vector_utils.py
+++ b/tests/test_vector_utils.py
@@ -1,0 +1,71 @@
+"""VectorUtilsクラスの単体テスト."""
+
+import numpy as np
+import pytest
+
+from src.utils import VectorUtils
+
+
+def test_safe_l2_normalize_returns_zeros_for_zero_vector() -> None:
+    """ゼロベクトルが正規化されること.
+
+    Given:
+        - ゼロベクトルがある
+    When:
+        - VectorUtils.safe_l2_normalizeで正規化される
+    Then:
+        - ゼロベクトルが返されること（NaNではない）
+    """
+    # Arrange
+    zero_vec = np.array([0.0, 0.0, 0.0])
+
+    # Act
+    result = VectorUtils.safe_l2_normalize(zero_vec)
+
+    # Assert
+    assert result.shape == zero_vec.shape
+    assert np.all(result == 0.0)
+    assert not np.any(np.isnan(result))
+
+
+def test_safe_l2_normalize_normalizes_nonzero_vector() -> None:
+    """非ゼロベクトルが正しく正規化されること.
+
+    Given:
+        - 非ゼロベクトルがある
+    When:
+        - VectorUtils.safe_l2_normalizeで正規化される
+    Then:
+        - L2ノルムが1になること
+    """
+    # Arrange
+    vec = np.array([3.0, 4.0])  # ノルム = 5
+
+    # Act
+    result = VectorUtils.safe_l2_normalize(vec)
+
+    # Assert
+    expected_norm = 1.0
+    actual_norm = np.linalg.norm(result)
+    assert actual_norm == pytest.approx(expected_norm)
+
+
+def test_safe_l2_normalize_handles_small_vectors() -> None:
+    """微小なベクトルが正しく処理されること.
+
+    Given:
+        - epsよりも小さなノルムを持つベクトルがある
+    When:
+        - VectorUtils.safe_l2_normalizeで正規化される
+    Then:
+        - ゼロベクトルが返されること
+    """
+    # Arrange
+    small_vec = np.array([1e-10, 1e-10, 1e-10])  # ノルム < 1e-8
+
+    # Act
+    result = VectorUtils.safe_l2_normalize(small_vec)
+
+    # Assert
+    assert result.shape == small_vec.shape
+    assert np.all(result == 0.0)


### PR DESCRIPTION
## 概要
`_safe_l2_normalize`関数の重複実装を`VectorUtils`クラスに統合し、メンテナンス性を向上させました。

## 変更内容
### 新規ファイル
- `src/utils/vector_utils.py` - `VectorUtils`クラス（`safe_l2_normalize`静的メソッド）
- `tests/test_vector_utils.py` - `VectorUtils`の単体テスト

### 変更ファイル
- `src/utils/__init__.py` - `VectorUtils`をエクスポート
- `src/analyzers/feature_extractor.py` - `_safe_l2_normalize`の実装を削除し、`VectorUtils.safe_l2_normalize`を使用
- `src/analyzers/image_quality_analyzer.py` - `_safe_l2_normalize`の実装を削除
- `tests/analyzers/test_feature_extractor.py` - 重複テストを削除し、`VectorUtils`を使用
- `tests/analyzers/test_image_quality_analyzer.py` - 重複テストを削除し、`VectorUtils`を使用

## 利点
- 将来の挙動差分リスクを解消（1箇所の実装に統合）
- テストが一本化され、メンテナンス性が向上
- ベクトル操作ユーティリティとして、他の場所でも再利用可能

## テスト
- 全テスト正常通過（120 passed, 1 skipped）