### PR TITLE
fix: CLIエントリーポイントをclick移行後のcli_mainに修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [project.scripts]
-game-screen-pick = "src.main:main"
+game-screen-pick = "src.main:cli_main"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## 概要
- `pyproject.toml` のエントリーポイントを `main` から `cli_main` に修正

## 変更内容
- `[project.scripts]` の `game-screen-pick` エントリーポイントを更新
- click への移行（#91）に伴う対応

## テスト計画
- [ ] CLIコマンドが正常に実行できること