### PR TITLE
fix: 選択スコア計算のパラメータ調整

### DIFF
--- a/src/models/analyzer_config.py
+++ b/src/models/analyzer_config.py
@@ -23,9 +23,9 @@ class AnalyzerConfig:
     max_dim: int = 720
     max_memory_mb: int = 512  # 約512MBのメモリ予算で動的チャンク
     min_chunk_size: int = 16  # 最低16枚は1チャンクで処理
-    brightness_penalty_threshold: float = 40.0
-    brightness_penalty_value: float = 0.6
-    semantic_weight: float = 0.002  # コサイン類似度[-1,1]用に調整（元の0.2から100倍）
+    brightness_penalty_threshold: float = 35.0
+    brightness_penalty_value: float = 0.15
+    semantic_weight: float = 0.03  # コサイン類似度[-1,1]用に調整（元の0.2から100倍）
     score_multiplier: float = 100.0
     result_max_workers: int | None = None
 


### PR DESCRIPTION
## 概要
選択スコア計算のパラメータを調整し、選品位を改善します。

## 変更内容
- `brightness_penalty_threshold`: 40.0 → 35.0（輝度ペナルティの閾値を引き下げ）
- `brightness_penalty_value`: 0.6 → 0.15（輝度ペナルティの影響を緩和）
- `semantic_weight`: 0.002 → 0.03（セマンティック類似度の重みを強化）

## 変更ファイル
- `src/models/analyzer_config.py`