### PR TITLE
refactor: セマンティックスコアを純粋なコサイン類似度計算に移行

### DIFF
--- a/src/analyzers/clip_model_manager.py
+++ b/src/analyzers/clip_model_manager.py
@@ -4,6 +4,7 @@ import logging
 from typing import Optional
 
 import torch
+import torch.nn.functional as F
 from transformers import CLIPModel, CLIPProcessor
 
 logger = logging.getLogger(__name__)
@@ -51,7 +52,7 @@ class CLIPModelManager:
         """テキスト埋め込みを事前計算してキャッシュする.
 
         Returns:
-            テキスト埋め込みテンソル（1次元の512要素）
+            L2正規化済みのテキスト埋め込みテンソル（1次元の512要素）
         """
         with torch.inference_mode():
             inputs = self.processor(
@@ -60,7 +61,9 @@ class CLIPModelManager:
                 padding=True,
             ).to(self.device)
             text_features: torch.Tensor = self.model.get_text_features(**inputs)
-            return text_features
+            # L2正規化を適用してコサイン類似度計算を可能にする
+            text_features_normalized = F.normalize(text_features, p=2, dim=-1)
+            return text_features_normalized
 
     def get_image_features(
         self, pil_image: object, batch_mode: bool = False

--- a/src/analyzers/metric_calculator.py
+++ b/src/analyzers/metric_calculator.py
@@ -5,6 +5,7 @@ import logging
 import cv2
 import numpy as np
 import torch
+import torch.nn.functional as F
 
 from ..models.analyzer_config import AnalyzerConfig
 from .metric_normalizer import MetricNormalizer
@@ -86,7 +87,7 @@ class MetricCalculator:
             pil_img: PIL画像（RGB形式）
 
         Returns:
-            セマンティックスコア
+            コサイン類似度ベースのセマンティックスコア（範囲: [-1, 1]）
         """
         with torch.inference_mode():
             inputs = self.model_manager.processor(
@@ -96,10 +97,14 @@ class MetricCalculator:
             ).to(self.model_manager.device)
             image_features = self.model_manager.model.get_image_features(**inputs)
 
-            # キャッシュされたテキスト埋め込みを使用
+            # 画像特徴をL2正規化
+            image_features_normalized = F.normalize(image_features, p=2, dim=-1)
+
+            # キャッシュされたテキスト埋め込み（既にL2正規化済み）との
+            # コサイン類似度を計算
             text_embeddings = self.model_manager.get_text_embeddings()
-            logits = torch.matmul(image_features, text_embeddings.T)
-            return float(logits[0][0]) / 100.0
+            cosine_sim = torch.matmul(image_features_normalized, text_embeddings.T)
+            return float(cosine_sim[0][0])
 
     def calculate_semantic_score_from_features(
         self, clip_features: np.ndarray
@@ -110,7 +115,7 @@ class MetricCalculator:
             clip_features: 正規化済みのCLIP画像特徴（512次元）
 
         Returns:
-            セマンティックスコア
+            コサイン類似度ベースのセマンティックスコア（範囲: [-1, 1]）
         """
         # NumPy配列をtorch.Tensorに変換（float32指定）
         with torch.inference_mode():
@@ -119,10 +124,11 @@ class MetricCalculator:
                 .unsqueeze(0)
                 .to(self.model_manager.device)
             )
-            # キャッシュされたテキスト埋め込みとの類似度を計算
+            # キャッシュされたテキスト埋め込み（既にL2正規化済み）との
+            # コサイン類似度を計算
             text_embeddings = self.model_manager.get_text_embeddings()
-            logits = torch.matmul(image_features, text_embeddings.T)
-            return float(logits[0][0]) / 100.0
+            cosine_sim = torch.matmul(image_features, text_embeddings.T)
+            return float(cosine_sim[0][0])
 
     def calculate_total_score(
         self, raw: dict[str, float], norm: dict[str, float], semantic: float

--- a/src/models/analyzer_config.py
+++ b/src/models/analyzer_config.py
@@ -20,7 +20,7 @@ class AnalyzerConfig:
     chunk_size: int = 128
     brightness_penalty_threshold: float = 40.0
     brightness_penalty_value: float = 0.6
-    semantic_weight: float = 0.2
+    semantic_weight: float = 0.002  # コサイン類似度[-1,1]用に調整（元の0.2から100倍）
     score_multiplier: float = 100.0
 
     def __post_init__(self) -> None:

--- a/tests/analyzers/test_batch_pipeline.py
+++ b/tests/analyzers/test_batch_pipeline.py
@@ -187,7 +187,8 @@ def test_process_batch_returns_correct_metrics_for_multiple_images(
         assert isinstance(result, ImageMetrics)
         assert result.path == path
         assert 0 <= result.total_score <= 100
-        assert 0 <= result.semantic_score <= 1
+        # コサイン類似度の範囲（浮動小数点の丸め誤差を許容）
+        assert -1.0 <= result.semantic_score <= 1.0 + 1e-5
 
 
 def test_process_batch_handles_mixed_valid_and_invalid_images(

--- a/tests/analyzers/test_image_quality_analyzer.py
+++ b/tests/analyzers/test_image_quality_analyzer.py
@@ -211,7 +211,8 @@ def test_analyze_returns_valid_metrics_with_genre_specific_weights(
     assert result.path == sample_image_path
     # スコア値が有効範囲内であることを検証
     assert 0 <= result.total_score <= 100
-    assert 0 <= result.semantic_score <= 1
+    # コサイン類似度の範囲（浮動小数点の丸め誤差を許容）
+    assert -1.0 <= result.semantic_score <= 1.0 + 1e-5
     # 正規化されたメトリックが存在することを検証
     assert len(result.normalized_metrics) > 0
 
@@ -353,7 +354,8 @@ def test_analyze_batch_returns_correct_metrics_for_multiple_images(
         assert isinstance(result, ImageMetrics)
         assert result.path == path
         assert 0 <= result.total_score <= 100
-        assert 0 <= result.semantic_score <= 1
+        # コサイン類似度の範囲（浮動小数点の丸め誤差を許容）
+        assert -1.0 <= result.semantic_score <= 1.0 + 1e-5
 
 
 def test_analyze_batch_handles_mixed_valid_and_invalid_images(

--- a/tests/analyzers/test_metric_calculator.py
+++ b/tests/analyzers/test_metric_calculator.py
@@ -206,7 +206,7 @@ def test_calculate_semantic_score_returns_value_in_expected_range(
     When:
         - セマンティックスコアが計算される
     Then:
-        - スコアが有効な範囲（0.0-1.0付近）にあること
+        - スコアがコサイン類似度の範囲（[-1, 1]）にあること
     """
     # Arrange
     with Image.open(sample_image_path) as img:
@@ -218,6 +218,9 @@ def test_calculate_semantic_score_returns_value_in_expected_range(
     # Assert
     assert isinstance(semantic_score, float)
     assert not np.isnan(semantic_score)
+    # 浮動小数点の丸め誤差を許容して境界チェック
+    assert -1.0 <= semantic_score
+    assert semantic_score <= 1.0 + 1e-5  # 丸め誤差を許容
 
 
 def test_calculate_semantic_score_from_features_returns_value_in_expected_range(
@@ -231,7 +234,7 @@ def test_calculate_semantic_score_from_features_returns_value_in_expected_range(
     When:
         - セマンティックスコアが特徴から計算される
     Then:
-        - スコアが有効な範囲にあること
+        - スコアがコサイン類似度の範囲（[-1, 1]）にあること
     """
     # Arrange
     clip_features = np.ones(512) / np.sqrt(512.0)
@@ -244,6 +247,9 @@ def test_calculate_semantic_score_from_features_returns_value_in_expected_range(
     # Assert
     assert isinstance(semantic_score, float)
     assert not np.isnan(semantic_score)
+    # 浮動小数点の丸め誤差を許容して境界チェック
+    assert -1.0 <= semantic_score
+    assert semantic_score <= 1.0 + 1e-5  # 丸め誤差を許容
 
 
 def test_calculate_semantic_score_from_features_returns_similar_result_as_direct(

--- a/tests/models/test_analyzer_config.py
+++ b/tests/models/test_analyzer_config.py
@@ -23,7 +23,7 @@ def test_analyzer_config_has_default_values() -> None:
     assert config.chunk_size == 128
     assert config.brightness_penalty_threshold == 40.0
     assert config.brightness_penalty_value == 0.6
-    assert config.semantic_weight == 0.2
+    assert config.semantic_weight == 0.002  # コサイン類似度用に調整
     assert config.score_multiplier == 100.0
 
 


### PR DESCRIPTION
## 概要

テキスト埋め込みと画像特徴のL2正規化を追加し、÷100というモデル依存のスケーリングを削除して、理論的に正しいコサイン類似度ベースのスコア計算に変更しました。

## 変更内容

- **clip_model_manager.py**: テキスト埋め込みのL2正規化を追加
- **metric_calculator.py**: 
  - 画像特徴のL2正規化を追加
  - ÷100のマジックナンバーを削除
  - 戻り値をコサイン類似度（範囲[-1, 1]）に変更
- **analyzer_config.py**: semantic_weightを0.2→0.002に調整（スケール調整）
- **テスト**: スコア範囲の検証を[-1, 1]に更新

## ベネフィット

- **モデル変更時の安定性**: コサイン類似度は常に[-1, 1]の範囲でモデルに依存しない
- **理論的な正しさ**: 正規化されたベクトル間のコサイン類似度として適切な計算
- **保守性の向上**: モデル固有の÷100というマジックナンバーを削除

## テスト

```
uv run task test
============================= 128 passed in 25.85s =============================
```

すべてのテストがパスしています。