### PR TITLE
refactor: force_cpuの環境変数書き換えをdevice引数で明示的に指定する設計に変更

### DIFF
--- a/src/analyzers/analyzer_pool.py
+++ b/src/analyzers/analyzer_pool.py
@@ -27,13 +27,13 @@ def _init_worker(genre: str = "mixed", force_cpu: bool = False) -> None:
         force_cpu: GPUを無効化してCPUを強制する（複数ワーカーでの競合回避）
     """
     global _analyzer  # noqa: PLW0603
-    # 環境変数でCUDAを無効化（force_cpu=Trueの場合）
-    if force_cpu:
-        os.environ["CUDA_VISIBLE_DEVICES"] = ""
-    _analyzer = ImageQualityAnalyzer(genre=genre)
+    # device引数でCPUを強制（force_cpu=Trueの場合）
+    device = "cpu" if force_cpu else None
+    _analyzer = ImageQualityAnalyzer(genre=genre, device=device)
     pid = os.getpid()
-    device = _analyzer.device
-    logger.info(f"Worker {pid}: ImageQualityAnalyzer initialized (device={device})")
+    logger.info(
+        f"Worker {pid}: ImageQualityAnalyzer initialized (device={_analyzer.device})"
+    )
 
 
 def _analyze_single(path: str) -> Optional[ImageMetrics]:

--- a/src/analyzers/image_quality_analyzer.py
+++ b/src/analyzers/image_quality_analyzer.py
@@ -40,18 +40,26 @@ class ImageQualityAnalyzer:
     複数のコンポーネントを統合し、公開APIを提供する。
     """
 
-    def __init__(self, genre: str = "mixed", config: AnalyzerConfig | None = None):
+    def __init__(
+        self,
+        genre: str = "mixed",
+        config: AnalyzerConfig | None = None,
+        device: str | None = None,
+    ):
         """アナライザーを初期化する.
 
         Args:
             genre: ジャンル（重み付け用）
             config: アナライザー設定（Noneの場合はデフォルト値を使用）
+            device: 使用するデバイス（Noneの場合は自動検出）
         """
         self.config = config or AnalyzerConfig()
         self.weights = GenreWeights.get_weights(genre)
 
         # レイヤー1: モデル管理（プライベート）
-        self._model_manager = CLIPModelManager(target_text="epic game scenery")
+        self._model_manager = CLIPModelManager(
+            target_text="epic game scenery", device=device
+        )
 
         # レイヤー2: 特徴抽出（モデルに依存）
         self.feature_extractor = FeatureExtractor(self._model_manager)


### PR DESCRIPTION
## 概要
`force_cpu` 時の `CUDA_VISIBLE_DEVICES` 環境変数書き換えを削除し、代わりに `device="cpu"` を明示的に渡す設計に変更しました。

## 変更内容
- `ImageQualityAnalyzer.__init__` に `device` パラメータを追加
- `analyzer_pool.py` で環境変数書き換えを削除し、`device` 引数で CPU を指定するように変更

## 改善の効果
- グローバルな環境変数書き換えによる副作用を削除
- 影響範囲がオブジェクト内に留まるため、より安全でテストしやすい設計