### PR TITLE
refactor: GitHub Actions改善と出力順序の調整

### DIFF
--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -15,17 +15,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: '3.14'
 
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run pytest
         id: pytest

--- a/src/main.py
+++ b/src/main.py
@@ -180,16 +180,16 @@ class Main:
             selected: 選択された画像メトリクスのリスト
             stats: 統計情報
         """
+        print("\n--- 選択された画像一覧 ---")
+        for i, res in enumerate(selected):
+            print(f"[{i + 1}] {Path(res.path).name} (Score: {res.total_score:.2f})")
+
         print("\n--- 統計情報 ---")
         print(f"総ファイル数: {stats.total_files}")
         print(f"解析成功: {stats.analyzed_ok}")
         print(f"解析失敗: {stats.analyzed_fail}")
         print(f"類似度で除外: {stats.rejected_by_similarity}")
         print(f"選択数: {stats.selected_count}")
-
-        print("\n--- 選択された画像一覧 ---")
-        for i, res in enumerate(selected):
-            print(f"[{i + 1}] {Path(res.path).name} (Score: {res.total_score:.2f})")
 
 
 def main() -> None:


### PR DESCRIPTION
## 概要
- GitHub Actionsで公式の`setup-uv`アクションを導入し、キャッシュ機能を有効化
- 統計情報の前に選択された画像一覧を表示するように出力順序を変更

## 変更内容
1. **CI/CD改善** (`.github/workflows/pr-quality-checks.yml`)
   - 手動でのuvインストールを廃止し、公式の`astral-sh/setup-uv@v7`アクションを使用
   - 依存関係キャッシュを有効化 (`enable-cache: true`)
   - `uv sync`に`--locked`フラグを追加してロックファイルの整合性を強化

2. **UI改善** (`src/main.py`)
   - 選択された画像一覧を統計情報の前に移動
   - ユーザーがまずどの画像が選択されたかを確認できるよう改善

## テスト計画
- [ ] CI/CDが正常に動作することを確認
- [ ] ローカルで実行し、出力順序が正しいことを確認