### PR TITLE
refactor: チャンク分割ロジックを画像解像度ベースに変更しデバッグログを追加

### DIFF
--- a/src/analyzers/batch_pipeline.py
+++ b/src/analyzers/batch_pipeline.py
@@ -29,8 +29,6 @@ class BatchPipeline:
     チャンク分割とlookaheadプリロードによるメモリ効率化を実現する。
     """
 
-    # ファイルサイズからメモリ使用量を見積もるための係数
-    MEMORY_ESTIMATION_FACTOR: float = 2.5
     # 進捗表示の間隔
     PROGRESS_REPORT_INTERVAL: int = 500
 
@@ -138,6 +136,7 @@ class BatchPipeline:
             paths,
             self.config.max_memory_mb,
             self.config.min_chunk_size,
+            self.config.max_dim,
         )
 
         # 先読み用のスレッドプール（インスタンスで再利用）
@@ -158,9 +157,16 @@ class BatchPipeline:
 
         for chunk_idx, (chunk_start, chunk_end) in enumerate(chunk_boundaries):
             chunk_paths = paths[chunk_start:chunk_end]
+            logger.debug(
+                f"チャンク処理開始: {chunk_idx + 1}/{len(chunk_boundaries)} "
+                f"({chunk_start}-{chunk_end}, {len(chunk_paths)}枚)"
+            )
 
             # プリロードされた画像を取得
+            logger.debug(f"プリロード画像を取得中: チャンク{chunk_idx}")
             pil_images = preload_futures[chunk_idx].result()
+            valid_count = len([p for p in pil_images if p is not None])
+            logger.debug(f"プリロード完了: {valid_count}枚有効")
             del preload_futures[chunk_idx]
 
             # 次のチャンクをプリロード
@@ -173,18 +179,26 @@ class BatchPipeline:
                     next_paths,
                     self.config.max_dim,
                 )
+                logger.debug(f"次チャンクのプリロード開始: チャンク{next_idx}")
 
             # ステージ2: チャンク単位でバッチCLIP推論を実行
+            logger.debug(f"CLIP推論開始: {len(pil_images)}枚")
             clip_features_list = self.feature_extractor.extract_clip_features_batch(
                 pil_images, initial_batch_size=batch_size
             )
+            logger.debug(
+                f"CLIP推論完了: "
+                f"{len([f for f in clip_features_list if f is not None])}枚成功"
+            )
 
             # ステージ3: セマンティックスコアをバッチ計算（バッチTensorを再利用）
+            logger.debug("セマンティックスコア計算開始")
             semantic_scores, batch_features, valid_indices = (
                 self.metric_calculator.calculate_semantic_score_batch(
                     clip_features_list
                 )
             )
+            logger.debug(f"セマンティックスコア計算完了: {len(valid_indices)}枚有効")
 
             # ステージ3.5: バッチTensorを再利用してGPU→CPU転送
             clip_features_np_list = self._convert_batch_features_to_numpy(
@@ -213,21 +227,35 @@ class BatchPipeline:
 
     @staticmethod
     def _compute_chunk_boundaries(
-        paths: list[str], max_memory_mb: int, min_chunk_size: int
+        paths: list[str],
+        max_memory_mb: int,
+        min_chunk_size: int,
+        max_dim: int | None = None,
     ) -> list[tuple[int, int]]:
         """メモリ予算に基づいてチャンク境界を計算する.
 
-        各画像のファイルサイズを取得し、指定されたメモリ予算を超えない
-        ように動的にチャンクを分割する。
+        画像解像度ベースでメモリ使用量を見積もり、max_dimで縮小後の
+        サイズを考慮してチャンクを分割する。
+
+        見積もり式:
+        - 1ピクセルあたり約4バイト（RGBA + PILオーバーヘッド）
+        - PIL Image: width × height × 4 bytes
+        - CLIP Tensor: 追加で同等程度
+        - 安全係数: 3.0
 
         Args:
             paths: 画像ファイルパスのリスト
             max_memory_mb: チャンクあたりの最大メモリ予算（MB）
             min_chunk_size: 最低限確保するチャンクサイズ
+            max_dim: 長辺の最大ピクセル数（Noneの場合は縮小しない）
 
         Returns:
             (start_index, end_index) のタプルリスト
         """
+        BYTES_PER_PIXEL = 4  # RGBA
+        SAFETY_FACTOR = 3.0  # CLIP Tensor等を考慮した安全係数
+        DEFAULT_MEMORY = 1024 * 1024  # 読み込み失敗時のデフォルト値（1MB相当）
+
         max_memory_bytes = max_memory_mb * 1024 * 1024
         chunks = []
         current_start = 0
@@ -235,37 +263,40 @@ class BatchPipeline:
         current_count = 0
 
         for i, path in enumerate(paths):
-            # os.statでファイルサイズを取得し、メモリを見積もる
+            # 画像の解像度からメモリを見積もる
             try:
-                file_size = os.path.getsize(path)
-                estimated_memory = int(
-                    file_size * BatchPipeline.MEMORY_ESTIMATION_FACTOR
-                )
-            except (OSError, ValueError):
-                estimated_memory = 0
+                with Image.open(path) as img:
+                    width, height = img.size
+                    # max_dimで縮小後のサイズを計算
+                    if max_dim is not None:
+                        scale = min(max_dim / max(width, height), 1.0)
+                        width = int(width * scale)
+                        height = int(height * scale)
+                    estimated_memory = int(
+                        width * height * BYTES_PER_PIXEL * SAFETY_FACTOR
+                    )
+            except Exception:
+                # 読み込み失敗時はデフォルト値（1MB相当）
+                estimated_memory = DEFAULT_MEMORY
 
             # チャンク追加でメモリ予算を超える場合は新規チャンクを検討
             would_exceed = current_memory + estimated_memory > max_memory_bytes
             has_min_images = current_count >= min_chunk_size
-            can_split = i > 0  # 最初の要素で分割しない
+            can_split = i > 0
 
             if would_exceed and has_min_images and can_split:
-                # 現在のチャンクを確定
                 chunks.append((current_start, i))
                 current_start = i
                 current_memory = estimated_memory
                 current_count = 1
             else:
-                # 現在のチャンクに追加
                 current_memory += estimated_memory
                 current_count += 1
 
         # 最後のチャンクを追加
         if current_start < len(paths):
             final_chunk = (current_start, len(paths))
-            # 最後のチャンクがmin_chunk_size未満で、前のチャンクがある場合はマージ
             if chunks and final_chunk[1] - final_chunk[0] < min_chunk_size:
-                # 前のチャンクとマージ
                 prev_start, _ = chunks.pop()
                 chunks.append((prev_start, final_chunk[1]))
             else:

--- a/src/analyzers/feature_extractor.py
+++ b/src/analyzers/feature_extractor.py
@@ -139,6 +139,10 @@ class FeatureExtractor:
             batch_start = i
             batch_end = min(i + current_batch_size, len(valid_images))
             batch = valid_images[batch_start:batch_end]
+            logger.debug(
+                f"CLIPバッチ処理: 位置{batch_start}-{batch_end}/{len(valid_images)} "
+                f"(バッチサイズ={current_batch_size})"
+            )
 
             try:
                 # GPU/CUDA/MPSの場合はautocastでfp16推論を使用（高速化）
@@ -198,7 +202,11 @@ class FeatureExtractor:
                         # 処理済みの結果は残すが、未処理の画像はNoneのまま
                         break
                 else:
-                    # OOM以外のRuntimeErrorはそのまま再raise
+                    # OOM以外のRuntimeErrorは詳細をログ出力して再raise
+                    logger.error(
+                        f"CLIP推論でRuntimeErrorが発生しました（OOM以外）: "
+                        f"{type(e).__name__}: {e}"
+                    )
                     raise
 
         return results

--- a/src/main.py
+++ b/src/main.py
@@ -178,6 +178,7 @@ class Main:
             "(デフォルト: 512、大きいほどチャンクが大きくなる）"
         ),
     )
+    @click.option("--debug", is_flag=True, help="デバッグログを有効化")
     @click.argument(
         "input", type=click.Path(exists=True, file_okay=False, dir_okay=True)
     )
@@ -191,6 +192,7 @@ class Main:
         result_max_workers: int | None,
         max_dim: int,
         max_memory_mb: int,
+        debug: bool,
         input: str,
         output: str,
     ) -> None:
@@ -201,35 +203,47 @@ class Main:
           game-screen-pick -n 15 ./screenshots ./output
           game-screen-pick -r -n 10 ./screenshots ./output
         """
-        # 入力フォルダのパスを検証
-        input_path = Path(input)
-        if not input_path.is_dir():
-            raise click.BadParameter(
-                f"指定パスはフォルダではありません: {input}", param_hint="input"
+        # デバッグモードの場合はログレベルをDEBUGに設定
+        if debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        try:
+            # 入力フォルダのパスを検証
+            input_path = Path(input)
+            if not input_path.is_dir():
+                raise click.BadParameter(
+                    f"指定パスはフォルダではありません: {input}", param_hint="input"
+                )
+
+            # 依存関係の遅延初期化
+            analyzer_config = AnalyzerConfig.from_cli_args(
+                result_max_workers=result_max_workers,
+                max_dim=max_dim,
+                max_memory_mb=max_memory_mb,
+            )
+            analyzer = ImageQualityAnalyzer(config=analyzer_config)
+
+            rng = random.Random(seed) if seed is not None else None
+
+            selection_config = SelectionConfig.from_cli_args(batch_size=batch_size)
+            picker = GameScreenPicker(analyzer, config=selection_config, rng=rng)
+
+            best, stats = picker.select(
+                str(input_path),
+                num,
+                similarity,
+                recursive,
             )
 
-        # 依存関係の遅延初期化
-        analyzer_config = AnalyzerConfig.from_cli_args(
-            result_max_workers=result_max_workers,
-            max_dim=max_dim,
-            max_memory_mb=max_memory_mb,
-        )
-        analyzer = ImageQualityAnalyzer(config=analyzer_config)
+            FileUtils.copy_selected_items(best, output)
+            ResultFormatter.display_results(best, stats)
 
-        rng = random.Random(seed) if seed is not None else None
+        except Exception as e:
+            import traceback
 
-        selection_config = SelectionConfig.from_cli_args(batch_size=batch_size)
-        picker = GameScreenPicker(analyzer, config=selection_config, rng=rng)
-
-        best, stats = picker.select(
-            str(input_path),
-            num,
-            similarity,
-            recursive,
-        )
-
-        FileUtils.copy_selected_items(best, output)
-        ResultFormatter.display_results(best, stats)
+            logger.error(f"予期しないエラーが発生しました: {type(e).__name__}: {e}")
+            logger.error(traceback.format_exc())
+            raise SystemExit(1) from None
 
     def run(self) -> None:
         """CLIを実行する.


### PR DESCRIPTION
## 概要

チャンク分割のメモリ見積もりロジックを改良し、デバッグ機能を強化しました。

## 変更内容

- **チャンク分割ロジックの改良**
  - ファイルサイズベースから画像解像度ベースのメモリ見積もりに変更
  - `max_dim`オプションで縮小後のサイズを考慮した正確な見積もりを実現
  - PIL画像を開いて実際の解像度から計算

- **デバッグログの追加**
  - チャンク処理、プリロード、CLIP推論の進捗を詳細に出力
  - RuntimeError（OOM以外）の詳細ログ出力を追加

- **CLIオプションの追加**
  - `--debug`フラグでデバッグログを有効化可能に
  - 例外発生時に詳細なエラー情報を出力