### PR TITLE
refactor: scene mix選定結果を専用モデルに集約

### DIFF
--- a/src/models/picker_statistics.py
+++ b/src/models/picker_statistics.py
@@ -1,7 +1,8 @@
 """ゲーム画面ピッカーの統計情報。"""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
+from .selection_annotation import SelectionAnnotation
 from .whole_input_profile import WholeInputProfile
 
 
@@ -23,6 +24,7 @@ class PickerStatistics:
         threshold_relaxation_steps: 類似度しきい値緩和ステップ
         content_filter_breakdown: content filter 除外理由ごとの件数
         whole_input_profile: 入力全体の明暗傾向プロフィール
+        selection_annotations_by_path: 候補パスごとのscene mix選定注釈
     """
 
     total_files: int
@@ -38,3 +40,6 @@ class PickerStatistics:
     threshold_relaxation_steps: list[float]
     content_filter_breakdown: dict[str, int]
     whole_input_profile: WholeInputProfile | None = None
+    selection_annotations_by_path: dict[str, SelectionAnnotation] = field(
+        default_factory=dict
+    )

--- a/src/models/scored_candidate.py
+++ b/src/models/scored_candidate.py
@@ -18,8 +18,6 @@ class ScoredCandidate:
     resolved_profile: str
     quality_score: float
     selection_score: float
-    score_band: str | None = None
-    outlier_rejected: bool = False
 
     @property
     def path(self) -> str:

--- a/src/models/selection_annotation.py
+++ b/src/models/selection_annotation.py
@@ -1,0 +1,11 @@
+"""候補ごとの選定注釈。"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SelectionAnnotation:
+    """scene mix 選定で候補へ付与される注釈."""
+
+    score_band: str | None = None
+    outlier_rejected: bool = False

--- a/src/models/selection_result.py
+++ b/src/models/selection_result.py
@@ -1,0 +1,21 @@
+"""scene mix 選定結果。"""
+
+from dataclasses import dataclass, field
+
+from .scored_candidate import ScoredCandidate
+from .selection_annotation import SelectionAnnotation
+
+
+@dataclass(frozen=True)
+class SelectionResult:
+    """scene mix 選定で得られる結果一式."""
+
+    selected: list[ScoredCandidate]
+    rejected_by_similarity: int
+    target_counts: dict[str, int]
+    actual_counts: dict[str, int]
+    annotations_by_path: dict[str, SelectionAnnotation] = field(default_factory=dict)
+
+    def annotation_for(self, candidate: ScoredCandidate) -> SelectionAnnotation:
+        """候補に対応する選定注釈を返す."""
+        return self.annotations_by_path.get(candidate.path, SelectionAnnotation())

--- a/src/services/game_screen_picker.py
+++ b/src/services/game_screen_picker.py
@@ -221,9 +221,8 @@ class GameScreenPicker:
         candidates, resolved_profile, scene_distribution = self._score_candidates(
             filtered_images
         )
-        selected, rejected_by_similarity, scene_mix_target, scene_mix_actual = (
-            self._scene_mix_selector.select(candidates, num)
-        )
+        selection_result = self._scene_mix_selector.select(candidates, num)
+        selected = selection_result.selected
         selected_paths = {candidate.path for candidate in selected}
         rejected = sorted(
             [
@@ -241,17 +240,18 @@ class GameScreenPicker:
             else len(analyzed_images),
             analyzed_ok=len(analyzed_images),
             analyzed_fail=analyzed_fail,
-            rejected_by_similarity=rejected_by_similarity,
+            rejected_by_similarity=selection_result.rejected_by_similarity,
             rejected_by_content_filter=content_filter_result.rejected_by_content_filter,
             selected_count=len(selected),
             resolved_profile=resolved_profile,
             scene_distribution=scene_distribution,
-            scene_mix_target=scene_mix_target,
-            scene_mix_actual=scene_mix_actual,
+            scene_mix_target=selection_result.target_counts,
+            scene_mix_actual=selection_result.actual_counts,
             threshold_relaxation_steps=self.config.compute_threshold_steps(
                 self.config.similarity_threshold
             ),
             content_filter_breakdown=content_filter_result.content_filter_breakdown,
             whole_input_profile=content_filter_result.whole_input_profile,
+            selection_annotations_by_path=selection_result.annotations_by_path,
         )
         return selected, rejected, stats

--- a/src/services/scene_mix_selector.py
+++ b/src/services/scene_mix_selector.py
@@ -8,7 +8,9 @@ import numpy as np
 from ..constants.scene_label import SceneLabel
 from ..models.bucket_plan import BucketPlan
 from ..models.scored_candidate import ScoredCandidate
+from ..models.selection_annotation import SelectionAnnotation
 from ..models.selection_config import SelectionConfig
+from ..models.selection_result import SelectionResult
 from ..utils.vector_utils import VectorUtils
 
 
@@ -33,13 +35,14 @@ class SceneMixSelector:
         self,
         candidates: list[ScoredCandidate],
         num: int,
-    ) -> tuple[list[ScoredCandidate], int, dict[str, int], dict[str, int]]:
+    ) -> SelectionResult:
         """比率に従って候補を選択する."""
         if num <= 0 or not candidates:
             empty_counts = {label.value: 0 for label in self.SCENE_ORDER}
-            return [], 0, empty_counts, empty_counts
+            return SelectionResult([], 0, empty_counts, empty_counts)
 
         targets = self._calculate_targets(num)
+        annotations_by_path: dict[str, SelectionAnnotation] = {}
         scene_buckets = {
             label: [
                 candidate
@@ -49,7 +52,11 @@ class SceneMixSelector:
             for label in self.SCENE_ORDER
         }
         bucket_plans = {
-            label: self._prepare_bucket(scene_buckets[label], targets[label])
+            label: self._prepare_bucket(
+                scene_buckets[label],
+                targets[label],
+                annotations_by_path,
+            )
             for label in self.SCENE_ORDER
         }
 
@@ -103,7 +110,13 @@ class SceneMixSelector:
         }
         target_map = {label.value: targets[label] for label in self.SCENE_ORDER}
         rejected_by_similarity = len(rejected_by_similarity_ids - selected_ids)
-        return selected[:num], rejected_by_similarity, target_map, actuals
+        return SelectionResult(
+            selected=selected[:num],
+            rejected_by_similarity=rejected_by_similarity,
+            target_counts=target_map,
+            actual_counts=actuals,
+            annotations_by_path=annotations_by_path,
+        )
 
     def _calculate_targets(self, num: int) -> dict[SceneLabel, int]:
         """scene mix 比率から目標枚数を計算する."""
@@ -113,24 +126,29 @@ class SceneMixSelector:
         self,
         candidates: list[ScoredCandidate],
         target: int,
+        annotations_by_path: dict[str, SelectionAnnotation],
     ) -> BucketPlan:
         """カテゴリ別の候補を band 分散選定向けに並べ替える."""
         if not candidates:
             return BucketPlan([], [])
 
-        for candidate in candidates:
-            candidate.outlier_rejected = False
-            candidate.score_band = None
-
-        eligible_candidates, outlier_candidates = self._exclude_outliers(candidates)
+        eligible_candidates, outlier_candidates = self._exclude_outliers(
+            candidates,
+            annotations_by_path,
+        )
         band_count = min(max(target, 1), 5)
-        band_queues = self._build_band_queues(eligible_candidates, band_count)
+        band_queues = self._build_band_queues(
+            eligible_candidates,
+            band_count,
+            annotations_by_path,
+        )
         ordered_candidates = self._round_robin_bands(band_queues)
         return BucketPlan(ordered_candidates, outlier_candidates)
 
     def _exclude_outliers(
         self,
         candidates: list[ScoredCandidate],
+        annotations_by_path: dict[str, SelectionAnnotation],
     ) -> tuple[list[ScoredCandidate], list[ScoredCandidate]]:
         """selection_score の外れ値を除外し、(適格候補, 外れ値候補) を返す."""
         if len(candidates) < self.MIN_OUTLIER_SAMPLES:
@@ -154,8 +172,10 @@ class SceneMixSelector:
             if lower <= score <= upper:
                 eligible_candidates.append(candidate)
             else:
-                candidate.outlier_rejected = True
-                candidate.score_band = "outlier"
+                annotations_by_path[candidate.path] = SelectionAnnotation(
+                    score_band="outlier",
+                    outlier_rejected=True,
+                )
                 outlier_candidates.append(candidate)
         return eligible_candidates, outlier_candidates
 
@@ -163,6 +183,7 @@ class SceneMixSelector:
         self,
         candidates: list[ScoredCandidate],
         band_count: int,
+        annotations_by_path: dict[str, SelectionAnnotation],
     ) -> list[deque[ScoredCandidate]]:
         """候補を score band ごとのキューに分ける."""
         if not candidates:
@@ -194,7 +215,10 @@ class SceneMixSelector:
                 ),
             )
             for candidate in ordered_band:
-                candidate.score_band = band_name
+                annotations_by_path[candidate.path] = SelectionAnnotation(
+                    score_band=band_name,
+                    outlier_rejected=False,
+                )
             band_queues.append(deque(ordered_band))
         return band_queues
 

--- a/src/utils/report_writer.py
+++ b/src/utils/report_writer.py
@@ -63,16 +63,7 @@ class ReportWriter:
         selection_annotation: SelectionAnnotation | None = None,
     ) -> dict[str, object]:
         """候補1件を辞書へ変換する."""
-        score_band = (
-            selection_annotation.score_band
-            if selection_annotation is not None
-            else None
-        )
-        outlier_rejected = (
-            selection_annotation.outlier_rejected
-            if selection_annotation is not None
-            else False
-        )
+        annotation = selection_annotation or SelectionAnnotation()
         payload: dict[str, object] = {
             "path": candidate.path,
             "scene_label": candidate.scene_assessment.scene_label.value,
@@ -82,8 +73,8 @@ class ReportWriter:
             "scene_confidence": round(candidate.scene_assessment.scene_confidence, 4),
             "quality_score": round(candidate.quality_score, 4),
             "selection_score": round(candidate.selection_score, 4),
-            "score_band": score_band,
-            "outlier_rejected": outlier_rejected,
+            "score_band": annotation.score_band,
+            "outlier_rejected": annotation.outlier_rejected,
         }
         if output_path is not None:
             payload["output_path"] = output_path

--- a/src/utils/report_writer.py
+++ b/src/utils/report_writer.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from ..models.metric_distribution import MetricDistribution
 from ..models.picker_statistics import PickerStatistics
 from ..models.scored_candidate import ScoredCandidate
+from ..models.selection_annotation import SelectionAnnotation
 
 
 class ReportWriter:
@@ -34,11 +35,18 @@ class ReportWriter:
                 ReportWriter._serialize_candidate(
                     candidate,
                     output_paths_by_candidate_id.get(candidate.path),
+                    stats.selection_annotations_by_path.get(candidate.path),
                 )
                 for candidate in selected
             ],
             "rejected": [
-                ReportWriter._serialize_candidate(candidate) for candidate in rejected
+                ReportWriter._serialize_candidate(
+                    candidate,
+                    selection_annotation=stats.selection_annotations_by_path.get(
+                        candidate.path
+                    ),
+                )
+                for candidate in rejected
             ],
         }
         report_path = Path(path)
@@ -52,8 +60,19 @@ class ReportWriter:
     def _serialize_candidate(
         candidate: ScoredCandidate,
         output_path: str | None = None,
+        selection_annotation: SelectionAnnotation | None = None,
     ) -> dict[str, object]:
         """候補1件を辞書へ変換する."""
+        score_band = (
+            selection_annotation.score_band
+            if selection_annotation is not None
+            else None
+        )
+        outlier_rejected = (
+            selection_annotation.outlier_rejected
+            if selection_annotation is not None
+            else False
+        )
         payload: dict[str, object] = {
             "path": candidate.path,
             "scene_label": candidate.scene_assessment.scene_label.value,
@@ -63,8 +82,8 @@ class ReportWriter:
             "scene_confidence": round(candidate.scene_assessment.scene_confidence, 4),
             "quality_score": round(candidate.quality_score, 4),
             "selection_score": round(candidate.selection_score, 4),
-            "score_band": candidate.score_band,
-            "outlier_rejected": candidate.outlier_rejected,
+            "score_band": score_band,
+            "outlier_rejected": outlier_rejected,
         }
         if output_path is not None:
             payload["output_path"] = output_path

--- a/src/utils/result_formatter.py
+++ b/src/utils/result_formatter.py
@@ -19,10 +19,12 @@ class ResultFormatter:
         """選択結果を表示する."""
         logger.info("--- 選択された画像一覧 ---")
         for i, res in enumerate(selected):
+            annotation = stats.selection_annotations_by_path.get(res.path)
+            score_band = annotation.score_band if annotation is not None else None
             logger.info(
                 f"[{i + 1}] {Path(res.path).name} "
                 f"(カテゴリ: {res.scene_assessment.scene_label.value}, "
-                f"band: {res.score_band}, "
+                f"band: {score_band}, "
                 f"play: {res.scene_assessment.play_score:.3f}, "
                 f"event: {res.scene_assessment.event_score:.3f}, "
                 f"density: {res.scene_assessment.density_score:.3f})"

--- a/src/utils/result_formatter.py
+++ b/src/utils/result_formatter.py
@@ -14,7 +14,7 @@ class ResultFormatter:
 
     @staticmethod
     def display_results(
-        selected: list["ScoredCandidate"], stats: "PickerStatistics"
+        selected: list[ScoredCandidate], stats: PickerStatistics
     ) -> None:
         """選択結果を表示する."""
         logger.info("--- 選択された画像一覧 ---")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,8 +163,6 @@ def create_scored_candidate(
     selection_score: float = 0.6,
     resolved_profile: str = "active",
     combined_features: np.ndarray[Any, Any] | None = None,
-    score_band: str | None = None,
-    outlier_rejected: bool = False,
 ) -> ScoredCandidate:
     """`ScoredCandidate` を作成する共通ヘルパー.
 
@@ -179,9 +177,6 @@ def create_scored_candidate(
         selection_score: 最終選定スコア。
         resolved_profile: 解決済みプロファイル名。
         combined_features: 類似度判定用の結合特徴。
-        score_band: スコアバンド。
-        outlier_rejected: 外れ値除外フラグ。
-
     Returns:
         scene 判定とスコアが付与済みの `ScoredCandidate` 。
     """
@@ -202,8 +197,6 @@ def create_scored_candidate(
         resolved_profile=resolved_profile,
         quality_score=quality_score,
         selection_score=selection_score,
-        score_band=score_band,
-        outlier_rejected=outlier_rejected,
     )
 
 

--- a/tests/services/test_scene_mix_selector.py
+++ b/tests/services/test_scene_mix_selector.py
@@ -51,12 +51,12 @@ def test_scene_mix_selector_respects_play_event_ratio() -> None:
     ]
 
     # Act
-    selected, _, targets, actuals = selector.select(candidates, 10)
+    result = selector.select(candidates, 10)
 
     # Assert
-    assert len(selected) == 10
-    assert targets == {"play": 7, "event": 3}
-    assert actuals == {"play": 7, "event": 3}
+    assert len(result.selected) == 10
+    assert result.target_counts == {"play": 7, "event": 3}
+    assert result.actual_counts == {"play": 7, "event": 3}
 
 
 def test_scene_mix_selector_keeps_similar_candidates_out_globally() -> None:
@@ -99,19 +99,19 @@ def test_scene_mix_selector_keeps_similar_candidates_out_globally() -> None:
     ]
 
     # Act
-    selected, rejected, _, actuals = selector.select(candidates, 2)
+    result = selector.select(candidates, 2)
 
     # Assert
-    assert [candidate.path for candidate in selected] == [
+    assert [candidate.path for candidate in result.selected] == [
         "/tmp/play_a.jpg",
         "/tmp/event_far.jpg",
     ]
-    assert rejected == 1
-    assert actuals == {"play": 1, "event": 1}
+    assert result.rejected_by_similarity == 1
+    assert result.actual_counts == {"play": 1, "event": 1}
 
 
-def test_scene_mix_selector_assigns_score_bands() -> None:
-    """選択候補へ score_band が設定されること.
+def test_scene_mix_selector_returns_score_bands_as_annotations() -> None:
+    """選択候補のscore_bandが注釈として返されること.
 
     Arrange:
         - 異なるselection_scoreを持つ5件のplay候補がある
@@ -119,7 +119,7 @@ def test_scene_mix_selector_assigns_score_bands() -> None:
     Act:
         - 5件を選択する
     Assert:
-        - 各候補にlow/mid_low/mid/mid_high/highのscore_bandが設定されること
+        - 各候補の注釈にlow/mid_low/mid/mid_high/highのscore_bandが返されること
     """
     # Arrange
     selector = SceneMixSelector(
@@ -139,16 +139,78 @@ def test_scene_mix_selector_assigns_score_bands() -> None:
     ]
 
     # Act
-    selected, _, _, _ = selector.select(candidates, 5)
+    result = selector.select(candidates, 5)
 
     # Assert
-    assert {candidate.score_band for candidate in selected} == {
+    assert {
+        result.annotation_for(candidate).score_band for candidate in result.selected
+    } == {
         "low",
         "mid_low",
         "mid",
         "mid_high",
         "high",
     }
+
+
+def test_scene_mix_selector_returns_annotations_without_mutating_candidates() -> None:
+    """選定注釈が結果として返され候補が変更されないこと.
+
+    Arrange:
+        - 異なるselection_scoreを持つ5件のplay候補がある
+        - scene_mix比率が100/0に設定されている
+    Act:
+        - 5件を選択する
+    Assert:
+        - 選定結果にscore_band注釈が含まれること
+        - 元候補にscore_band属性が追加されないこと
+    """
+    # Arrange
+    selector = SceneMixSelector(
+        SelectionConfig(scene_mix=SceneMix(play=1.0, event=0.0))
+    )
+    candidates = [
+        create_scored_candidate(
+            path=f"/tmp/play_result_{index}.jpg",
+            scene_label=SceneLabel.PLAY,
+            selection_score=score,
+            play_score=score,
+            event_score=1.0 - score,
+            density_score=score,
+            combined_features=_feature(index),
+        )
+        for index, score in enumerate([0.1, 0.3, 0.5, 0.7, 0.9])
+    ]
+
+    # Act
+    result = selector.select(candidates, 5)
+
+    # Assert
+    assert [candidate.path for candidate in result.selected] == [
+        "/tmp/play_result_0.jpg",
+        "/tmp/play_result_1.jpg",
+        "/tmp/play_result_2.jpg",
+        "/tmp/play_result_3.jpg",
+        "/tmp/play_result_4.jpg",
+    ]
+    assert result.target_counts == {"play": 5, "event": 0}
+    assert result.actual_counts == {"play": 5, "event": 0}
+    assert result.rejected_by_similarity == 0
+    assert {
+        result.annotation_for(candidate).score_band for candidate in result.selected
+    } == {
+        "low",
+        "mid_low",
+        "mid",
+        "mid_high",
+        "high",
+    }
+    assert all(
+        result.annotation_for(candidate).score_band is not None
+        for candidate in candidates
+    )
+    assert all(not hasattr(candidate, "score_band") for candidate in candidates)
+    assert all(not hasattr(candidate, "outlier_rejected") for candidate in candidates)
 
 
 def test_scene_mix_selector_fallback_includes_outliers() -> None:
@@ -197,11 +259,17 @@ def test_scene_mix_selector_fallback_includes_outliers() -> None:
     ]
 
     # Act
-    selected, _, targets, actuals = selector.select(candidates, 4)
+    result = selector.select(candidates, 4)
 
     # Assert
-    assert len(selected) == 4, "4件全てが選ばれること"
-    assert targets == {"play": 4, "event": 0}
-    assert actuals == {"play": 4, "event": 0}, "targetsとactualsが一致すること"
-    assert selected[-1].path == "/tmp/play_outlier.jpg", "外れ値が最後に選ばれること"
-    assert selected[-1].score_band == "outlier", "外れ値のscore_bandが保持されること"
+    assert len(result.selected) == 4, "4件全てが選ばれること"
+    assert result.target_counts == {"play": 4, "event": 0}
+    assert result.actual_counts == {"play": 4, "event": 0}, (
+        "targetsとactualsが一致すること"
+    )
+    assert result.selected[-1].path == "/tmp/play_outlier.jpg", (
+        "外れ値が最後に選ばれること"
+    )
+    assert result.annotation_for(result.selected[-1]).score_band == "outlier", (
+        "外れ値のscore_bandが保持されること"
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,6 +10,7 @@ import pytest
 from src.constants.scene_label import SceneLabel
 from src.main import build_selection_config, run, validate_similarity_range
 from src.models.picker_statistics import PickerStatistics
+from src.models.selection_annotation import SelectionAnnotation
 from src.services.game_screen_picker import GameScreenPicker
 from tests.conftest import create_scored_candidate
 
@@ -124,7 +125,8 @@ def test_cli_writes_report_json_with_new_fields(
 
     Arrange:
         - 入力ディレクトリに1件の画像がある
-        - 選択結果にplay_score/event_score/density_score/score_bandが含まれる
+        - 選択結果にplay_score/event_score/density_scoreが含まれる
+        - 統計情報にscore_bandの選定注釈が含まれる
         - --report-jsonオプションが指定されている
     Act:
         - CLIを実行する
@@ -146,7 +148,6 @@ def test_cli_writes_report_json_with_new_fields(
             event_score=0.2,
             density_score=0.8,
             selection_score=0.8,
-            score_band="high",
         )
     ]
     stats = PickerStatistics(
@@ -167,6 +168,9 @@ def test_cli_writes_report_json_with_new_fields(
             "single_tone": 0,
             "fade_transition": 0,
             "temporal_transition": 0,
+        },
+        selection_annotations_by_path={
+            str(source): SelectionAnnotation(score_band="high")
         },
     )
     mock_game_screen_picker.select.return_value = (results, [], stats)

--- a/tests/utils/test_report_writer.py
+++ b/tests/utils/test_report_writer.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from src.constants.scene_label import SceneLabel
 from src.models.picker_statistics import PickerStatistics
+from src.models.selection_annotation import SelectionAnnotation
 from src.utils.report_writer import ReportWriter
 from tests.conftest import (
     build_whole_input_profile,
@@ -71,8 +72,8 @@ def test_report_writer_serializes_play_event_fields(tmp_path: Path) -> None:
     """play/eventフィールドが正しくシリアライズされること.
 
     Arrange:
-        - play候補にplay_score/event_score/density_score/score_bandが設定されている
-        - event候補にoutlier_rejectedがTrueで設定されている
+        - play候補にplay_score/event_score/density_scoreが設定されている
+        - 統計情報にscore_band/outlier_rejectedの選定注釈がある
         - 統計情報にscene_distribution/scene_mix_targetがある
     Act:
         - ReportWriterでJSONレポートを出力する
@@ -91,7 +92,6 @@ def test_report_writer_serializes_play_event_fields(tmp_path: Path) -> None:
             event_score=0.2,
             density_score=0.8,
             selection_score=0.8,
-            score_band="high",
         )
     ]
     rejected = [
@@ -102,17 +102,23 @@ def test_report_writer_serializes_play_event_fields(tmp_path: Path) -> None:
             event_score=0.8,
             density_score=0.2,
             selection_score=0.8,
-            score_band="low",
-            outlier_rejected=True,
         )
     ]
+    stats = _build_stats()
+    stats.selection_annotations_by_path = {
+        selected[0].path: SelectionAnnotation(score_band="high"),
+        rejected[0].path: SelectionAnnotation(
+            score_band="low",
+            outlier_rejected=True,
+        ),
+    }
 
     # Act
     ReportWriter.write(
         path=str(report_path),
         selected=selected,
         rejected=rejected,
-        stats=_build_stats(),
+        stats=stats,
         output_paths_by_candidate_id={
             selected[0].path: "/tmp/output/play0001.jpg",
         },
@@ -127,6 +133,48 @@ def test_report_writer_serializes_play_event_fields(tmp_path: Path) -> None:
     assert payload["selected"][0]["density_score"] == 0.8
     assert payload["selected"][0]["score_band"] == "high"
     assert payload["selected"][0]["output_path"] == "/tmp/output/play0001.jpg"
+    assert payload["rejected"][0]["outlier_rejected"] is True
+
+
+def test_report_writer_serializes_selection_annotations_from_stats(
+    tmp_path: Path,
+) -> None:
+    """選定注釈が統計情報からJSONへ出力されること.
+
+    Arrange:
+        - 候補にはscore_band/outlier_rejectedが設定されていない
+        - 統計情報に候補パスごとの選定注釈がある
+    Act:
+        - ReportWriterでJSONレポートを出力する
+    Assert:
+        - score_bandとoutlier_rejectedが選定注釈から出力されること
+    """
+    # Arrange
+    report_path = tmp_path / "report.json"
+    selected = [create_scored_candidate(path="/tmp/annotated_play.jpg")]
+    rejected = [create_scored_candidate(path="/tmp/annotated_event.jpg")]
+    stats = _build_stats()
+    stats.selection_annotations_by_path = {
+        "/tmp/annotated_play.jpg": SelectionAnnotation(score_band="high"),
+        "/tmp/annotated_event.jpg": SelectionAnnotation(
+            score_band="outlier",
+            outlier_rejected=True,
+        ),
+    }
+
+    # Act
+    ReportWriter.write(
+        path=str(report_path),
+        selected=selected,
+        rejected=rejected,
+        stats=stats,
+    )
+
+    # Assert
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["selected"][0]["score_band"] == "high"
+    assert payload["selected"][0]["outlier_rejected"] is False
+    assert payload["rejected"][0]["score_band"] == "outlier"
     assert payload["rejected"][0]["outlier_rejected"] is True
 
 

--- a/tests/utils/test_result_formatter.py
+++ b/tests/utils/test_result_formatter.py
@@ -4,6 +4,7 @@ from io import StringIO
 from unittest.mock import patch
 
 from src.models.picker_statistics import PickerStatistics
+from src.models.selection_annotation import SelectionAnnotation
 from src.utils.result_formatter import ResultFormatter
 from tests.conftest import create_scored_candidate
 
@@ -42,3 +43,44 @@ def test_display_results_runs_without_error() -> None:
         ResultFormatter.display_results([candidate], stats)
 
     # Assert — 例外なく完了すればOK
+
+
+def test_display_results_uses_selection_annotations_from_stats() -> None:
+    """選定注釈のscore_bandが表示に使われること.
+
+    Arrange:
+        - 候補にはscore_bandが設定されていない
+        - 統計情報に候補パスごとの選定注釈がある
+    Act:
+        - display_resultsが実行される
+    Assert:
+        - 表示ログに選定注釈のscore_bandが含まれること
+    """
+    # Arrange
+    candidate = create_scored_candidate(path="/tmp/test_image.jpg")
+    stats = PickerStatistics(
+        total_files=1,
+        analyzed_ok=1,
+        analyzed_fail=0,
+        rejected_by_similarity=0,
+        rejected_by_content_filter=0,
+        selected_count=1,
+        resolved_profile="active",
+        scene_distribution={"play": 1, "event": 0},
+        scene_mix_target={"play": 1, "event": 0},
+        scene_mix_actual={"play": 1, "event": 0},
+        threshold_relaxation_steps=[0.7],
+        content_filter_breakdown={},
+        whole_input_profile=None,
+        selection_annotations_by_path={
+            candidate.path: SelectionAnnotation(score_band="high")
+        },
+    )
+
+    # Act
+    with patch("src.utils.result_formatter.logger") as logger:
+        ResultFormatter.display_results([candidate], stats)
+
+    # Assert
+    messages = [call.args[0] for call in logger.info.call_args_list]
+    assert any("band: high" in message for message in messages)


### PR DESCRIPTION
## Summary

- `SceneMixSelector.select()` の戻り値を `SelectionResult` に変更し、選定結果・類似除外数・scene mix 目標/実績・候補ごとの選定注釈を集約しました。
- `score_band` / `outlier_rejected` を `ScoredCandidate` から切り離し、`SelectionAnnotation` として統計・レポート・表示へ受け渡すようにしました。
- scene mix 選定、picker、JSONレポート、表示のテストを新しい選定結果インターフェースに合わせて更新しました。

## Verification

- `uv run task test`
  - `104 passed`

## Notes

- User-facing behavior and JSON field names are preserved.
- Related issue: #116
