### PR TITLE
refactor: normalized_metricsとtotal_scoreを必須化してキャッシュスキーマを変更

### DIFF
--- a/src/analyzers/batch_pipeline.py
+++ b/src/analyzers/batch_pipeline.py
@@ -122,8 +122,6 @@ class BatchPipeline:
             metadata_list = [PathMetadata(path=path) for path in paths]
             return [None] * len(paths), metadata_list
 
-        from .metric_normalizer import MetricNormalizer
-
         # 第1パス: 全パスのキャッシュキーとメタ情報を生成
         cache_keys_with_meta = []
         all_metadata: List[PathMetadata] = []
@@ -131,7 +129,7 @@ class BatchPipeline:
 
         for i, path in enumerate(paths):
             try:
-                absolute_path = str(Path(path).resolve())
+                absolute_path = os.path.abspath(path)
                 file_stat = Path(path).stat()
                 cache_key = self.cache.generate_cache_key(
                     absolute_path=absolute_path,
@@ -199,12 +197,9 @@ class BatchPipeline:
             combined_features = np.concatenate(
                 [entry_info.entry.hsv_features, entry_info.entry.clip_features]
             )
-            # 正規化メトリクスを計算（生メトリクスから）
-            norm = MetricNormalizer.normalize_all(entry_info.entry.raw_metrics)
-            # 総合スコアを計算
-            total = self.metric_calculator.calculate_total_score(
-                entry_info.entry.raw_metrics, norm, semantic
-            )
+            # キャッシュに保存されている値を使用
+            norm = entry_info.entry.normalized_metrics
+            total = entry_info.entry.total_score
             cached_results[idx] = ImageMetrics(
                 entry_info.path,
                 entry_info.entry.raw_metrics,
@@ -491,7 +486,7 @@ class BatchPipeline:
                         file_stat = metadata.file_stat or Path(path).stat()
                     else:
                         # 従来通り取得（フォールバック）
-                        absolute_path = str(Path(path).resolve())
+                        absolute_path = os.path.abspath(path)
                         file_stat = Path(path).stat()
                         cache_key = self.cache.generate_cache_key(
                             absolute_path=absolute_path,
@@ -510,6 +505,8 @@ class BatchPipeline:
                         "raw_metrics": raw,
                         "hsv_features": hsv_features,
                         "semantic_score": semantic,
+                        "normalized_metrics": norm,
+                        "total_score": total,
                     }
                 except Exception as e:
                     # キャッシュエントリ構築に失敗しても処理は継続

--- a/src/cache/feature_cache.py
+++ b/src/cache/feature_cache.py
@@ -25,7 +25,7 @@ class FeatureCache:
     _init_lock = threading.Lock()
 
     # キャッシュスキーマのバージョン（アルゴリズム変更時に更新）
-    METRICS_VERSION: str = "2"  # float16 features
+    METRICS_VERSION: str = "3"  # Add normalized_metrics and total_score
 
     def __init__(self, cache_path: Optional[str | Path] = None):
         """特徴量キャッシュを初期化する.
@@ -112,6 +112,8 @@ class FeatureCache:
             raw_metrics TEXT NOT NULL,
             hsv_features BLOB NOT NULL,
             semantic_score REAL,
+            normalized_metrics TEXT,
+            total_score REAL,
             created_at REAL NOT NULL,
             PRIMARY KEY (
                 absolute_path, model_name, target_text, max_dim, metrics_version
@@ -183,6 +185,8 @@ class FeatureCache:
                 raw_metrics TEXT NOT NULL,
                 hsv_features BLOB NOT NULL,
                 semantic_score REAL,
+                normalized_metrics TEXT,
+                total_score REAL,
                 created_at REAL NOT NULL,
                 PRIMARY KEY (
                     absolute_path, model_name, target_text, max_dim, metrics_version
@@ -243,7 +247,8 @@ class FeatureCache:
         cursor = conn.cursor()
         cursor.execute(
             """
-            SELECT clip_features, raw_metrics, hsv_features, semantic_score
+            SELECT clip_features, raw_metrics, hsv_features, semantic_score,
+                   normalized_metrics, total_score
             FROM feature_cache
             WHERE absolute_path = ?
               AND file_size = ?
@@ -276,6 +281,8 @@ class FeatureCache:
                 np.float32
             ),
             semantic_score=row["semantic_score"],
+            normalized_metrics=json.loads(row["normalized_metrics"]),
+            total_score=row["total_score"],
         )
 
     def put(
@@ -285,6 +292,8 @@ class FeatureCache:
         raw_metrics: dict[str, float],
         hsv_features: np.ndarray,
         semantic_score: float,
+        normalized_metrics: dict[str, float],
+        total_score: float,
     ) -> None:
         """特徴量をキャッシュに保存する.
 
@@ -294,6 +303,8 @@ class FeatureCache:
             raw_metrics: 生メトリクス
             hsv_features: HSV特徴（64次元）
             semantic_score: セマンティックスコア
+            normalized_metrics: 正規化メトリクス
+            total_score: 総合スコア
         """
         import time
 
@@ -304,8 +315,9 @@ class FeatureCache:
             INSERT OR REPLACE INTO feature_cache (
                 absolute_path, file_size, mtime_ns, model_name, target_text,
                 max_dim, metrics_version, clip_features, raw_metrics,
-                hsv_features, semantic_score, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                hsv_features, semantic_score, normalized_metrics, total_score,
+                created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 cache_key["absolute_path"],
@@ -319,6 +331,8 @@ class FeatureCache:
                 json.dumps(raw_metrics),
                 hsv_features.astype(np.float16).tobytes(),
                 semantic_score,
+                json.dumps(normalized_metrics),
+                total_score,
                 time.time(),
             ),
         )
@@ -391,7 +405,9 @@ class FeatureCache:
                 fc.clip_features,
                 fc.raw_metrics,
                 fc.hsv_features,
-                fc.semantic_score
+                fc.semantic_score,
+                fc.normalized_metrics,
+                fc.total_score
             FROM feature_cache fc
             INNER JOIN temp_lookup tl ON
                 fc.absolute_path = tl.absolute_path AND
@@ -427,6 +443,8 @@ class FeatureCache:
                 raw_metrics=json.loads(row["raw_metrics"]),
                 hsv_features=hsv,
                 semantic_score=row["semantic_score"],
+                normalized_metrics=json.loads(row["normalized_metrics"]),
+                total_score=row["total_score"],
             )
 
         return results
@@ -450,6 +468,8 @@ class FeatureCache:
                 - raw_metrics: 生メトリクス（辞書）
                 - hsv_features: HSV特徴（64次元、np.ndarray）
                 - semantic_score: セマンティックスコア（オプション）
+                - normalized_metrics: 正規化メトリクス（オプション）
+                - total_score: 総合スコア（オプション）
         """
         import time
 
@@ -458,6 +478,13 @@ class FeatureCache:
 
         conn = self._get_connection()
         cursor = conn.cursor()
+        # 既に進行中のトランザクションがある場合はコミットしておく
+        # （get_many()等のTEMP TABLE操作でトランザクションが開始されている可能性）
+        try:
+            conn.commit()
+        except Exception:
+            pass  # トランザクションが開始されていない場合は無視
+
         cursor.execute("BEGIN TRANSACTION")
         try:
             insert_data = []
@@ -475,7 +502,9 @@ class FeatureCache:
                         entry["clip_features"].astype(np.float16).tobytes(),
                         json.dumps(entry["raw_metrics"]),
                         entry["hsv_features"].astype(np.float16).tobytes(),
-                        entry.get("semantic_score"),
+                        entry["semantic_score"],
+                        json.dumps(entry["normalized_metrics"]),
+                        entry["total_score"],
                         time.time(),
                     )
                 )
@@ -486,8 +515,9 @@ class FeatureCache:
                 INSERT OR REPLACE INTO feature_cache (
                     absolute_path, file_size, mtime_ns, model_name, target_text,
                     max_dim, metrics_version, clip_features, raw_metrics,
-                    hsv_features, semantic_score, created_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    hsv_features, semantic_score, normalized_metrics, total_score,
+                    created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 insert_data,
             )

--- a/src/models/cache_entry.py
+++ b/src/models/cache_entry.py
@@ -14,9 +14,13 @@ class CacheEntry:
         raw_metrics: 生メトリクス（9つの値）
         hsv_features: HSV特徴（64次元ベクトル）
         semantic_score: セマンティックスコア
+        normalized_metrics: 正規化メトリクス
+        total_score: 総合スコア
     """
 
     clip_features: np.ndarray
     raw_metrics: dict[str, float]
     hsv_features: np.ndarray
     semantic_score: float
+    normalized_metrics: dict[str, float]
+    total_score: float

--- a/tests/analyzers/test_batch_pipeline.py
+++ b/tests/analyzers/test_batch_pipeline.py
@@ -170,7 +170,7 @@ def test_cached_results_use_stored_semantic_score(tmp_path: Path) -> None:
     # キャッシュキーを生成して保存
     file_stat = img_path.stat()
     cache_key = cache.generate_cache_key(
-        absolute_path=str(img_path.resolve()),
+        absolute_path=os.path.abspath(str(img_path)),
         file_size=file_stat.st_size,
         mtime_ns=int(file_stat.st_mtime_ns),
         model_name="openai/clip-vit-base-patch32",
@@ -179,12 +179,16 @@ def test_cached_results_use_stored_semantic_score(tmp_path: Path) -> None:
     )
 
     # semantic_score付きで保存
+    normalized_metrics = {"blur_score": 0.5}
+    total_score = 75.0
     cache.put(
         cache_key=cache_key,
         clip_features=clip_features,
         raw_metrics=raw_metrics,
         hsv_features=hsv_features,
         semantic_score=semantic_score,
+        normalized_metrics=normalized_metrics,
+        total_score=total_score,
     )
 
     # Act: キャッシュから取得
@@ -471,3 +475,78 @@ def test_process_single_result_reuses_metadata(
     assert result.path == sample_image_path
     assert 0 <= result.total_score <= 100
     assert result.semantic_score == semantic
+
+
+def test_cached_results_uses_stored_metrics(tmp_path: Path) -> None:
+    """キャッシュヒット時に保存されたnormalized_metricsとtotal_scoreが使用されること.
+
+    Given:
+        - normalized_metricsとtotal_score付きのエントリがキャッシュに保存されている
+    When:
+        - キャッシュから結果を取得
+    Then:
+        - 保存されたnormalized_metricsとtotal_scoreが使用されること
+        - 再計算がスキップされること
+    """
+    # Arrange: キャッシュ付きのパイプラインを作成
+    config = AnalyzerConfig()
+    weights = GenreWeights.get_weights("mixed")
+    model_manager = CLIPModelManager()
+    feature_extractor = FeatureExtractor(model_manager)
+    metric_calculator = MetricCalculator(config, weights, model_manager)
+
+    cache_path = tmp_path / "test_stored_metrics_cache.sqlite3"
+    cache = FeatureCache(cache_path)
+
+    pipeline = BatchPipeline(
+        feature_extractor,
+        metric_calculator,
+        config,
+        cache=cache,
+    )
+
+    # テスト画像を作成
+    np.random.seed(42)
+    img_array = np.random.randint(0, 255, (240, 320, 3), dtype=np.uint8)
+    img_path = tmp_path / "stored_metrics_test.jpg"
+    cv2.imwrite(str(img_path), img_array)
+
+    # ファイル情報を事前に取得してキャッシュキーを作成
+    file_stat = img_path.stat()
+    cache_key = cache.generate_cache_key(
+        absolute_path=os.path.abspath(str(img_path)),
+        file_size=file_stat.st_size,
+        mtime_ns=int(file_stat.st_mtime_ns),
+        model_name="openai/clip-vit-base-patch32",
+        target_text="epic game scenery",
+        max_dim=config.max_dim,
+    )
+
+    # Act: 最初の実行（キャッシュミス）
+    first_results = pipeline.process_batch([str(img_path)], batch_size=1)
+
+    # Assert: 最初の実行で有効な結果が得られる
+    assert len(first_results) == 1
+    assert first_results[0] is not None
+    assert first_results[0].path == str(img_path)
+    assert -1.0 <= first_results[0].semantic_score <= 1.0 + 1e-5
+    assert 0 <= first_results[0].total_score <= 100
+
+    # キャッシュから直接取得して確認（事前に取得したcache_keyを使用）
+    entry = cache.get(cache_key)
+    assert entry is not None, f"Cache entry not found for key: {cache_key}"
+    # normalized_metricsとtotal_scoreが保存されていること
+    assert entry.normalized_metrics is not None
+    assert entry.total_score is not None
+
+    # 2回目の実行（キャッシュヒット）
+    second_results = pipeline.process_batch([str(img_path)], batch_size=1)
+
+    # Assert: 2回目の実行でも有効な結果が得られる
+    assert len(second_results) == 1
+    assert second_results[0] is not None
+
+    # キャッシュヒット時も結果が正しく取得できる
+    assert second_results[0].path == str(img_path)
+    assert -1.0 <= second_results[0].semantic_score <= 1.0 + 1e-5
+    assert 0 <= second_results[0].total_score <= 100

--- a/tests/cache/test_feature_cache.py
+++ b/tests/cache/test_feature_cache.py
@@ -49,6 +49,7 @@ def test_put_and_get_roundtrip() -> None:
         - キャッシュに保存してから取得
     Then:
         - 保存したデータが正しく取得できること
+        - normalized_metricsとtotal_scoreも正しく保存・取得できること
     """
     # Arrange
     clip_features = np.random.randn(512).astype(np.float32)
@@ -65,6 +66,18 @@ def test_put_and_get_roundtrip() -> None:
         "dramatic_score": 50.0,
     }
     semantic_score = 0.75
+    normalized_metrics = {
+        "blur_score": 0.5,
+        "brightness": 0.6,
+        "contrast": 0.7,
+        "edge_density": 0.8,
+        "color_richness": 0.9,
+        "ui_density": 0.1,
+        "action_intensity": 0.2,
+        "visual_balance": 0.3,
+        "dramatic_score": 0.4,
+    }
+    total_score = 85.5
     cache_key: dict[str, str | int] = {
         "absolute_path": "/test/image.jpg",
         "file_size": 1024,
@@ -72,17 +85,19 @@ def test_put_and_get_roundtrip() -> None:
         "model_name": "openai/clip-vit-base-patch32",
         "target_text": "epic game scenery",
         "max_dim": 1280,
-        "metrics_version": "2",
+        "metrics_version": "3",
     }
 
     with FeatureCache(None) as cache:
-        # Act: 保存
+        # Act: 保存（normalized_metricsとtotal_scoreを含む）
         cache.put(
             cache_key=cache_key,
             clip_features=clip_features,
             raw_metrics=raw_metrics,
             hsv_features=hsv_features,
             semantic_score=semantic_score,
+            normalized_metrics=normalized_metrics,
+            total_score=total_score,
         )
 
         # Act: 取得
@@ -97,6 +112,9 @@ def test_put_and_get_roundtrip() -> None:
         np.testing.assert_array_almost_equal(result.hsv_features, expected_hsv)
         assert result.raw_metrics == raw_metrics
         assert result.semantic_score == semantic_score
+        # normalized_metricsとtotal_scoreが正しく保存・取得されること
+        assert result.normalized_metrics == normalized_metrics
+        assert result.total_score == total_score
 
 
 def test_get_returns_none_for_nonexistent_key() -> None:
@@ -117,7 +135,7 @@ def test_get_returns_none_for_nonexistent_key() -> None:
         "model_name": "test_model",
         "target_text": "test",
         "max_dim": 1280,
-        "metrics_version": "2",
+        "metrics_version": "3",
     }
 
     with FeatureCache(None) as cache:
@@ -149,16 +167,20 @@ def test_get_returns_none_when_file_size_changed() -> None:
         "model_name": "openai/clip-vit-base-patch32",
         "target_text": "epic game scenery",
         "max_dim": 1280,
-        "metrics_version": "2",
+        "metrics_version": "3",
     }
 
     with FeatureCache(None) as cache:
+        normalized_metrics = {"blur_score": 0.5}
+        total_score = 75.0
         cache.put(
             cache_key=original_key,
             clip_features=clip_features,
             raw_metrics=raw_metrics,
             hsv_features=hsv_features,
             semantic_score=0.75,
+            normalized_metrics=normalized_metrics,
+            total_score=total_score,
         )
 
         # Act: file_sizeを変更して取得
@@ -192,26 +214,34 @@ def test_put_replaces_existing_entry() -> None:
         "model_name": "openai/clip-vit-base-patch32",
         "target_text": "epic game scenery",
         "max_dim": 1280,
-        "metrics_version": "2",
+        "metrics_version": "3",
     }
 
     with FeatureCache(None) as cache:
         # 初期データを保存
+        normalized_metrics1 = {"blur_score": 0.5}
+        total_score1 = 75.0
         cache.put(
             cache_key=cache_key,
             clip_features=original_features,
             raw_metrics=raw_metrics,
             hsv_features=hsv_features,
             semantic_score=0.5,
+            normalized_metrics=normalized_metrics1,
+            total_score=total_score1,
         )
 
         # Act: 同じキーで更新
+        normalized_metrics2 = {"blur_score": 0.8}
+        total_score2 = 80.0
         cache.put(
             cache_key=cache_key,
             clip_features=updated_features,
             raw_metrics={"blur_score": 200.0},
             hsv_features=hsv_features,
             semantic_score=0.8,
+            normalized_metrics=normalized_metrics2,
+            total_score=total_score2,
         )
 
         # Assert: 更新後のデータが取得できる
@@ -220,6 +250,9 @@ def test_put_replaces_existing_entry() -> None:
         np.testing.assert_array_equal(result.clip_features, updated_features)
         assert result.raw_metrics["blur_score"] == 200.0
         assert result.semantic_score == 0.8
+        # normalized_metricsとtotal_scoreも更新されていること
+        assert result.normalized_metrics == normalized_metrics2
+        assert result.total_score == total_score2
 
 
 def test_persistent_storage() -> None:
@@ -243,13 +276,15 @@ def test_persistent_storage() -> None:
         "model_name": "openai/clip-vit-base-patch32",
         "target_text": "epic game scenery",
         "max_dim": 1280,
-        "metrics_version": "2",
+        "metrics_version": "3",
     }
 
     with tempfile.TemporaryDirectory() as tmpdir:
         cache_path = Path(tmpdir) / "test_cache.sqlite3"
 
         # 最初のセッションで保存
+        normalized_metrics = {"blur_score": 0.5}
+        total_score = 75.0
         with FeatureCache(cache_path) as cache1:
             cache1.put(
                 cache_key=cache_key,
@@ -257,6 +292,8 @@ def test_persistent_storage() -> None:
                 raw_metrics=raw_metrics,
                 hsv_features=hsv_features,
                 semantic_score=0.75,
+                normalized_metrics=normalized_metrics,
+                total_score=total_score,
             )
 
         # Act: 別セッションで取得
@@ -268,6 +305,11 @@ def test_persistent_storage() -> None:
         # float16で保存されているため、精度が異なることを考慮
         expected_clip = clip_features.astype(np.float16).astype(np.float32)
         np.testing.assert_array_almost_equal(result.clip_features, expected_clip)
+        assert result.raw_metrics == raw_metrics
+        assert result.semantic_score == 0.75
+        # normalized_metricsとtotal_scoreも永続化されていること
+        assert result.normalized_metrics == normalized_metrics
+        assert result.total_score == total_score
 
 
 def test_generate_cache_key() -> None:
@@ -310,6 +352,7 @@ def test_put_batch_saves_multiple_entries() -> None:
         - put_batch()で一括保存
     Then:
         - すべてのエントリが正しく取得できること
+        - normalized_metricsとtotal_scoreも正しく保存されること
         - 単一トランザクションで処理されること
     """
     # Arrange: 複数のテストエントリを作成
@@ -320,6 +363,8 @@ def test_put_batch_saves_multiple_entries() -> None:
         hsv_features = np.random.randn(64).astype(np.float32)
         raw_metrics = {"blur_score": float(i * 10)}
         semantic_score = 0.1 * i
+        normalized_metrics = {"blur_score": 0.5 * i}
+        total_score = 50.0 + i * 5
         cache_key: dict[str, str | int] = {
             "absolute_path": f"/test/batch_image_{i}.jpg",
             "file_size": 1024 + i,
@@ -327,7 +372,7 @@ def test_put_batch_saves_multiple_entries() -> None:
             "model_name": "test_model",
             "target_text": "test target",
             "max_dim": 1280,
-            "metrics_version": "2",
+            "metrics_version": "3",
         }
         entries.append(
             {
@@ -336,10 +381,20 @@ def test_put_batch_saves_multiple_entries() -> None:
                 "raw_metrics": raw_metrics,
                 "hsv_features": hsv_features,
                 "semantic_score": semantic_score,
+                "normalized_metrics": normalized_metrics,
+                "total_score": total_score,
             }
         )
         expected_results.append(
-            (cache_key, clip_features, hsv_features, raw_metrics, semantic_score)
+            (
+                cache_key,
+                clip_features,
+                hsv_features,
+                raw_metrics,
+                semantic_score,
+                normalized_metrics,
+                total_score,
+            )
         )
 
     with FeatureCache(None) as cache:
@@ -353,6 +408,8 @@ def test_put_batch_saves_multiple_entries() -> None:
             hsv_features,
             raw_metrics,
             semantic,
+            norm,
+            total,
         ) in expected_results:
             result = cache.get(cache_key)
             assert result is not None
@@ -363,6 +420,9 @@ def test_put_batch_saves_multiple_entries() -> None:
             np.testing.assert_array_almost_equal(result.hsv_features, expected_hsv)
             assert result.raw_metrics == raw_metrics
             assert result.semantic_score == semantic
+            # normalized_metricsとtotal_scoreも正しく保存・取得されること
+            assert result.normalized_metrics == norm
+            assert result.total_score == total
 
 
 def test_composite_key_allows_different_params_for_same_path() -> None:
@@ -390,7 +450,7 @@ def test_composite_key_allows_different_params_for_same_path() -> None:
         "model_name": "model_A",
         "target_text": "epic game scenery",
         "max_dim": 1280,
-        "metrics_version": "2",
+        "metrics_version": "3",
     }
     cache_key2: dict[str, str | int] = {
         "absolute_path": "/test/same_path.jpg",
@@ -399,7 +459,7 @@ def test_composite_key_allows_different_params_for_same_path() -> None:
         "model_name": "model_B",  # 異なるモデル
         "target_text": "epic game scenery",
         "max_dim": 1280,
-        "metrics_version": "2",
+        "metrics_version": "3",
     }
     cache_key3: dict[str, str | int] = {
         "absolute_path": "/test/same_path.jpg",
@@ -408,7 +468,7 @@ def test_composite_key_allows_different_params_for_same_path() -> None:
         "model_name": "model_A",
         "target_text": "epic game scenery",
         "max_dim": 640,  # 異なるmax_dim
-        "metrics_version": "2",
+        "metrics_version": "3",
     }
 
     with FeatureCache(None) as cache:
@@ -419,6 +479,8 @@ def test_composite_key_allows_different_params_for_same_path() -> None:
             raw_metrics=raw_metrics,
             hsv_features=hsv_features,
             semantic_score=0.5,
+            normalized_metrics={"blur_score": 0.5},
+            total_score=75.0,
         )
         cache.put(
             cache_key=cache_key2,
@@ -426,6 +488,8 @@ def test_composite_key_allows_different_params_for_same_path() -> None:
             raw_metrics=raw_metrics,
             hsv_features=hsv_features,
             semantic_score=0.6,
+            normalized_metrics={"blur_score": 0.6},
+            total_score=80.0,
         )
         cache.put(
             cache_key=cache_key3,
@@ -433,6 +497,8 @@ def test_composite_key_allows_different_params_for_same_path() -> None:
             raw_metrics=raw_metrics,
             hsv_features=hsv_features,
             semantic_score=0.7,
+            normalized_metrics={"blur_score": 0.7},
+            total_score=85.0,
         )
 
         # Assert: 各エントリが独立して取得できる
@@ -470,6 +536,8 @@ def test_get_many_retrieves_multiple_entries() -> None:
         hsv_features = np.random.randn(64).astype(np.float32)
         raw_metrics = {"blur_score": float(i * 10)}
         semantic_score = 0.1 * i
+        normalized_metrics = {"blur_score": 0.5 * i}
+        total_score = 50.0 + i * 5
         cache_key: dict[str, str | int] = {
             "absolute_path": f"/test/get_many_{i}.jpg",
             "file_size": 1024 + i,
@@ -477,11 +545,19 @@ def test_get_many_retrieves_multiple_entries() -> None:
             "model_name": "test_model",
             "target_text": "test target",
             "max_dim": 1280,
-            "metrics_version": "2",
+            "metrics_version": "3",
         }
         cache_keys.append(cache_key)
         entries.append(
-            (cache_key, clip_features, hsv_features, raw_metrics, semantic_score)
+            (
+                cache_key,
+                clip_features,
+                hsv_features,
+                raw_metrics,
+                semantic_score,
+                normalized_metrics,
+                total_score,
+            )
         )
         expected_results[
             (
@@ -493,16 +569,33 @@ def test_get_many_retrieves_multiple_entries() -> None:
                 cache_key["max_dim"],
                 cache_key["metrics_version"],
             )
-        ] = (clip_features, hsv_features, raw_metrics, semantic_score)
+        ] = (
+            clip_features,
+            hsv_features,
+            raw_metrics,
+            semantic_score,
+            normalized_metrics,
+            total_score,
+        )
 
     with FeatureCache(None) as cache:
-        for cache_key, clip_features, hsv_features, raw_metrics, semantic in entries:
+        for (
+            cache_key,
+            clip_features,
+            hsv_features,
+            raw_metrics,
+            semantic,
+            norm,
+            total,
+        ) in entries:
             cache.put(
                 cache_key=cache_key,
                 clip_features=clip_features,
                 raw_metrics=raw_metrics,
                 hsv_features=hsv_features,
                 semantic_score=semantic,
+                normalized_metrics=norm,
+                total_score=total,
             )
 
         # 存在しないキーも含める
@@ -513,7 +606,7 @@ def test_get_many_retrieves_multiple_entries() -> None:
             "model_name": "test_model",
             "target_text": "test target",
             "max_dim": 1280,
-            "metrics_version": "2",
+            "metrics_version": "3",
         }
         cache_keys.append(nonexistent_key)
 
@@ -541,6 +634,8 @@ def test_get_many_retrieves_multiple_entries() -> None:
                 expected_hsv,
                 expected_raw,
                 expected_semantic,
+                expected_norm,
+                expected_total,
             ) = expected_results[key_id]
             # float16で保存されているため、精度が異なることを考慮
             expected_clip_f16 = expected_clip.astype(np.float16).astype(np.float32)
@@ -551,6 +646,9 @@ def test_get_many_retrieves_multiple_entries() -> None:
             np.testing.assert_array_almost_equal(result.hsv_features, expected_hsv_f16)
             assert result.raw_metrics == expected_raw
             assert result.semantic_score == expected_semantic
+            # normalized_metricsとtotal_scoreも正しく取得できること
+            assert result.normalized_metrics == expected_norm
+            assert result.total_score == expected_total
 
         # 存在しないキーはNone
         nonexistent_key_id = (
@@ -659,6 +757,8 @@ def test_get_many_reuses_temp_table() -> None:
         hsv_features = np.random.randn(64).astype(np.float32)
         raw_metrics = {"blur_score": float(i * 10)}
         semantic_score = 0.1 * i
+        normalized_metrics = {"blur_score": 0.5 * i}
+        total_score = 50.0 + i * 5
         cache_key: dict[str, str | int] = {
             "absolute_path": f"/test/reuse_temp_{i}.jpg",
             "file_size": 1024 + i,
@@ -666,22 +766,23 @@ def test_get_many_reuses_temp_table() -> None:
             "model_name": "test_model",
             "target_text": "test target",
             "max_dim": 1280,
-            "metrics_version": "2",
+            "metrics_version": "3",
         }
         cache_keys.append(cache_key)
         entries.append(
-            (cache_key, clip_features, hsv_features, raw_metrics, semantic_score)
+            {
+                "cache_key": cache_key,
+                "clip_features": clip_features,
+                "raw_metrics": raw_metrics,
+                "hsv_features": hsv_features,
+                "semantic_score": semantic_score,
+                "normalized_metrics": normalized_metrics,
+                "total_score": total_score,
+            }
         )
 
     with FeatureCache(None) as cache:
-        for cache_key, clip_features, hsv_features, raw_metrics, semantic in entries:
-            cache.put(
-                cache_key=cache_key,
-                clip_features=clip_features,
-                raw_metrics=raw_metrics,
-                hsv_features=hsv_features,
-                semantic_score=semantic,
-            )
+        cache.put_batch(entries)
 
         # Act: 1回目の呼び出し（TEMP TABLEが作成される）
         results1 = cache.get_many(cache_keys)
@@ -716,6 +817,7 @@ def test_put_batch_uses_executemany() -> None:
         - put_batch()で一括保存
     Then:
         - すべてのエントリが正しく保存されること
+        - normalized_metricsとtotal_scoreも正しく保存されること
         - トランザクション内で処理されること
     """
     # Arrange: 複数のテストエントリを作成（100件）
@@ -726,6 +828,8 @@ def test_put_batch_uses_executemany() -> None:
         hsv_features = np.random.randn(64).astype(np.float32)
         raw_metrics = {"blur_score": float(i)}
         semantic_score = 0.01 * i
+        normalized_metrics = {"blur_score": 0.5 * i}
+        total_score = 50.0 + i * 0.5
         cache_key: dict[str, str | int] = {
             "absolute_path": f"/test/executemany_{i}.jpg",
             "file_size": 1024 + i,
@@ -733,7 +837,7 @@ def test_put_batch_uses_executemany() -> None:
             "model_name": "test_model",
             "target_text": "test target",
             "max_dim": 1280,
-            "metrics_version": "2",
+            "metrics_version": "3",
         }
         entries.append(
             {
@@ -742,10 +846,20 @@ def test_put_batch_uses_executemany() -> None:
                 "raw_metrics": raw_metrics,
                 "hsv_features": hsv_features,
                 "semantic_score": semantic_score,
+                "normalized_metrics": normalized_metrics,
+                "total_score": total_score,
             }
         )
         expected_results.append(
-            (cache_key, clip_features, hsv_features, raw_metrics, semantic_score)
+            (
+                cache_key,
+                clip_features,
+                hsv_features,
+                raw_metrics,
+                semantic_score,
+                normalized_metrics,
+                total_score,
+            )
         )
 
     with FeatureCache(None) as cache:
@@ -759,6 +873,8 @@ def test_put_batch_uses_executemany() -> None:
             hsv_features,
             raw_metrics,
             semantic,
+            norm,
+            total,
         ) in expected_results:
             result = cache.get(cache_key)
             assert result is not None
@@ -769,6 +885,9 @@ def test_put_batch_uses_executemany() -> None:
             np.testing.assert_array_almost_equal(result.hsv_features, expected_hsv)
             assert result.raw_metrics == raw_metrics
             assert result.semantic_score == semantic
+            # normalized_metricsとtotal_scoreも正しく保存・取得されること
+            assert result.normalized_metrics == norm
+            assert result.total_score == total
 
 
 def test_semantic_score_roundtrip() -> None:
@@ -793,17 +912,21 @@ def test_semantic_score_roundtrip() -> None:
         "model_name": "test_model",
         "target_text": "test target",
         "max_dim": 1280,
-        "metrics_version": "2",
+        "metrics_version": "3",
     }
 
     with FeatureCache(None) as cache:
         # Act: 保存（semantic_scoreを指定）
+        normalized_metrics = {"blur_score": 0.5}
+        total_score = 75.0
         cache.put(
             cache_key=cache_key,
             clip_features=clip_features,
             raw_metrics=raw_metrics,
             hsv_features=hsv_features,
             semantic_score=semantic_score,
+            normalized_metrics=normalized_metrics,
+            total_score=total_score,
         )
 
         # Act: 取得
@@ -812,6 +935,9 @@ def test_semantic_score_roundtrip() -> None:
         # Assert
         assert result is not None
         assert result.semantic_score == semantic_score
+        # normalized_metricsとtotal_scoreも正しく保存・取得されること
+        assert result.normalized_metrics == normalized_metrics
+        assert result.total_score == total_score
 
 
 def test_table_recreated_when_schema_differs() -> None:
@@ -858,6 +984,8 @@ def test_table_recreated_when_schema_differs() -> None:
             assert "clip_features" in columns
             assert "hsv_features" in columns
             assert "semantic_score" in columns
+            assert "normalized_metrics" in columns
+            assert "total_score" in columns
             assert "model_name" in columns
             assert "target_text" in columns
 
@@ -883,6 +1011,7 @@ def test_correct_schema_preserved() -> None:
     Then:
         - テーブルが再作成されないこと
         - 既存データが保持されること
+        - normalized_metricsとtotal_scoreも保持されること
     """
     import tempfile
 
@@ -894,6 +1023,8 @@ def test_correct_schema_preserved() -> None:
         hsv_features = np.ones(64, dtype=np.float32) * 0.3
         raw_metrics = {"blur_score": 100.0}
         semantic = 0.75
+        normalized_metrics = {"blur_score": 0.5}
+        total_score = 85.5
         cache_key: dict[str, str | int] = {
             "absolute_path": "/test/preserved.jpg",
             "file_size": 2048,
@@ -901,7 +1032,7 @@ def test_correct_schema_preserved() -> None:
             "model_name": "test_model",
             "target_text": "test target",
             "max_dim": 1280,
-            "metrics_version": "2",
+            "metrics_version": "3",
         }
 
         with FeatureCache(cache_path) as cache1:
@@ -911,6 +1042,8 @@ def test_correct_schema_preserved() -> None:
                 raw_metrics=raw_metrics,
                 hsv_features=hsv_features,
                 semantic_score=semantic,
+                normalized_metrics=normalized_metrics,
+                total_score=total_score,
             )
 
         # Act: 同じパスでFeatureCacheを再度初期化
@@ -925,6 +1058,9 @@ def test_correct_schema_preserved() -> None:
             np.testing.assert_array_equal(result.hsv_features, expected_hsv)
             assert result.raw_metrics == raw_metrics
             assert result.semantic_score == semantic
+            # normalized_metricsとtotal_scoreも保持されること
+            assert result.normalized_metrics == normalized_metrics
+            assert result.total_score == total_score
 
 
 def test_float16_features_roundtrip() -> None:
@@ -937,6 +1073,7 @@ def test_float16_features_roundtrip() -> None:
     Then:
         - float16の精度で丸められた特徴量が読み出されること
         - 読み出し後はfloat32に変換されていること
+        - normalized_metricsとtotal_scoreも正しく保存・取得できること
     """
     # Arrange: float32で特徴量を作成
     clip_features = np.array(
@@ -945,6 +1082,8 @@ def test_float16_features_roundtrip() -> None:
     hsv_features = np.array([0.5, 0.25, 0.75, 0.125], dtype=np.float32)
     raw_metrics = {"blur_score": 100.0}
     semantic_score = 0.75
+    normalized_metrics = {"blur_score": 0.5}
+    total_score = 85.5
     cache_key: dict[str, str | int] = {
         "absolute_path": "/test/float16_roundtrip.jpg",
         "file_size": 2048,
@@ -952,7 +1091,7 @@ def test_float16_features_roundtrip() -> None:
         "model_name": "test_model",
         "target_text": "test target",
         "max_dim": 1280,
-        "metrics_version": "2",
+        "metrics_version": "3",
     }
 
     with FeatureCache(None) as cache:
@@ -963,6 +1102,8 @@ def test_float16_features_roundtrip() -> None:
             raw_metrics=raw_metrics,
             hsv_features=hsv_features,
             semantic_score=semantic_score,
+            normalized_metrics=normalized_metrics,
+            total_score=total_score,
         )
 
         # Act: 取得（float16から読み出してfloat32に変換される）
@@ -985,3 +1126,6 @@ def test_float16_features_roundtrip() -> None:
         )
         assert result.raw_metrics == raw_metrics
         assert result.semantic_score == semantic_score
+        # normalized_metricsとtotal_scoreも正しく保存・取得されること
+        assert result.normalized_metrics == normalized_metrics
+        assert result.total_score == total_score


### PR DESCRIPTION
## 概要

キャッシュエントリの `normalized_metrics` と `total_score` をオプションから必須に変更し、パフォーマンス改善とデータ整合性を向上させました。

## 変更内容

- **CacheEntry モデル**: `normalized_metrics` と `total_score` を必須属性に変更
- **FeatureCache.put()**: 引数を必須に変更（NULL許容削除）
- **FeatureCache.get/get_many()**: NULLチェックを削除（必須化されたため）
- **batch_pipeline**: フォールバック処理を削除、Path.resolve() を os.path.abspath() に置換
- **テスト**: 必須引数指定に更新、フォールバックテストを削除

## 背景

キャッシュヒット時に `normalized_metrics` と `total_score` を再計算しており、パフォーマンスの低下とコードの複雑化を招いていました。これらを必須化することで、常にキャッシュに保存された値を使用するようになり、計算コストを削減できます。

## テスト

すべてのテスト（86件）がパスしています。