### PR TITLE
docs: READMEに出力フォルダの自動作成について記述追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ uv run game-screen-pick -n 20 ./screenshots ./output
 uv run game-screen-pick -r -n 10 ./screenshots ./output
 ```
 
+### 出力フォルダ
+
+出力フォルダが存在しない場合は自動的に作成されます。
+親ディレクトリも含めて必要な階層が自動作成されます。
+
 ## 選択アルゴリズム
 
 ### スコアリング


### PR DESCRIPTION
## 概要

出力フォルダが存在しない場合の自動作成動作について README.md に記述を追加しました。

## 変更内容

- 「使用例」セクションの後に「出力フォルダ」セクションを追加
- 出力フォルダが存在しない場合は自動的に作成されることを明記
- 親ディレクトリも含めて必要な階層が自動作成されることを説明

## 動作確認

※ 既に実装済みの機能についての説明追加のみです