### PR TITLE
refactor: バッチ処理でのsemantic二重計算を回避して計算経路を分離

### DIFF
--- a/src/analyzers/batch_pipeline.py
+++ b/src/analyzers/batch_pipeline.py
@@ -95,7 +95,7 @@ class BatchPipeline:
             for i, (path, pil_img, clip_features, semantic) in enumerate(
                 zip(chunk_paths, pil_images, clip_features_list, semantic_scores)
             ):
-                if pil_img is None or clip_features is None:
+                if pil_img is None or clip_features is None or semantic is None:
                     results.append(None)
                     continue
 
@@ -120,24 +120,13 @@ class BatchPipeline:
                     else:
                         img = cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
 
-                    # すべてのメトリクスを一括計算（セマンティックスコアは除外）
-                    raw, norm, _, total = self.metric_calculator.calculate_all_metrics(
-                        img,
-                        clip_features,
+                    # 生メトリクスと正規化メトリクスのみ計算
+                    # （セマンティックスコアはバッチ計算済みの値を使用）
+                    raw, norm = self.metric_calculator.calculate_raw_norm_metrics(img)
+                    # バッチ計算したセマンティックスコアを使用して総合スコアを計算
+                    total = self.metric_calculator.calculate_total_score(
+                        raw, norm, semantic
                     )
-                    # バッチ計算したセマンティックスコアを使用
-                    if semantic is not None:
-                        total = self.metric_calculator.calculate_total_score(
-                            raw, norm, semantic
-                        )
-                    else:
-                        # semanticがNoneの場合はcalculate_all_metricsの結果を使用
-                        _, _, semantic, total = (
-                            self.metric_calculator.calculate_all_metrics(
-                                img,
-                                clip_features,
-                            )
-                        )
 
                     # HSV特徴とCLIP特徴を結合
                     features = self.feature_extractor.extract_combined_features(

--- a/src/analyzers/metric_calculator.py
+++ b/src/analyzers/metric_calculator.py
@@ -215,6 +215,24 @@ class MetricCalculator:
             * self.config.score_multiplier,
         )
 
+    def calculate_raw_norm_metrics(
+        self, img: np.ndarray
+    ) -> tuple[dict[str, float], dict[str, float]]:
+        """生メトリクスと正規化メトリクスのみ計算する.
+
+        セマンティックスコアはバッチ計算済みの値を使用するため、
+        このメソッドでは計算しない。
+
+        Args:
+            img: OpenCV画像（BGR形式）
+
+        Returns:
+            (生メトリクス, 正規化メトリクス)のタプル
+        """
+        raw = self.calculate_raw_metrics(img)
+        norm = MetricNormalizer.normalize_all(raw)
+        return raw, norm
+
     def calculate_all_metrics(
         self, img: np.ndarray, clip_features: np.ndarray
     ) -> tuple[dict[str, float], dict[str, float], float, float]:


### PR DESCRIPTION
## 概要
- MetricCalculatorに`calculate_raw_norm_metrics`メソッドを追加し、生メトリクスと正規化メトリクスのみを計算する経路を新設
- BatchPipelineでバッチ計算済みのsemanticスコアを使用してtotalを計算するように変更

## 変更内容
- **src/analyzers/metric_calculator.py**: `calculate_raw_norm_metrics`メソッド（raw+normのみ計算）を追加
- **src/analyzers/batch_pipeline.py**: `calculate_all_metrics`の代わりに`calculate_raw_norm_metrics`を使用し、バッチ計算済みのsemanticでtotalを計算

## 効果
- 単画像でのsemantic再計算を回避し、バッチ化の恩恵が得られるように改善