### PR TITLE
refactor: CacheEntry.semantic_scoreを必須化してキャッシュスキーマ管理を簡素化

### DIFF
--- a/src/analyzers/batch_pipeline.py
+++ b/src/analyzers/batch_pipeline.py
@@ -111,18 +111,16 @@ class BatchPipeline:
         if keys_to_lookup:
             cache_results = self.cache.get_many(keys_to_lookup)
 
-            # 結果をマッピング
+            # 結果をマッピング（タプルを直接使用して文字列化を回避）
             for idx, cache_key, path in cache_keys_with_meta:
-                key_id = str(
-                    (
-                        cache_key["absolute_path"],
-                        cache_key["file_size"],
-                        cache_key["mtime_ns"],
-                        cache_key["model_name"],
-                        cache_key["target_text"],
-                        cache_key["max_dim"],
-                        cache_key["metrics_version"],
-                    )
+                key_id = (
+                    cache_key["absolute_path"],
+                    cache_key["file_size"],
+                    cache_key["mtime_ns"],
+                    cache_key["model_name"],
+                    cache_key["target_text"],
+                    cache_key["max_dim"],
+                    cache_key["metrics_version"],
                 )
                 entry = cache_results.get(key_id)
                 if entry is not None:
@@ -137,26 +135,11 @@ class BatchPipeline:
         if not cached_indices:
             return [None] * len(paths), uncached_indices
 
-        # 第2パス: セマンティックスコアをバッチ計算
-        clip_features_list: list[torch.Tensor | None] = []
-        for idx in cached_indices:
-            entry_info = cast(CacheEntryInfo, cached_entries[idx])
-            # NumPy配列をtorch.Tensorに変換（CPU上に配置）
-            # calculate_semantic_score_batch内でデバイス移動が行われる
-            clip_tensor = torch.from_numpy(
-                entry_info.entry.clip_features.astype(np.float32)
-            )
-            clip_features_list.append(clip_tensor)
-
-        semantic_scores = self.metric_calculator.calculate_semantic_score_batch(
-            clip_features_list
-        )
-
-        # 第3パス: ImageMetricsを構築
+        # 第2パス: ImageMetricsを構築（キャッシュヒット時）
         cached_results: List[Optional[ImageMetrics]] = [None] * len(paths)
         for i, idx in enumerate(cached_indices):
             entry_info = cast(CacheEntryInfo, cached_entries[idx])
-            semantic = cast(float, semantic_scores[i])
+            semantic = entry_info.entry.semantic_score
             # CLIP特徴とHSV特徴を結合
             combined_features = np.concatenate(
                 [entry_info.entry.hsv_features, entry_info.entry.clip_features]
@@ -444,6 +427,7 @@ class BatchPipeline:
                         "clip_features": clip_features_np,
                         "raw_metrics": raw,
                         "hsv_features": hsv_features,
+                        "semantic_score": semantic,
                     }
                 except Exception as e:
                     # キャッシュエントリ構築に失敗しても処理は継続
@@ -485,9 +469,9 @@ class BatchPipeline:
             ImageMetricsオブジェクトのリスト（失敗時はNone）
         """
         # 並列処理するタスクを準備
-        # 型エイリアス（行長制限対応）
-        TaskDataType = tuple[str, Image.Image, torch.Tensor, float, int]
-        tasks: list[tuple[int, TaskDataType | None]] = []
+        tasks: list[
+            tuple[int, tuple[str, Image.Image, torch.Tensor, float, int] | None]
+        ] = []
         for i, (path, pil_img, clip_features, semantic) in enumerate(
             zip(
                 chunk_paths,

--- a/src/cache/feature_cache.py
+++ b/src/cache/feature_cache.py
@@ -1,6 +1,7 @@
 """特徴量キャッシュ - 画像解析の中間結果をSQLiteで永続化する."""
 
 import json
+import logging
 import sqlite3
 import threading
 from pathlib import Path
@@ -9,6 +10,8 @@ from typing import Any, Optional
 import numpy as np
 
 from ..models.cache_entry import CacheEntry
+
+logger = logging.getLogger(__name__)
 
 
 class FeatureCache:
@@ -77,44 +80,88 @@ class FeatureCache:
             )
         return self._local.conn
 
+    @staticmethod
+    def _normalize_sql(sql: str) -> str:
+        """SQL文字列を正規化して比較可能にする.
+
+        空白、改行、大文字小文字を正規化し、スキーマ比較を安定させる。
+
+        Args:
+            sql: 正規化するSQL文字列
+
+        Returns:
+            正規化されたSQL文字列
+        """
+        return " ".join(sql.strip().split()).upper()
+
+    def _get_expected_schema_sql(self) -> str:
+        """期待されるテーブル作成SQLを取得.
+
+        Returns:
+            期待されるCREATE TABLE文
+        """
+        return """CREATE TABLE feature_cache (
+            absolute_path TEXT NOT NULL,
+            file_size INTEGER NOT NULL,
+            mtime_ns INTEGER NOT NULL,
+            model_name TEXT NOT NULL,
+            target_text TEXT NOT NULL,
+            max_dim INTEGER NOT NULL,
+            metrics_version TEXT NOT NULL,
+            clip_features BLOB NOT NULL,
+            raw_metrics TEXT NOT NULL,
+            hsv_features BLOB NOT NULL,
+            semantic_score REAL,
+            created_at REAL NOT NULL,
+            PRIMARY KEY (
+                absolute_path, model_name, target_text, max_dim, metrics_version
+            )
+        )"""
+
     def _init_db(self) -> None:
         """データベーススキーマを初期化する.
 
-        必要に応じて既存スキーマから複合主キースキーマへマイグレーションを実行する。
+        スキーマが期待と異なる場合はテーブルをドロップして再作成する。
+        キャッシュデータは破棄されるが、次回実行時に再構築される。
         スレッドセーフのため、クラスロックを使用して初期化を保護する。
         """
         with FeatureCache._init_lock:
-            # ロック内でもう一度テーブル存在チェック（ダブルチェックロック）
             conn = self._get_connection()
             cursor = conn.cursor()
-            cursor.execute(
-                """
-                SELECT name FROM sqlite_master
-                WHERE type='table' AND name='feature_cache'
-                """
-            )
-            if cursor.fetchone() is None:
-                # テーブルが存在しない場合、新しいスキーマで作成
-                self._create_new_schema(cursor)
-                conn.commit()
-                return
 
-            # 既存テーブルのスキーマを確認
+            # テーブルが存在する場合、スキーマを確認
             cursor.execute(
-                """
-                SELECT sql FROM sqlite_master
-                WHERE type='table' AND name='feature_cache'
-                """
+                "SELECT sql FROM sqlite_master "
+                "WHERE type='table' AND name='feature_cache'"
             )
             result = cursor.fetchone()
-            existing_sql = result[0] if result else ""
 
-            # 既存スキーマの主キーを確認（PRIMARY KEYがabsolute_pathのみかチェック）
-            if "absolute_path TEXT PRIMARY KEY" in existing_sql:
-                # マイグレーション必要: 古いスキーマから新しいスキーマへ移行
-                self._migrate_to_composite_key(cursor)
+            if result is not None:
+                # 既存テーブルのスキーマを取得
+                existing_sql = result[0]
+                # スキーマを正規化して比較（空白、改行を正規化）
+                normalized_existing = self._normalize_sql(existing_sql)
+                normalized_expected = self._normalize_sql(
+                    self._get_expected_schema_sql()
+                )
+
+                if normalized_existing != normalized_expected:
+                    # スキーマが異なる場合はドロップして再作成
+                    logger.info(
+                        f"キャッシュスキーマが異なるためテーブルを再作成します: "
+                        f"expected={normalized_expected[:50]}..., "
+                        f"got={normalized_existing[:50]}..."
+                    )
+                    cursor.execute("DROP TABLE feature_cache")
+
+            # テーブル作成（存在しないか、ドロップされた場合）
+            cursor.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='feature_cache'"
+            )
+            if cursor.fetchone() is None:
+                self._create_new_schema(cursor)
                 conn.commit()
-            # 新しいスキーマの場合は何もしない（既に複合主キー）
 
     def _create_new_schema(self, cursor: sqlite3.Cursor) -> None:
         """新しい複合主キースキーマでテーブルを作成する.
@@ -135,6 +182,7 @@ class FeatureCache:
                 clip_features BLOB NOT NULL,
                 raw_metrics TEXT NOT NULL,
                 hsv_features BLOB NOT NULL,
+                semantic_score REAL,
                 created_at REAL NOT NULL,
                 PRIMARY KEY (
                     absolute_path, model_name, target_text, max_dim, metrics_version
@@ -149,52 +197,6 @@ class FeatureCache:
             ON feature_cache(absolute_path, file_size, mtime_ns)
             """
         )
-
-    def _migrate_to_composite_key(self, cursor: sqlite3.Cursor) -> None:
-        """古いスキーマから新しい複合主キースキーマへマイグレーションする.
-
-        手順:
-        1. 既存データをfeature_cache_backupに退避
-        2. 古いテーブルを削除
-        3. 新しいスキーマでテーブル作成
-        4. データを復元（INSERT OR REPLACEで重複処理）
-        5. バックアップテーブルを削除
-
-        Args:
-            cursor: データベースカーソル
-        """
-        import logging
-
-        logger = logging.getLogger(__name__)
-
-        # ステップ1: 既存テーブルをリネーム
-        cursor.execute("ALTER TABLE feature_cache RENAME TO feature_cache_backup")
-
-        # ステップ2: 新しいスキーマでテーブル作成
-        self._create_new_schema(cursor)
-
-        # ステップ3: データを復元
-        cursor.execute(
-            """
-            INSERT OR REPLACE INTO feature_cache (
-                absolute_path, file_size, mtime_ns, model_name, target_text,
-                max_dim, metrics_version, clip_features, raw_metrics,
-                hsv_features, created_at
-            )
-            SELECT
-                absolute_path, file_size, mtime_ns, model_name, target_text,
-                max_dim, metrics_version, clip_features, raw_metrics,
-                hsv_features, created_at
-            FROM feature_cache_backup
-            """
-        )
-
-        # 移行した行数をログ出力
-        migrated_count = cursor.rowcount
-        logger.info(f"キャッシュスキーマをマイグレーションしました: {migrated_count}件")
-
-        # ステップ4: バックアップテーブルを削除
-        cursor.execute("DROP TABLE feature_cache_backup")
 
     def generate_cache_key(
         self,
@@ -241,7 +243,7 @@ class FeatureCache:
         cursor = conn.cursor()
         cursor.execute(
             """
-            SELECT clip_features, raw_metrics, hsv_features
+            SELECT clip_features, raw_metrics, hsv_features, semantic_score
             FROM feature_cache
             WHERE absolute_path = ?
               AND file_size = ?
@@ -269,6 +271,7 @@ class FeatureCache:
             clip_features=np.frombuffer(row["clip_features"], dtype=np.float32),
             raw_metrics=json.loads(row["raw_metrics"]),
             hsv_features=np.frombuffer(row["hsv_features"], dtype=np.float32),
+            semantic_score=row["semantic_score"],
         )
 
     def put(
@@ -277,6 +280,7 @@ class FeatureCache:
         clip_features: np.ndarray,
         raw_metrics: dict[str, float],
         hsv_features: np.ndarray,
+        semantic_score: float,
     ) -> None:
         """特徴量をキャッシュに保存する.
 
@@ -285,6 +289,7 @@ class FeatureCache:
             clip_features: CLIP特徴（512次元）
             raw_metrics: 生メトリクス
             hsv_features: HSV特徴（64次元）
+            semantic_score: セマンティックスコア
         """
         import time
 
@@ -295,8 +300,8 @@ class FeatureCache:
             INSERT OR REPLACE INTO feature_cache (
                 absolute_path, file_size, mtime_ns, model_name, target_text,
                 max_dim, metrics_version, clip_features, raw_metrics,
-                hsv_features, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                hsv_features, semantic_score, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 cache_key["absolute_path"],
@@ -309,6 +314,7 @@ class FeatureCache:
                 clip_features.astype(np.float32).tobytes(),
                 json.dumps(raw_metrics),
                 hsv_features.astype(np.float32).tobytes(),
+                semantic_score,
                 time.time(),
             ),
         )
@@ -316,20 +322,20 @@ class FeatureCache:
 
     def get_many(
         self, cache_keys: list[dict[str, str | int]]
-    ) -> dict[str, Optional[CacheEntry]]:
+    ) -> dict[tuple[Any, ...], Optional[CacheEntry]]:
         """複数のキャッシュキーで特徴量を一括取得する.
 
         パフォーマンス最適化:
         - 単一のINクエリで複数キーを取得
         - SQLiteの複合主キー（7フィールド）を考慮
-        - 結果をキャッシュキーの文字列表現でマッピング
+        - 結果をキャッシュキーのタプルでマッピング（文字列化を回避）
         - TEMP TABLEを再利用してCREATE/DROPオーバーヘッドを削減
 
         Args:
             cache_keys: キャッシュキーのリスト
 
         Returns:
-            キャッシュキーの文字列表現をキー、CacheEntry（ヒットしない場合はNone）を値とする辞書
+            キャッシュキーのタプルをキー、CacheEntry（ヒットしない場合はNone）を値とする辞書
         """
         if not cache_keys:
             return {}
@@ -351,9 +357,9 @@ class FeatureCache:
             for k in cache_keys
         ]
 
-        # 結果を格納する辞書（キーはタプルの文字列表現）
-        results: dict[str, Optional[CacheEntry]] = {
-            str(k_id): None for k_id in key_identifiers
+        # 結果を格納する辞書（キーはタプル、文字列化を回避）
+        results: dict[tuple[Any, ...], Optional[CacheEntry]] = {
+            k_id: None for k_id in key_identifiers
         }
 
         # TEMP TABLEをクリアして再利用（接続時に作成済み）
@@ -380,7 +386,8 @@ class FeatureCache:
                 fc.metrics_version,
                 fc.clip_features,
                 fc.raw_metrics,
-                fc.hsv_features
+                fc.hsv_features,
+                fc.semantic_score
             FROM feature_cache fc
             INNER JOIN temp_lookup tl ON
                 fc.absolute_path = tl.absolute_path AND
@@ -393,23 +400,22 @@ class FeatureCache:
             """
         )
 
-        # 結果をマッピング
+        # 結果をマッピング（タプルを直接使用して文字列化を回避）
         for row in cursor.fetchall():
-            key_id = str(
-                (
-                    row["absolute_path"],
-                    row["file_size"],
-                    row["mtime_ns"],
-                    row["model_name"],
-                    row["target_text"],
-                    row["max_dim"],
-                    row["metrics_version"],
-                )
+            key_id = (
+                row["absolute_path"],
+                row["file_size"],
+                row["mtime_ns"],
+                row["model_name"],
+                row["target_text"],
+                row["max_dim"],
+                row["metrics_version"],
             )
             results[key_id] = CacheEntry(
                 clip_features=np.frombuffer(row["clip_features"], dtype=np.float32),
                 raw_metrics=json.loads(row["raw_metrics"]),
                 hsv_features=np.frombuffer(row["hsv_features"], dtype=np.float32),
+                semantic_score=row["semantic_score"],
             )
 
         return results
@@ -432,6 +438,7 @@ class FeatureCache:
                 - clip_features: CLIP特徴（512次元、np.ndarray）
                 - raw_metrics: 生メトリクス（辞書）
                 - hsv_features: HSV特徴（64次元、np.ndarray）
+                - semantic_score: セマンティックスコア（オプション）
         """
         import time
 
@@ -457,6 +464,7 @@ class FeatureCache:
                         entry["clip_features"].astype(np.float32).tobytes(),
                         json.dumps(entry["raw_metrics"]),
                         entry["hsv_features"].astype(np.float32).tobytes(),
+                        entry.get("semantic_score"),
                         time.time(),
                     )
                 )
@@ -467,8 +475,8 @@ class FeatureCache:
                 INSERT OR REPLACE INTO feature_cache (
                     absolute_path, file_size, mtime_ns, model_name, target_text,
                     max_dim, metrics_version, clip_features, raw_metrics,
-                    hsv_features, created_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    hsv_features, semantic_score, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 insert_data,
             )
@@ -489,9 +497,16 @@ class FeatureCache:
 
     def __exit__(
         self,
-        _exc_type: type[BaseException] | None,
-        _exc_val: BaseException | None,
-        _exc_tb: Any,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
     ) -> None:
-        """コンテキストマネージャーの終了時に接続を閉じる."""
+        """コンテキストマネージャーの終了時に接続を閉じる.
+
+        Args:
+            exc_type: 例外タイプ（使用しない）
+            exc_val: 例外値（使用しない）
+            exc_tb: 例外トレースバック（使用しない）
+        """
+        _ = (exc_type, exc_val, exc_tb)  # 未使用警告を抑制
         self.close()

--- a/src/models/cache_entry.py
+++ b/src/models/cache_entry.py
@@ -13,8 +13,10 @@ class CacheEntry:
         clip_features: CLIP特徴（512次元ベクトル）
         raw_metrics: 生メトリクス（9つの値）
         hsv_features: HSV特徴（64次元ベクトル）
+        semantic_score: セマンティックスコア
     """
 
     clip_features: np.ndarray
     raw_metrics: dict[str, float]
     hsv_features: np.ndarray
+    semantic_score: float

--- a/tests/analyzers/test_batch_pipeline.py
+++ b/tests/analyzers/test_batch_pipeline.py
@@ -135,6 +135,64 @@ def test_cached_results_semantic_score_calculation_is_batched(
         assert -1.0 <= second.semantic_score <= 1.0 + 1e-5
 
 
+def test_cached_results_use_stored_semantic_score(tmp_path: Path) -> None:
+    """キャッシュヒット時に保存されたsemantic_scoreが使用されること.
+
+    Given:
+        - semantic_score付きのエントリがキャッシュに保存されている
+    When:
+        - キャッシュから結果を取得
+    Then:
+        - 保存されたsemantic_scoreが使用されること
+        - 再計算がスキップされること
+    """
+    import numpy as np
+    from src.cache.feature_cache import FeatureCache
+
+    # Arrange: semantic_score付きでキャッシュにエントリを保存
+    cache_path = tmp_path / "test_semantic_cache.sqlite3"
+    cache = FeatureCache(cache_path)
+
+    # テスト用のキャッシュエントリを作成
+    clip_features = np.random.randn(512).astype(np.float32)
+    hsv_features = np.random.randn(64).astype(np.float32)
+    raw_metrics = {"blur_score": 100.0}
+    semantic_score = 0.85
+
+    # テスト画像を作成
+    np.random.seed(42)
+    img_array = np.random.randint(0, 255, (240, 320, 3), dtype=np.uint8)
+    img_path = tmp_path / "semantic_cache_test.jpg"
+    cv2.imwrite(str(img_path), img_array)
+
+    # キャッシュキーを生成して保存
+    file_stat = img_path.stat()
+    cache_key = cache.generate_cache_key(
+        absolute_path=str(img_path.resolve()),
+        file_size=file_stat.st_size,
+        mtime_ns=int(file_stat.st_mtime_ns),
+        model_name="openai/clip-vit-base-patch32",
+        target_text="epic game scenery",
+        max_dim=1280,
+    )
+
+    # semantic_score付きで保存
+    cache.put(
+        cache_key=cache_key,
+        clip_features=clip_features,
+        raw_metrics=raw_metrics,
+        hsv_features=hsv_features,
+        semantic_score=semantic_score,
+    )
+
+    # Act: キャッシュから取得
+    result = cache.get(cache_key)
+
+    # Assert: semantic_scoreが正しく取得できる
+    assert result is not None
+    assert result.semantic_score == semantic_score
+
+
 def test_compute_chunk_boundaries_uses_fast_estimation(tmp_path: Path) -> None:
     """チャンク境界計算で高速なメモリ推定が使用されていること.
 

--- a/tests/cache/test_feature_cache.py
+++ b/tests/cache/test_feature_cache.py
@@ -64,6 +64,7 @@ def test_put_and_get_roundtrip() -> None:
         "visual_balance": 80.0,
         "dramatic_score": 50.0,
     }
+    semantic_score = 0.75
     cache_key: dict[str, str | int] = {
         "absolute_path": "/test/image.jpg",
         "file_size": 1024,
@@ -81,6 +82,7 @@ def test_put_and_get_roundtrip() -> None:
             clip_features=clip_features,
             raw_metrics=raw_metrics,
             hsv_features=hsv_features,
+            semantic_score=semantic_score,
         )
 
         # Act: 取得
@@ -91,6 +93,7 @@ def test_put_and_get_roundtrip() -> None:
         np.testing.assert_array_almost_equal(result.clip_features, clip_features)
         np.testing.assert_array_almost_equal(result.hsv_features, hsv_features)
         assert result.raw_metrics == raw_metrics
+        assert result.semantic_score == semantic_score
 
 
 def test_get_returns_none_for_nonexistent_key() -> None:
@@ -152,6 +155,7 @@ def test_get_returns_none_when_file_size_changed() -> None:
             clip_features=clip_features,
             raw_metrics=raw_metrics,
             hsv_features=hsv_features,
+            semantic_score=0.75,
         )
 
         # Act: file_sizeを変更して取得
@@ -195,6 +199,7 @@ def test_put_replaces_existing_entry() -> None:
             clip_features=original_features,
             raw_metrics=raw_metrics,
             hsv_features=hsv_features,
+            semantic_score=0.5,
         )
 
         # Act: 同じキーで更新
@@ -203,6 +208,7 @@ def test_put_replaces_existing_entry() -> None:
             clip_features=updated_features,
             raw_metrics={"blur_score": 200.0},
             hsv_features=hsv_features,
+            semantic_score=0.8,
         )
 
         # Assert: 更新後のデータが取得できる
@@ -210,6 +216,7 @@ def test_put_replaces_existing_entry() -> None:
         assert result is not None
         np.testing.assert_array_equal(result.clip_features, updated_features)
         assert result.raw_metrics["blur_score"] == 200.0
+        assert result.semantic_score == 0.8
 
 
 def test_persistent_storage() -> None:
@@ -246,6 +253,7 @@ def test_persistent_storage() -> None:
                 clip_features=clip_features,
                 raw_metrics=raw_metrics,
                 hsv_features=hsv_features,
+                semantic_score=0.75,
             )
 
         # Act: 別セッションで取得
@@ -306,6 +314,7 @@ def test_put_batch_saves_multiple_entries() -> None:
         clip_features = np.random.randn(512).astype(np.float32)
         hsv_features = np.random.randn(64).astype(np.float32)
         raw_metrics = {"blur_score": float(i * 10)}
+        semantic_score = 0.1 * i
         cache_key: dict[str, str | int] = {
             "absolute_path": f"/test/batch_image_{i}.jpg",
             "file_size": 1024 + i,
@@ -321,21 +330,31 @@ def test_put_batch_saves_multiple_entries() -> None:
                 "clip_features": clip_features,
                 "raw_metrics": raw_metrics,
                 "hsv_features": hsv_features,
+                "semantic_score": semantic_score,
             }
         )
-        expected_results.append((cache_key, clip_features, hsv_features, raw_metrics))
+        expected_results.append(
+            (cache_key, clip_features, hsv_features, raw_metrics, semantic_score)
+        )
 
     with FeatureCache(None) as cache:
         # Act: バッチ保存
         cache.put_batch(entries)
 
         # Assert: すべてのエントリが取得できる
-        for cache_key, clip_features, hsv_features, raw_metrics in expected_results:
+        for (
+            cache_key,
+            clip_features,
+            hsv_features,
+            raw_metrics,
+            semantic,
+        ) in expected_results:
             result = cache.get(cache_key)
             assert result is not None
             np.testing.assert_array_almost_equal(result.clip_features, clip_features)
             np.testing.assert_array_almost_equal(result.hsv_features, hsv_features)
             assert result.raw_metrics == raw_metrics
+            assert result.semantic_score == semantic
 
 
 def test_composite_key_allows_different_params_for_same_path() -> None:
@@ -391,18 +410,21 @@ def test_composite_key_allows_different_params_for_same_path() -> None:
             clip_features=clip_features1,
             raw_metrics=raw_metrics,
             hsv_features=hsv_features,
+            semantic_score=0.5,
         )
         cache.put(
             cache_key=cache_key2,
             clip_features=clip_features2,
             raw_metrics=raw_metrics,
             hsv_features=hsv_features,
+            semantic_score=0.6,
         )
         cache.put(
             cache_key=cache_key3,
             clip_features=clip_features3,
             raw_metrics=raw_metrics,
             hsv_features=hsv_features,
+            semantic_score=0.7,
         )
 
         # Assert: 各エントリが独立して取得できる
@@ -417,88 +439,6 @@ def test_composite_key_allows_different_params_for_same_path() -> None:
         np.testing.assert_array_equal(result1.clip_features, clip_features1)
         np.testing.assert_array_equal(result2.clip_features, clip_features2)
         np.testing.assert_array_equal(result3.clip_features, clip_features3)
-
-
-def test_migration_from_old_schema_to_composite_key() -> None:
-    """古いスキーマ（absolute_pathのみのPRIMARY KEY）から新しいスキーマへ正しく
-    マイグレーションされること.
-
-    Given:
-        - 古いスキーマで作成されたキャッシュデータベース
-    When:
-        - FeatureCacheを初期化してマイグレーションを実行
-    Then:
-        - 新しいスキーマに変換されること
-        - 既存データが保持されること
-    """
-    import tempfile
-    import sqlite3
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        cache_path = Path(tmpdir) / "old_cache.sqlite3"
-
-        # Arrange: 古いスキーマでテーブルを作成
-        conn = sqlite3.connect(str(cache_path))
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            CREATE TABLE feature_cache (
-                absolute_path TEXT PRIMARY KEY,
-                file_size INTEGER NOT NULL,
-                mtime_ns INTEGER NOT NULL,
-                model_name TEXT NOT NULL,
-                target_text TEXT NOT NULL,
-                max_dim INTEGER NOT NULL,
-                metrics_version TEXT NOT NULL,
-                clip_features BLOB NOT NULL,
-                raw_metrics TEXT NOT NULL,
-                hsv_features BLOB NOT NULL,
-                created_at REAL NOT NULL
-            )
-            """
-        )
-
-        # テストデータを投入
-        import json
-
-        clip_features = np.ones(512, dtype=np.float32) * 0.5
-        hsv_features = np.ones(64, dtype=np.float32) * 0.3
-        raw_metrics = {"blur_score": 100.0}
-
-        cursor.execute(
-            """
-            INSERT INTO feature_cache VALUES (
-                '/old/image.jpg', 1024, 1234567890, 'old_model',
-                'test target', 1280, '1', ?, ?, ?, 1234567890.0
-            )
-            """,
-            (
-                clip_features.astype(np.float32).tobytes(),
-                json.dumps(raw_metrics),
-                hsv_features.astype(np.float32).tobytes(),
-            ),
-        )
-        conn.commit()
-        conn.close()
-
-        # Act: 新しいFeatureCacheを初期化（マイグレーションが実行される）
-        with FeatureCache(cache_path) as cache:
-            # 新しいスキーマでデータが取得できることを確認
-            cache_key = cache.generate_cache_key(
-                absolute_path="/old/image.jpg",
-                file_size=1024,
-                mtime_ns=1234567890,
-                model_name="old_model",
-                target_text="test target",
-                max_dim=1280,
-            )
-            result = cache.get(cache_key)
-
-        # Assert: データが正しくマイグレーションされている
-        assert result is not None
-        np.testing.assert_array_equal(result.clip_features, clip_features)
-        np.testing.assert_array_equal(result.hsv_features, hsv_features)
-        assert result.raw_metrics == raw_metrics
 
 
 def test_get_many_retrieves_multiple_entries() -> None:
@@ -521,6 +461,7 @@ def test_get_many_retrieves_multiple_entries() -> None:
         clip_features = np.random.randn(512).astype(np.float32)
         hsv_features = np.random.randn(64).astype(np.float32)
         raw_metrics = {"blur_score": float(i * 10)}
+        semantic_score = 0.1 * i
         cache_key: dict[str, str | int] = {
             "absolute_path": f"/test/get_many_{i}.jpg",
             "file_size": 1024 + i,
@@ -531,28 +472,29 @@ def test_get_many_retrieves_multiple_entries() -> None:
             "metrics_version": "1",
         }
         cache_keys.append(cache_key)
-        entries.append((cache_key, clip_features, hsv_features, raw_metrics))
+        entries.append(
+            (cache_key, clip_features, hsv_features, raw_metrics, semantic_score)
+        )
         expected_results[
-            str(
-                (
-                    cache_key["absolute_path"],
-                    cache_key["file_size"],
-                    cache_key["mtime_ns"],
-                    cache_key["model_name"],
-                    cache_key["target_text"],
-                    cache_key["max_dim"],
-                    cache_key["metrics_version"],
-                )
+            (
+                cache_key["absolute_path"],
+                cache_key["file_size"],
+                cache_key["mtime_ns"],
+                cache_key["model_name"],
+                cache_key["target_text"],
+                cache_key["max_dim"],
+                cache_key["metrics_version"],
             )
-        ] = (clip_features, hsv_features, raw_metrics)
+        ] = (clip_features, hsv_features, raw_metrics, semantic_score)
 
     with FeatureCache(None) as cache:
-        for cache_key, clip_features, hsv_features, raw_metrics in entries:
+        for cache_key, clip_features, hsv_features, raw_metrics, semantic in entries:
             cache.put(
                 cache_key=cache_key,
                 clip_features=clip_features,
                 raw_metrics=raw_metrics,
                 hsv_features=hsv_features,
+                semantic_score=semantic,
             )
 
         # 存在しないキーも含める
@@ -575,35 +517,37 @@ def test_get_many_retrieves_multiple_entries() -> None:
 
         # 存在するキーが取得できることを確認
         for i in range(3):
-            key_id = str(
-                (
-                    cache_keys[i]["absolute_path"],
-                    cache_keys[i]["file_size"],
-                    cache_keys[i]["mtime_ns"],
-                    cache_keys[i]["model_name"],
-                    cache_keys[i]["target_text"],
-                    cache_keys[i]["max_dim"],
-                    cache_keys[i]["metrics_version"],
-                )
+            key_id = (
+                cache_keys[i]["absolute_path"],
+                cache_keys[i]["file_size"],
+                cache_keys[i]["mtime_ns"],
+                cache_keys[i]["model_name"],
+                cache_keys[i]["target_text"],
+                cache_keys[i]["max_dim"],
+                cache_keys[i]["metrics_version"],
             )
             result = results.get(key_id)
             assert result is not None
-            expected_clip, expected_hsv, expected_raw = expected_results[key_id]
+            (
+                expected_clip,
+                expected_hsv,
+                expected_raw,
+                expected_semantic,
+            ) = expected_results[key_id]
             np.testing.assert_array_almost_equal(result.clip_features, expected_clip)
             np.testing.assert_array_almost_equal(result.hsv_features, expected_hsv)
             assert result.raw_metrics == expected_raw
+            assert result.semantic_score == expected_semantic
 
         # 存在しないキーはNone
-        nonexistent_key_id = str(
-            (
-                nonexistent_key["absolute_path"],
-                nonexistent_key["file_size"],
-                nonexistent_key["mtime_ns"],
-                nonexistent_key["model_name"],
-                nonexistent_key["target_text"],
-                nonexistent_key["max_dim"],
-                nonexistent_key["metrics_version"],
-            )
+        nonexistent_key_id = (
+            nonexistent_key["absolute_path"],
+            nonexistent_key["file_size"],
+            nonexistent_key["mtime_ns"],
+            nonexistent_key["model_name"],
+            nonexistent_key["target_text"],
+            nonexistent_key["max_dim"],
+            nonexistent_key["metrics_version"],
         )
         assert results.get(nonexistent_key_id) is None
 
@@ -701,6 +645,7 @@ def test_get_many_reuses_temp_table() -> None:
         clip_features = np.random.randn(512).astype(np.float32)
         hsv_features = np.random.randn(64).astype(np.float32)
         raw_metrics = {"blur_score": float(i * 10)}
+        semantic_score = 0.1 * i
         cache_key: dict[str, str | int] = {
             "absolute_path": f"/test/reuse_temp_{i}.jpg",
             "file_size": 1024 + i,
@@ -711,15 +656,18 @@ def test_get_many_reuses_temp_table() -> None:
             "metrics_version": "1",
         }
         cache_keys.append(cache_key)
-        entries.append((cache_key, clip_features, hsv_features, raw_metrics))
+        entries.append(
+            (cache_key, clip_features, hsv_features, raw_metrics, semantic_score)
+        )
 
     with FeatureCache(None) as cache:
-        for cache_key, clip_features, hsv_features, raw_metrics in entries:
+        for cache_key, clip_features, hsv_features, raw_metrics, semantic in entries:
             cache.put(
                 cache_key=cache_key,
                 clip_features=clip_features,
                 raw_metrics=raw_metrics,
                 hsv_features=hsv_features,
+                semantic_score=semantic,
             )
 
         # Act: 1回目の呼び出し（TEMP TABLEが作成される）
@@ -764,6 +712,7 @@ def test_put_batch_uses_executemany() -> None:
         clip_features = np.random.randn(512).astype(np.float32)
         hsv_features = np.random.randn(64).astype(np.float32)
         raw_metrics = {"blur_score": float(i)}
+        semantic_score = 0.01 * i
         cache_key: dict[str, str | int] = {
             "absolute_path": f"/test/executemany_{i}.jpg",
             "file_size": 1024 + i,
@@ -779,18 +728,181 @@ def test_put_batch_uses_executemany() -> None:
                 "clip_features": clip_features,
                 "raw_metrics": raw_metrics,
                 "hsv_features": hsv_features,
+                "semantic_score": semantic_score,
             }
         )
-        expected_results.append((cache_key, clip_features, hsv_features, raw_metrics))
+        expected_results.append(
+            (cache_key, clip_features, hsv_features, raw_metrics, semantic_score)
+        )
 
     with FeatureCache(None) as cache:
         # Act: バッチ保存（executemanyで一括挿入）
         cache.put_batch(entries)
 
         # Assert: すべてのエントリが取得できる
-        for cache_key, clip_features, hsv_features, raw_metrics in expected_results:
+        for (
+            cache_key,
+            clip_features,
+            hsv_features,
+            raw_metrics,
+            semantic,
+        ) in expected_results:
             result = cache.get(cache_key)
             assert result is not None
             np.testing.assert_array_almost_equal(result.clip_features, clip_features)
             np.testing.assert_array_almost_equal(result.hsv_features, hsv_features)
             assert result.raw_metrics == raw_metrics
+            assert result.semantic_score == semantic
+
+
+def test_semantic_score_roundtrip() -> None:
+    """semantic_scoreが正しく保存・取得できること.
+
+    Given:
+        - semantic_scoreを含むテストデータを作成
+    When:
+        - キャッシュに保存してから取得
+    Then:
+        - semantic_scoreが正しく取得できること
+    """
+    # Arrange
+    clip_features = np.random.randn(512).astype(np.float32)
+    hsv_features = np.random.randn(64).astype(np.float32)
+    raw_metrics = {"blur_score": 100.0}
+    semantic_score = 0.75
+    cache_key: dict[str, str | int] = {
+        "absolute_path": "/test/semantic.jpg",
+        "file_size": 2048,
+        "mtime_ns": 9876543210,
+        "model_name": "test_model",
+        "target_text": "test target",
+        "max_dim": 1280,
+        "metrics_version": "1",
+    }
+
+    with FeatureCache(None) as cache:
+        # Act: 保存（semantic_scoreを指定）
+        cache.put(
+            cache_key=cache_key,
+            clip_features=clip_features,
+            raw_metrics=raw_metrics,
+            hsv_features=hsv_features,
+            semantic_score=semantic_score,
+        )
+
+        # Act: 取得
+        result = cache.get(cache_key)
+
+        # Assert
+        assert result is not None
+        assert result.semantic_score == semantic_score
+
+
+def test_table_recreated_when_schema_differs() -> None:
+    """スキーマが異なる場合にテーブルが再作成されること.
+
+    Given:
+        - 期待されるスキーマと異なる定義でテーブルが作成されている
+    When:
+        - FeatureCacheを初期化
+    Then:
+        - テーブルがドロップされて再作成されること
+        - 期待されるスキーマになること
+    """
+    import tempfile
+    import sqlite3
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_path = Path(tmpdir) / "invalid_cache.sqlite3"
+
+        # Arrange: 異なるスキーマでテーブルを作成（カラムが不足）
+        conn = sqlite3.connect(str(cache_path))
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE feature_cache (
+                absolute_path TEXT NOT NULL,
+                file_size INTEGER NOT NULL,
+                max_dim INTEGER NOT NULL,
+                PRIMARY KEY (absolute_path, max_dim)
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        # Act: FeatureCacheを初期化（スキーマが異なるため再作成）
+        with FeatureCache(cache_path) as cache:
+            conn2 = cache._get_connection()
+            cursor2 = conn2.cursor()
+
+            # Assert: 期待されるスキーマになっていること
+            cursor2.execute("PRAGMA table_info(feature_cache)")
+            columns = [row[1] for row in cursor2.fetchall()]
+            assert "clip_features" in columns
+            assert "hsv_features" in columns
+            assert "semantic_score" in columns
+            assert "model_name" in columns
+            assert "target_text" in columns
+
+            # 複合主キーが正しく設定されていること
+            cursor2.execute(
+                "SELECT sql FROM sqlite_master "
+                "WHERE type='table' AND name='feature_cache'"
+            )
+            schema_sql = cursor2.fetchone()[0]
+            assert "PRIMARY KEY" in schema_sql
+            assert "absolute_path" in schema_sql
+            assert "model_name" in schema_sql
+
+
+def test_correct_schema_preserved() -> None:
+    """スキーマが正しい場合は何もしないこと.
+
+    Given:
+        - 正しいスキーマでテーブルが作成されている
+        - データが保存されている
+    When:
+        - FeatureCacheを初期化
+    Then:
+        - テーブルが再作成されないこと
+        - 既存データが保持されること
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_path = Path(tmpdir) / "correct_cache.sqlite3"
+
+        # Arrange: 正しいスキーマでFeatureCacheを作成し、データを保存
+        clip_features = np.ones(512, dtype=np.float32) * 0.5
+        hsv_features = np.ones(64, dtype=np.float32) * 0.3
+        raw_metrics = {"blur_score": 100.0}
+        semantic = 0.75
+        cache_key: dict[str, str | int] = {
+            "absolute_path": "/test/preserved.jpg",
+            "file_size": 2048,
+            "mtime_ns": 1234567890,
+            "model_name": "test_model",
+            "target_text": "test target",
+            "max_dim": 1280,
+            "metrics_version": "1",
+        }
+
+        with FeatureCache(cache_path) as cache1:
+            cache1.put(
+                cache_key=cache_key,
+                clip_features=clip_features,
+                raw_metrics=raw_metrics,
+                hsv_features=hsv_features,
+                semantic_score=semantic,
+            )
+
+        # Act: 同じパスでFeatureCacheを再度初期化
+        with FeatureCache(cache_path) as cache2:
+            # Assert: データが保持されている
+            result = cache2.get(cache_key)
+            assert result is not None
+            np.testing.assert_array_equal(result.clip_features, clip_features)
+            np.testing.assert_array_equal(result.hsv_features, hsv_features)
+            assert result.raw_metrics == raw_metrics
+            assert result.semantic_score == semantic


### PR DESCRIPTION
## 概要
- `CacheEntry.semantic_score` を `float | None` から `float` へ変更し必須化
- `_normalize_sql` 関数を `FeatureCache` クラスの静的メソッド化
- 古いスキーマからのマイグレーション処理を削除し、スキーマ比較によるテーブル再作成に変更
- キャッシュヒット時の `semantic_score` 計算スキップ処理を削除

## 変更内容
- キャッシュスキーマが期待と異なる場合はテーブルをドロップして再作成
- マイグレーション処理（`_add_semantic_score_column`, `_migrate_to_composite_key`）を削除
- `semantic_score` が常に保存・取得されることを保証

## テスト
- マイグレーション関連テストを削除
- スキーマが異なる場合にテーブルが再作成されるテストを追加