### PR TITLE
refactor: チャンクサイズ固定値をメモリ予算ベースの動的分割に変更

### DIFF
--- a/src/analyzers/batch_pipeline.py
+++ b/src/analyzers/batch_pipeline.py
@@ -1,6 +1,7 @@
 """バッチ処理パイプライン - 複数画像のバッチ処理をオーケストレーションする."""
 
 import logging
+import os
 from concurrent.futures import ThreadPoolExecutor
 from typing import List, Optional
 
@@ -53,6 +54,7 @@ class BatchPipeline:
         2. CLIPステージはバッチで直列
 
         メモリ効率化のためチャンク単位でストリーミング処理:
+        - メモリ予算に基づいて動的にチャンクサイズを決定
         - チャンク単位で「前処理→CLIP→結果確定→解放」を実行
         - 大規模画像時のスワップ回避で速度安定化
 
@@ -66,8 +68,14 @@ class BatchPipeline:
         """
         results: List[Optional[ImageMetrics]] = []
 
-        for chunk_start in range(0, len(paths), self.config.chunk_size):
-            chunk_end = min(chunk_start + self.config.chunk_size, len(paths))
+        # メモリ予算に基づいてチャンク境界を計算
+        chunk_boundaries = self._compute_chunk_boundaries(
+            paths,
+            self.config.max_memory_mb,
+            self.config.min_chunk_size,
+        )
+
+        for chunk_start, chunk_end in chunk_boundaries:
             chunk_paths = paths[chunk_start:chunk_end]
 
             # ステージ1: チャンク単位でI/O + 前処理を並列実行
@@ -120,6 +128,67 @@ class BatchPipeline:
             del pil_images, clip_features_list
 
         return results
+
+    @staticmethod
+    def _compute_chunk_boundaries(
+        paths: List[str], max_memory_mb: int, min_chunk_size: int
+    ) -> List[tuple[int, int]]:
+        """メモリ予算に基づいてチャンク境界を計算する.
+
+        各画像のファイルサイズを取得し、指定されたメモリ予算を超えない
+        ように動的にチャンクを分割する。
+
+        Args:
+            paths: 画像ファイルパスのリスト
+            max_memory_mb: チャンクあたりの最大メモリ予算（MB）
+            min_chunk_size: 最低限確保するチャンクサイズ
+
+        Returns:
+            (start_index, end_index) のタプルリスト
+        """
+        max_memory_bytes = max_memory_mb * 1024 * 1024
+        chunks = []
+        current_start = 0
+        current_memory = 0
+        current_count = 0
+
+        for i, path in enumerate(paths):
+            # ファイルサイズを取得（存在しない場合は0とする）
+            try:
+                file_size = os.path.getsize(path)
+                # 推定メモリ使用量はファイルサイズの約2倍（デコード後）とする
+                estimated_memory = file_size * 2
+            except OSError:
+                estimated_memory = 0
+
+            # チャンク追加でメモリ予算を超える場合は新規チャンクを検討
+            would_exceed = current_memory + estimated_memory > max_memory_bytes
+            has_min_images = current_count >= min_chunk_size
+            can_split = i > 0  # 最初の要素で分割しない
+
+            if would_exceed and has_min_images and can_split:
+                # 現在のチャンクを確定
+                chunks.append((current_start, i))
+                current_start = i
+                current_memory = estimated_memory
+                current_count = 1
+            else:
+                # 現在のチャンクに追加
+                current_memory += estimated_memory
+                current_count += 1
+
+        # 最後のチャンクを追加
+        if current_start < len(paths):
+            final_chunk = (current_start, len(paths))
+            # 最後のチャンクがmin_chunk_size未満で、前のチャンクがある場合はマージ
+            if chunks and final_chunk[1] - final_chunk[0] < min_chunk_size:
+                # 前のチャンクとマージ
+                prev_start, _ = chunks.pop()
+                chunks.append((prev_start, final_chunk[1]))
+            else:
+                chunks.append(final_chunk)
+
+        return chunks
 
     @staticmethod
     def load_and_preprocess_images(

--- a/src/models/analyzer_config.py
+++ b/src/models/analyzer_config.py
@@ -9,7 +9,9 @@ class AnalyzerConfig:
 
     Attributes:
         max_dim: メトリクス計算用の画像リサイズ時の長辺の最大ピクセル数
-        chunk_size: バッチ処理時のチャンクサイズ（メモリ使用量を抑える）
+        max_memory_mb: チャンク処理時のメモリ予算（MB）。画像サイズ合計が
+            この値を超えないように動的チャンク分割
+        min_chunk_size: メモリ予算が大きい場合でも最低限確保するチャンクサイズ
         brightness_penalty_threshold: 輝度ペナルティを適用する輝度の境界値
         brightness_penalty_value: 輝度ペナルティの値
         semantic_weight: 総合スコア計算時のセマンティックスコアの重み
@@ -17,7 +19,8 @@ class AnalyzerConfig:
     """
 
     max_dim: int = 720
-    chunk_size: int = 128
+    max_memory_mb: int = 512  # 約512MBのメモリ予算で動的チャンク
+    min_chunk_size: int = 16  # 最低16枚は1チャンクで処理
     brightness_penalty_threshold: float = 40.0
     brightness_penalty_value: float = 0.6
     semantic_weight: float = 0.002  # コサイン類似度[-1,1]用に調整（元の0.2から100倍）
@@ -28,8 +31,11 @@ class AnalyzerConfig:
         if self.max_dim <= 0:
             msg = f"max_dimは正の整数である必要があります: {self.max_dim}"
             raise ValueError(msg)
-        if self.chunk_size <= 0:
-            msg = f"chunk_sizeは正の整数である必要があります: {self.chunk_size}"
+        if self.max_memory_mb <= 0:
+            msg = f"max_memory_mbは正の整数である必要があります: {self.max_memory_mb}"
+            raise ValueError(msg)
+        if self.min_chunk_size <= 0:
+            msg = f"min_chunk_sizeは正の整数である必要があります: {self.min_chunk_size}"
             raise ValueError(msg)
         if self.brightness_penalty_threshold < 0:
             msg = (

--- a/tests/analyzers/test_batch_pipeline.py
+++ b/tests/analyzers/test_batch_pipeline.py
@@ -375,3 +375,146 @@ def test_process_batch_with_large_number_of_images(
     assert len(results) == 10
     # 少なくとも1つの画像が処理されている
     assert any(r is not None for r in results)
+
+
+def test_compute_chunk_boundaries_with_small_files(tmp_path: Path) -> None:
+    """小さいファイルの場合、メモリ予算内で最大限の画像を1チャンクに収めること.
+
+    Given:
+        - 小さいテスト画像ファイルが複数ある
+        - メモリ予算が十分に大きい
+    When:
+        - チャンク境界を計算する
+    Then:
+        - すべての画像が1チャンクに含まれること
+    """
+    # Arrange
+    paths = []
+    for i in range(5):
+        np.random.seed(42 + i)
+        # 小さい画像（約23KB）
+        img_array = np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8)
+        img_path = tmp_path / f"small_{i}.jpg"
+        cv2.imwrite(str(img_path), img_array)
+        paths.append(str(img_path))
+
+    # Act - メモリ予算1MB、最低4枚でチャンク分割
+    chunks = BatchPipeline._compute_chunk_boundaries(
+        paths, max_memory_mb=1, min_chunk_size=4
+    )
+
+    # Assert
+    assert len(chunks) == 1  # すべて1チャンク
+    assert chunks[0] == (0, 5)
+
+
+def test_compute_chunk_boundaries_splits_large_files(tmp_path: Path) -> None:
+    """大きいファイルの場合、メモリ予算に従ってチャンク分割されること.
+
+    Given:
+        - 大きいテスト画像ファイルが複数ある
+        - メモリ予算が小さい
+    When:
+        - チャンク境界を計算する
+    Then:
+        - メモリ予算に従って複数チャンクに分割されること
+    """
+    # Arrange
+    paths = []
+    for i in range(6):
+        np.random.seed(42 + i)
+        # 大きい画像（約1.4MB）
+        img_array = np.random.randint(0, 255, (1000, 1000, 3), dtype=np.uint8)
+        img_path = tmp_path / f"large_{i}.jpg"
+        cv2.imwrite(str(img_path), img_array)
+        paths.append(str(img_path))
+
+    # Act - メモリ予算1MB、最低2枚でチャンク分割
+    chunks = BatchPipeline._compute_chunk_boundaries(
+        paths, max_memory_mb=1, min_chunk_size=2
+    )
+
+    # Assert
+    # 1.4MBのファイルが6枚あるので、1MB予備で複数チャンクに分割される
+    assert len(chunks) > 1
+    # すべての画像がカバーされている
+    covered_count = sum(end - start for start, end in chunks)
+    assert covered_count == 6
+
+
+def test_compute_chunk_boundaries_respects_min_chunk_size(tmp_path: Path) -> None:
+    """最低チャンクサイズが尊重されること.
+
+    Given:
+        - 画像ファイルがある
+        - 最低チャンクサイズが設定されている
+    When:
+        - チャンク境界を計算する
+    Then:
+        - 最低チャンクサイズ未満のチャークが作られないこと
+    """
+    # Arrange
+    paths = []
+    for i in range(5):
+        np.random.seed(42 + i)
+        # 大きい画像（約1.4MB）
+        img_array = np.random.randint(0, 255, (1000, 1000, 3), dtype=np.uint8)
+        img_path = tmp_path / f"large_{i}.jpg"
+        cv2.imwrite(str(img_path), img_array)
+        paths.append(str(img_path))
+
+    # Act - メモリ予算1MB、最低3枚でチャンク分割
+    chunks = BatchPipeline._compute_chunk_boundaries(
+        paths, max_memory_mb=1, min_chunk_size=3
+    )
+
+    # Assert
+    for start, end in chunks:
+        chunk_size = end - start
+        assert chunk_size == 0 or chunk_size >= 3  # 最後のチャンクを除いて3枚以上
+
+
+def test_compute_chunk_boundaries_with_empty_list() -> None:
+    """空のリストの場合、空のチャンクリストが返されること.
+
+    Given:
+        - 空のパスリスト
+    When:
+        - チャンク境界を計算する
+    Then:
+        - 空のリストが返されること
+    """
+    # Arrange
+    paths: list[str] = []
+
+    # Act
+    chunks = BatchPipeline._compute_chunk_boundaries(
+        paths, max_memory_mb=512, min_chunk_size=16
+    )
+
+    # Assert
+    assert chunks == []
+
+
+def test_compute_chunk_boundaries_with_nonexistent_files() -> None:
+    """存在しないファイルの場合、0バイトとして扱われチャンク分割されること.
+
+    Given:
+        - 存在しないファイルパスのリスト
+    When:
+        - チャンク境界を計算する
+    Then:
+        - 最低チャンクサイズに基づいて分割されること
+    """
+    # Arrange
+    paths = ["/nonexistent/1.jpg", "/nonexistent/2.jpg", "/nonexistent/3.jpg"]
+
+    # Act - 最低2枚でチャンク分割
+    chunks = BatchPipeline._compute_chunk_boundaries(
+        paths, max_memory_mb=1, min_chunk_size=2
+    )
+
+    # Assert
+    # 存在しないファイルは0バイトとして扱われるため、メモリ予算を超えない
+    # 最低チャンクサイズに従って分割
+    assert len(chunks) >= 1

--- a/tests/models/test_analyzer_config.py
+++ b/tests/models/test_analyzer_config.py
@@ -20,7 +20,8 @@ def test_analyzer_config_has_default_values() -> None:
 
     # Assert
     assert config.max_dim == 720
-    assert config.chunk_size == 128
+    assert config.max_memory_mb == 512
+    assert config.min_chunk_size == 16
     assert config.brightness_penalty_threshold == 40.0
     assert config.brightness_penalty_value == 0.6
     assert config.semantic_weight == 0.002  # コサイン類似度用に調整
@@ -39,7 +40,8 @@ def test_analyzer_config_can_be_customized() -> None:
     """
     # Arrange
     custom_max_dim = 1080
-    custom_chunk_size = 256
+    custom_max_memory_mb = 256
+    custom_min_chunk_size = 8
     custom_brightness_threshold = 30.0
     custom_penalty_value = 0.8
     custom_semantic_weight = 0.3
@@ -48,7 +50,8 @@ def test_analyzer_config_can_be_customized() -> None:
     # Act
     config = AnalyzerConfig(
         max_dim=custom_max_dim,
-        chunk_size=custom_chunk_size,
+        max_memory_mb=custom_max_memory_mb,
+        min_chunk_size=custom_min_chunk_size,
         brightness_penalty_threshold=custom_brightness_threshold,
         brightness_penalty_value=custom_penalty_value,
         semantic_weight=custom_semantic_weight,
@@ -57,7 +60,8 @@ def test_analyzer_config_can_be_customized() -> None:
 
     # Assert
     assert config.max_dim == custom_max_dim
-    assert config.chunk_size == custom_chunk_size
+    assert config.max_memory_mb == custom_max_memory_mb
+    assert config.min_chunk_size == custom_min_chunk_size
     assert config.brightness_penalty_threshold == custom_brightness_threshold
     assert config.brightness_penalty_value == custom_penalty_value
     assert config.semantic_weight == custom_semantic_weight
@@ -69,8 +73,10 @@ def test_analyzer_config_can_be_customized() -> None:
     [
         ("max_dim", 0),
         ("max_dim", -100),
-        ("chunk_size", 0),
-        ("chunk_size", -50),
+        ("max_memory_mb", 0),
+        ("max_memory_mb", -100),
+        ("min_chunk_size", 0),
+        ("min_chunk_size", -10),
         ("brightness_penalty_threshold", -1.0),
         ("brightness_penalty_value", -0.1),
         ("semantic_weight", -0.1),


### PR DESCRIPTION
## 概要
- `AnalyzerConfig` の `chunk_size` (固定値128) を廃止
- `max_memory_mb` (デフォルト512MB) と `min_chunk_size` (デフォルト16) を追加
- `BatchPipeline._compute_chunk_boundaries()` メソッドを追加し、画像ファイルサイズに基づいてメモリ予算内で動的にチャンク分割するように変更

## 変更理由
画像が大きいと1チャンクで保持するメモリが急増し、スワップで急激に遅くなる問題があった。画像サイズ合計が一定MBを超えないように動的チャンクにすることで、画像枚数が増えても速度の落ち方が緩和される。

## テスト計画
- [x] 既存テストがパスすること
- [x] `compute_chunk_boundaries` のユニットテストを追加