### PR TITLE
refactor: CLIP後処理を画像ごとからバッチごとの処理に変更

### DIFF
--- a/src/analyzers/batch_pipeline.py
+++ b/src/analyzers/batch_pipeline.py
@@ -78,9 +78,14 @@ class BatchPipeline:
                 pil_images, initial_batch_size=batch_size
             )
 
-            # ステージ3: チャンク単位で結果を構築
-            for i, (path, pil_img, clip_features) in enumerate(
-                zip(chunk_paths, pil_images, clip_features_list)
+            # ステージ3: セマンティックスコアをバッチ計算
+            semantic_scores = self.metric_calculator.calculate_semantic_score_batch(
+                clip_features_list
+            )
+
+            # ステージ4: チャンク単位で結果を構築
+            for i, (path, pil_img, clip_features, semantic) in enumerate(
+                zip(chunk_paths, pil_images, clip_features_list, semantic_scores)
             ):
                 if pil_img is None or clip_features is None:
                     results.append(None)
@@ -93,13 +98,24 @@ class BatchPipeline:
                     # OpenCV形式（BGR）に変換
                     img = cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
 
-                    # すべてのメトリクスを一括計算
-                    raw, norm, semantic, total = (
-                        self.metric_calculator.calculate_all_metrics(
-                            img,
-                            clip_features,
-                        )
+                    # すべてのメトリクスを一括計算（セマンティックスコアは除外）
+                    raw, norm, _, total = self.metric_calculator.calculate_all_metrics(
+                        img,
+                        clip_features,
                     )
+                    # バッチ計算したセマンティックスコアを使用
+                    if semantic is not None:
+                        total = self.metric_calculator.calculate_total_score(
+                            raw, norm, semantic
+                        )
+                    else:
+                        # semanticがNoneの場合はcalculate_all_metricsの結果を使用
+                        _, _, semantic, total = (
+                            self.metric_calculator.calculate_all_metrics(
+                                img,
+                                clip_features,
+                            )
+                        )
 
                     # HSV特徴とCLIP特徴を結合
                     features = self.feature_extractor.extract_combined_features(

--- a/src/analyzers/feature_extractor.py
+++ b/src/analyzers/feature_extractor.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 
 import cv2
 import numpy as np
+import torch.nn.functional as F
 from PIL import Image
 
 from ..utils.vector_utils import VectorUtils
@@ -147,12 +148,10 @@ class FeatureExtractor:
                         **inputs
                     )
 
-                    # L2正規化してNumPy配列に変換
-                    batch_features = []
-                    for j in range(image_features.shape[0]):
-                        features = image_features[j].cpu().numpy()
-                        normalized = VectorUtils.safe_l2_normalize(features)
-                        batch_features.append(normalized)
+                    # バッチ単位でL2正規化（テンソルのまま処理して高速化）
+                    batch_features_normalized = F.normalize(image_features, p=2, dim=-1)
+                    # まとめてCPUに転送してNumPy配列に変換
+                    batch_features = batch_features_normalized.cpu().numpy()
 
                 # 結果を元のインデックスにマッピング
                 for j, features in enumerate(batch_features):

--- a/src/analyzers/metric_calculator.py
+++ b/src/analyzers/metric_calculator.py
@@ -131,6 +131,61 @@ class MetricCalculator:
             cosine_sim = torch.matmul(image_features, text_embeddings.T)
             return float(cosine_sim[0][0])
 
+    def calculate_semantic_score_batch(
+        self, clip_features_list: list[np.ndarray | None]
+    ) -> list[float | None]:
+        """複数のCLIP特徴からセマンティックスコアをバッチ計算する.
+
+        画像ごとにCPU/NumPy ↔ Torch 変換を行うのではなく、
+        まとめてテンソルに変換して一括計算することで高速化する。
+
+        Args:
+            clip_features_list: 正規化済みのCLIP画像特徴のリスト
+                                （512次元、Noneを含む場合あり）
+
+        Returns:
+            セマンティックスコアのリスト（範囲: [-1, 1]、失敗した要素はNone）
+        """
+        # 有効な特徴のインデックスと特徴を収集
+        valid_indices = [
+            i for i, features in enumerate(clip_features_list) if features is not None
+        ]
+        valid_features = [
+            clip_features_list[i]
+            for i in valid_indices
+            if clip_features_list[i] is not None
+        ]
+
+        if not valid_features:
+            return [None] * len(clip_features_list)
+
+        # 結果を格納する配列（初期値はNone）
+        results: list[float | None] = [None] * len(clip_features_list)
+
+        with torch.inference_mode():
+            # valid_featuresの要素はすべてnp.ndarrayであることが保証されている
+            # （valid_indicesでNoneを除外済み）
+            valid_features_array: list[np.ndarray] = [
+                f for f in valid_features if f is not None
+            ]
+            # まとめてテンソルに変換してデバイスに転送
+            batch_features = torch.from_numpy(
+                np.stack([f.astype(np.float32) for f in valid_features_array])
+            ).to(self.model_manager.device)
+            # 入力は既にL2正規化済みであるため、再正規化は行わない
+            # （calculate_semantic_score_from_featuresの動作と整合性を保つため）
+
+            # キャッシュされたテキスト埋め込み（既にL2正規化済み）との
+            # コサイン類似度を一括計算
+            text_embeddings = self.model_manager.get_text_embeddings()
+            cosine_sims = torch.matmul(batch_features, text_embeddings.T)
+
+            # 結果を元のインデックスにマッピング
+            for j, idx in enumerate(valid_indices):
+                results[idx] = float(cosine_sims[j][0])
+
+        return results
+
     def calculate_total_score(
         self, raw: dict[str, float], norm: dict[str, float], semantic: float
     ) -> float:

--- a/tests/analyzers/test_metric_calculator.py
+++ b/tests/analyzers/test_metric_calculator.py
@@ -418,3 +418,152 @@ def test_calculate_total_score_with_zero_semantic_weight(
     assert total_score >= 0.0
     # セマンティック重みが0でもスコアが計算されている
     assert total_score > 0
+
+
+def test_calculate_semantic_score_batch_returns_correct_count(
+    metric_calculator: MetricCalculator,
+) -> None:
+    """バッチ計算で正しい数の結果が返されること.
+
+    Given:
+        - メトリクス計算器がある
+        - 複数の正規化済みCLIP特徴がある
+    When:
+        - セマンティックスコアがバッチ計算される
+    Then:
+        - 入力数と同じ数の結果が返されること
+        - 各スコアが期待される範囲にあること
+    """
+    # Arrange
+    # 正規化済みのランダムベクトルを作成
+    vec = np.random.randn(512).astype(np.float32)
+    vec /= np.linalg.norm(vec)
+
+    clip_features_list = [
+        np.ones(512) / np.sqrt(512.0),
+        vec,
+        np.ones(512) / np.sqrt(512.0),
+    ]
+
+    # Act
+    scores = metric_calculator.calculate_semantic_score_batch(clip_features_list)
+
+    # Assert
+    assert len(scores) == 3
+    for score in scores:
+        assert isinstance(score, float)
+        assert not np.isnan(score)
+        assert -1.0 <= score
+        assert score <= 1.0 + 1e-5
+
+
+def test_calculate_semantic_score_batch_handles_none_features(
+    metric_calculator: MetricCalculator,
+) -> None:
+    """バッチ計算でNone特徴が正しく処理されること.
+
+    Given:
+        - メトリクス計算器がある
+        - 有効な特徴とNoneが混在している
+    When:
+        - セマンティックスコアがバッチ計算される
+    Then:
+        - 有効な特徴にはスコアが返されること
+        - None特徴にはNoneが返されること
+    """
+    # Arrange
+    clip_features_list = [
+        np.ones(512) / np.sqrt(512.0),
+        None,
+        np.ones(512) / np.sqrt(512.0),
+    ]
+
+    # Act
+    scores = metric_calculator.calculate_semantic_score_batch(clip_features_list)
+
+    # Assert
+    assert len(scores) == 3
+    assert scores[0] is not None
+    assert isinstance(scores[0], float)
+    assert scores[1] is None
+    assert scores[2] is not None
+    assert isinstance(scores[2], float)
+
+
+def test_calculate_semantic_score_batch_returns_similar_results_as_single(
+    metric_calculator: MetricCalculator,
+) -> None:
+    """バッチ計算の結果が単一計算の結果と一致すること.
+
+    Given:
+        - メトリクス計算器がある
+        - 複数のCLIP特徴がある
+    When:
+        - セマンティックスコアが両方の方法で計算される
+    Then:
+        - バッチ計算と単一計算の結果が一致すること
+    """
+    # Arrange
+    clip_features_list = [
+        np.ones(512) / np.sqrt(512.0),
+        np.random.randn(512).astype(np.float32),
+    ]
+
+    # Act
+    batch_scores = metric_calculator.calculate_semantic_score_batch(clip_features_list)
+    single_scores = [
+        metric_calculator.calculate_semantic_score_from_features(f)
+        for f in clip_features_list
+    ]
+
+    # Assert
+    assert len(batch_scores) == len(single_scores)
+    for batch_score, single_score in zip(batch_scores, single_scores):
+        assert batch_score == pytest.approx(single_score)
+
+
+def test_calculate_semantic_score_batch_returns_empty_list_for_empty_input(
+    metric_calculator: MetricCalculator,
+) -> None:
+    """空入力に対して空リストが返されること.
+
+    Given:
+        - メトリクス計算器がある
+        - 空のリストが入力される
+    When:
+        - セマンティックスコアがバッチ計算される
+    Then:
+        - 空のリストが返されること
+    """
+    # Arrange
+    clip_features_list: list[np.ndarray | None] = []
+
+    # Act
+    scores = metric_calculator.calculate_semantic_score_batch(clip_features_list)
+
+    # Assert
+    assert scores == []
+
+
+def test_calculate_semantic_score_batch_handles_all_none_features(
+    metric_calculator: MetricCalculator,
+) -> None:
+    """すべてNone特徴の入力に対してすべてNoneが返されること.
+
+    Given:
+        - メトリクス計算器がある
+        - すべてNoneのリストが入力される
+    When:
+        - セマンティックスコアがバッチ計算される
+    Then:
+        - すべてNoneのリストが返されること
+    """
+    # Arrange
+    clip_features_list: list[np.ndarray | None] = [None, None, None]
+
+    # Act
+    scores = metric_calculator.calculate_semantic_score_batch(clip_features_list)
+
+    # Assert
+    assert len(scores) == 3
+    assert all(s is None for s in scores)


### PR DESCRIPTION
## 概要
CLIP後処理を「画像ごと」から「バッチごと」に変更し、CPU/NumPy ↔ Torch 変換のオーバーヘッドを削減して高速化しました。

## 変更内容

### `feature_extractor.py`
- **`extract_clip_features_batch`**: 画像ごとのループ処理（CPU転送→NumPy変換→正規化）を削除
- `F.normalize`でテンソルのまま一括L2正規化後、まとめてCPU転送・NumPy変換

### `metric_calculator.py`
- **新規 `calculate_semantic_score_batch`**: 複数のCLIP特徴からセマンティックスコアを一括計算
- `np.stack` + `torch.from_numpy`でまとめてテンソル変換
- `torch.matmul`で一括コサイン類似度計算

### `batch_pipeline.py`
- バッチ計算したセマンティックスコアを活用するように変更
- ステージ3: セマンティックスコアをバッチ計算
- ステージ4: チャンク単位で結果を構築

### `test_metric_calculator.py`
- バッチ計算メソッドのテスト5件を追加

## テスト
- すべて136件のテストが通過