### PR TITLE
fix: バッチ処理でのCLIP推論時のdtype不一致エラーを修正

### DIFF
--- a/src/analyzers/metric_calculator.py
+++ b/src/analyzers/metric_calculator.py
@@ -201,7 +201,11 @@ class MetricCalculator:
             # キャッシュされたテキスト埋め込み（既にL2正規化済み）との
             # コサイン類似度を一括計算
             text_embeddings = self.model_manager.get_text_embeddings()
-            cosine_sims = torch.matmul(batch_features, text_embeddings.T)
+            # batch_features は autocast により float16 になる可能性があるため
+            # text_embeddings を同じ dtype にキャストして型不一致を回避
+            target_dtype = batch_features.dtype
+            casted_embeddings = text_embeddings.to(target_dtype).T
+            cosine_sims = torch.matmul(batch_features, casted_embeddings)
 
             # 結果を元のインデックスにマッピング
             for j, idx in enumerate(valid_indices):


### PR DESCRIPTION
## 概要

バッチ処理での CLIP 推論時に発生していた PyTorch dtype 不一致エラーを修正しました。

## 問題

```
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: c10::Half != float
```

- `extract_clip_features_batch` で `torch.autocast(dtype=torch.float16)` が使用されており、画像特徴 (`batch_features`) が `float16` 型になる
- `_precompute_text_embeddings` では autocast が使用されておらず、テキスト特徴 (`text_embeddings`) が `float32` 型のまま
- 行列積計算時に dtype 不一致でエラー発生

## 修正内容

`src/analyzers/metric_calculator.py` の `calculate_semantic_score_batch` メソッドで、行列計算前に `text_embeddings` を `batch_features` と同じ dtype にキャストするように修正。

```python
target_dtype = batch_features.dtype
casted_embeddings = text_embeddings.to(target_dtype).T
cosine_sims = torch.matmul(batch_features, casted_embeddings)
```

## 検証

- `uv run task test` で全テストがパスすることを確認