### PR TITLE
refactor: NumPy変換前に画像を縮小して二重リサイズを回避

### DIFF
--- a/src/analyzers/batch_pipeline.py
+++ b/src/analyzers/batch_pipeline.py
@@ -90,8 +90,22 @@ class BatchPipeline:
                     print(f"解析済み: {chunk_start + i}/{len(paths)}")
 
                 try:
-                    # OpenCV形式（BGR）に変換
-                    img = cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
+                    # メトリクス計算用に先に画像を縮小
+                    # （長辺max_dim px、アスペクト比保持）
+                    # フル解像度のままnp.array変換→後で縮小の二重処理を回避
+                    w, h = pil_img.size
+                    max_dim = self.config.max_dim
+                    if max(w, h) > max_dim:
+                        scale = max_dim / max(w, h)
+                        new_w, new_h = int(w * scale), int(h * scale)
+                        # PILのthumbnailを使用してアスペクト比を保持しつつ縮小
+                        pil_img_resized = pil_img.copy()
+                        pil_img_resized.thumbnail(
+                            (new_w, new_h), Image.Resampling.LANCZOS
+                        )
+                        img = cv2.cvtColor(np.array(pil_img_resized), cv2.COLOR_RGB2BGR)
+                    else:
+                        img = cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
 
                     # すべてのメトリクスを一括計算
                     raw, norm, semantic, total = (

--- a/src/analyzers/feature_extractor.py
+++ b/src/analyzers/feature_extractor.py
@@ -32,8 +32,11 @@ class FeatureExtractor:
     def extract_hsv_features(img: np.ndarray) -> np.ndarray:
         """HSV色空間のヒストグラム特徴を抽出する.
 
+        注: 呼出し元（batch_pipeline.py）で既にmax_dim以下に縮小された画像を
+        受け取ることを想定している。
+
         Args:
-            img: OpenCV画像（BGR形式）
+            img: OpenCV画像（BGR形式、既に縮小されている）
 
         Returns:
             正規化されたHSVヒストグラム特徴（64次元）
@@ -70,8 +73,11 @@ class FeatureExtractor:
     ) -> np.ndarray:
         """HSV特徴とCLIP特徴を結合する.
 
+        注: imgは呼出し元（batch_pipeline.py）で既にmax_dim以下に
+        縮小された画像であることを想定している。
+
         Args:
-            img: OpenCV画像（BGR形式）
+            img: OpenCV画像（BGR形式、既に縮小されている）
             clip_features: CLIP画像埋め込み（512次元、正規化済み）
 
         Returns:

--- a/src/analyzers/metric_calculator.py
+++ b/src/analyzers/metric_calculator.py
@@ -42,16 +42,18 @@ class MetricCalculator:
     def calculate_raw_metrics(self, img: np.ndarray) -> dict[str, float]:
         """生の画像メトリクスを計算する.
 
-        メトリクス計算用に画像を長辺max_dim pxに縮小して処理することで、
-        計算コストを削減する。アスペクト比は保持する。
+        注: 呼出し元（batch_pipeline.py）で既にmax_dimまで縮小された画像を
+        受け取ることを想定している。高解像度画像での二重リサイズを回避し、
+        メモリと計算コストを削減する。
 
         Args:
-            img: OpenCV画像（BGR形式）
+            img: OpenCV画像（BGR形式、既にmax_dim以下に縮小されている）
 
         Returns:
             生メトリクスの辞書
         """
-        # メトリクス計算用に画像を縮小（長辺max_dim px、アスペクト比保持）
+        # 念のため、画像サイズがmax_dimを超えている場合のみ縮小
+        # （通常はbatch_pipeline側で既に縮小済みのためスキップされる）
         h, w = img.shape[:2]
         if max(h, w) > self.config.max_dim:
             scale = self.config.max_dim / max(h, w)


### PR DESCRIPTION
## 概要
高解像度画像でのメモリ使用量と計算コストを削減するため、NumPy変換前に画像を縮小するように変更しました。

## 変更内容
- **batch_pipeline.py**: `np.array(pil_img)` の前に、長辺が `max_dim` を超える場合に事前に縮小
  - PILの `thumbnail()` メソッドを使用してアスペクト比を保持
  - 縮小済みの画像を raw metric と HSV特徴 で共用
- **metric_calculator.py**: 呼び出し元で既に縮小された画像を受け取ることをコメントに明記
- **feature_extractor.py**: 同様にコメントを更新

## 効果
- 修正前: フル解像度で NumPy 化 → calculate_raw_metrics() で縮小 → extract_hsv_features() で再度縮小
- 修正後: 事前に縮小 → NumPy 化 → 各メソッドで共用（2回目の縮小はスキップ）
- 高解像度画像が多い場合、メモリと計算コストの削減効果が大きい

## テスト
- `uv run task test` で全131件のテストが通過済み