### PR TITLE
chore: PRワークフローに手動実行トリガーを追加し条件を修正

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,4 +1,4 @@
-_commit: 7e0a792
+_commit: 7086d9b
 _src_path: git@github.com:mizucopo/repo-template.git
 author_email: mizu.copo@gmail.com
 author_name: みず

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -2,6 +2,7 @@ name: PR Quality Checks
 
 on:
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -74,7 +75,7 @@ jobs:
           echo "result=$RESULT" >> $GITHUB_OUTPUT
 
       - name: Comment on PR
-        if: github.event.pull_request.head.repo.fork == false
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/pr-tag-check.yml
+++ b/.github/workflows/pr-tag-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -34,6 +35,7 @@ jobs:
           fi
 
       - name: Comment on PR
+        if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -45,7 +47,6 @@ jobs:
               "" \
               "Please update the version with a new version number before merging.")"
             gh pr comment "${{ github.event.pull_request.number }}" --body "$MESSAGE"
-            exit 1
           else
             MESSAGE="$(printf '%s\n' \
               "## Version Tag Check ✅" \
@@ -55,3 +56,7 @@ jobs:
               "This version is available for use.")"
             gh pr comment "${{ github.event.pull_request.number }}" --body "$MESSAGE"
           fi
+
+      - name: Fail if tag exists
+        if: steps.tag.outputs.exists == 'true'
+        run: exit 1


### PR DESCRIPTION
## Summary
PRワークフロー（品質チェック・タグチェック）に `workflow_dispatch` トリガーを追加し、手動実行を可能にしました。あわせて、PRイベント以外での実行時にエラーとならないよう条件を修正しました。

## Changes
- `pr-quality-checks.yml` / `pr-tag-check.yml` に `workflow_dispatch` トリガーを追加
- PRコメントステップの実行条件を `pull_request` イベントのみに限定
- タグチェックの失敗処理をコメント出力から独立したステップに分離
- テンプレートコミットハッシュを更新（`.copier-answers.yml`）