### PR TITLE
refactor: scene mix選定候補の依存を分離

### DIFF
--- a/src/models/bucket_plan.py
+++ b/src/models/bucket_plan.py
@@ -1,11 +1,9 @@
 """カテゴリ別の選定準備結果."""
 
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import Generic
 
-from .scene_mix_candidate import SceneMixCandidate
-
-SceneMixCandidateT = TypeVar("SceneMixCandidateT", bound=SceneMixCandidate)
+from .scene_mix_candidate import SceneMixCandidateT
 
 
 @dataclass

--- a/src/models/bucket_plan.py
+++ b/src/models/bucket_plan.py
@@ -1,13 +1,16 @@
 """カテゴリ別の選定準備結果."""
 
 from dataclasses import dataclass
+from typing import Generic, TypeVar
 
-from .scored_candidate import ScoredCandidate
+from .scene_mix_candidate import SceneMixCandidate
+
+SceneMixCandidateT = TypeVar("SceneMixCandidateT", bound=SceneMixCandidate)
 
 
 @dataclass
-class BucketPlan:
+class BucketPlan(Generic[SceneMixCandidateT]):
     """カテゴリ別の選定準備結果."""
 
-    ordered_candidates: list[ScoredCandidate]
-    leftovers: list[ScoredCandidate]
+    ordered_candidates: list[SceneMixCandidateT]
+    leftovers: list[SceneMixCandidateT]

--- a/src/models/scene_mix_candidate.py
+++ b/src/models/scene_mix_candidate.py
@@ -1,6 +1,6 @@
 """scene mix 選定が参照する候補インターフェース。"""
 
-from typing import Any, Protocol
+from typing import Any, Protocol, TypeVar
 
 import numpy as np
 
@@ -34,3 +34,6 @@ class SceneMixCandidate(Protocol):
     def combined_features(self) -> np.ndarray[Any, Any]:
         """類似度判定に使う結合特徴を返す."""
         ...
+
+
+SceneMixCandidateT = TypeVar("SceneMixCandidateT", bound=SceneMixCandidate)

--- a/src/models/scene_mix_candidate.py
+++ b/src/models/scene_mix_candidate.py
@@ -1,0 +1,36 @@
+"""scene mix 選定が参照する候補インターフェース。"""
+
+from typing import Any, Protocol
+
+import numpy as np
+
+from ..constants.scene_label import SceneLabel
+
+
+class SceneMixCandidate(Protocol):
+    """scene mix 選定に必要な候補情報."""
+
+    @property
+    def path(self) -> str:
+        """元画像パスを返す."""
+        ...
+
+    @property
+    def scene_label(self) -> SceneLabel:
+        """scene mix 分類を返す."""
+        ...
+
+    @property
+    def quality_score(self) -> float:
+        """同一 score band 内の優先度を返す."""
+        ...
+
+    @property
+    def selection_score(self) -> float:
+        """score band 分割に使う選定スコアを返す."""
+        ...
+
+    @property
+    def combined_features(self) -> np.ndarray[Any, Any]:
+        """類似度判定に使う結合特徴を返す."""
+        ...

--- a/src/models/scored_candidate.py
+++ b/src/models/scored_candidate.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import numpy as np
 
+from ..constants.scene_label import SceneLabel
 from .analyzed_image import AnalyzedImage
 from .scene_assessment import SceneAssessment
 
@@ -23,6 +24,11 @@ class ScoredCandidate:
     def path(self) -> str:
         """元画像パスを返す."""
         return self.analyzed_image.path
+
+    @property
+    def scene_label(self) -> SceneLabel:
+        """scene mix 選定に使う画面種別を返す."""
+        return self.scene_assessment.scene_label
 
     @property
     def combined_features(self) -> np.ndarray[Any, Any]:

--- a/src/models/selection_result.py
+++ b/src/models/selection_result.py
@@ -1,21 +1,24 @@
 """scene mix 選定結果。"""
 
 from dataclasses import dataclass, field
+from typing import Generic, TypeVar
 
-from .scored_candidate import ScoredCandidate
+from .scene_mix_candidate import SceneMixCandidate
 from .selection_annotation import SelectionAnnotation
+
+SceneMixCandidateT = TypeVar("SceneMixCandidateT", bound=SceneMixCandidate)
 
 
 @dataclass(frozen=True)
-class SelectionResult:
+class SelectionResult(Generic[SceneMixCandidateT]):
     """scene mix 選定で得られる結果一式."""
 
-    selected: list[ScoredCandidate]
+    selected: list[SceneMixCandidateT]
     rejected_by_similarity: int
     target_counts: dict[str, int]
     actual_counts: dict[str, int]
     annotations_by_path: dict[str, SelectionAnnotation] = field(default_factory=dict)
 
-    def annotation_for(self, candidate: ScoredCandidate) -> SelectionAnnotation:
+    def annotation_for(self, candidate: SceneMixCandidate) -> SelectionAnnotation:
         """候補に対応する選定注釈を返す."""
         return self.annotations_by_path.get(candidate.path, SelectionAnnotation())

--- a/src/models/selection_result.py
+++ b/src/models/selection_result.py
@@ -1,12 +1,10 @@
 """scene mix 選定結果。"""
 
 from dataclasses import dataclass, field
-from typing import Generic, TypeVar
+from typing import Generic
 
-from .scene_mix_candidate import SceneMixCandidate
+from .scene_mix_candidate import SceneMixCandidate, SceneMixCandidateT
 from .selection_annotation import SelectionAnnotation
-
-SceneMixCandidateT = TypeVar("SceneMixCandidateT", bound=SceneMixCandidate)
 
 
 @dataclass(frozen=True)

--- a/src/services/scene_mix_selector.py
+++ b/src/services/scene_mix_selector.py
@@ -2,19 +2,17 @@
 
 from collections import deque
 from collections.abc import Sequence
-from typing import Any, TypeVar
+from typing import Any
 
 import numpy as np
 
 from ..constants.scene_label import SceneLabel
 from ..models.bucket_plan import BucketPlan
-from ..models.scene_mix_candidate import SceneMixCandidate
+from ..models.scene_mix_candidate import SceneMixCandidateT
 from ..models.selection_annotation import SelectionAnnotation
 from ..models.selection_config import SelectionConfig
 from ..models.selection_result import SelectionResult
 from ..utils.vector_utils import VectorUtils
-
-SceneMixCandidateT = TypeVar("SceneMixCandidateT", bound=SceneMixCandidate)
 
 
 class SceneMixSelector:
@@ -201,14 +199,13 @@ class SceneMixSelector:
         band_names = self.BAND_LABELS[band_count]
         band_queues: list[deque[SceneMixCandidateT]] = []
         for band_name, group in zip(band_names, groups, strict=True):
-            group_candidates = list(group)
-            if not group_candidates:
+            if not group:
                 continue
             band_center = float(
-                np.mean([candidate.selection_score for candidate in group_candidates])
+                np.mean([candidate.selection_score for candidate in group])
             )
             ordered_band = sorted(
-                group_candidates,
+                group,
                 key=lambda candidate: (
                     -candidate.quality_score,
                     abs(candidate.selection_score - band_center),

--- a/src/services/scene_mix_selector.py
+++ b/src/services/scene_mix_selector.py
@@ -1,17 +1,20 @@
 """scene mix と全体多様性を両立する選定ロジック."""
 
 from collections import deque
-from typing import Any
+from collections.abc import Sequence
+from typing import Any, TypeVar
 
 import numpy as np
 
 from ..constants.scene_label import SceneLabel
 from ..models.bucket_plan import BucketPlan
-from ..models.scored_candidate import ScoredCandidate
+from ..models.scene_mix_candidate import SceneMixCandidate
 from ..models.selection_annotation import SelectionAnnotation
 from ..models.selection_config import SelectionConfig
 from ..models.selection_result import SelectionResult
 from ..utils.vector_utils import VectorUtils
+
+SceneMixCandidateT = TypeVar("SceneMixCandidateT", bound=SceneMixCandidate)
 
 
 class SceneMixSelector:
@@ -33,21 +36,21 @@ class SceneMixSelector:
 
     def select(
         self,
-        candidates: list[ScoredCandidate],
+        candidates: Sequence[SceneMixCandidateT],
         num: int,
-    ) -> SelectionResult:
+    ) -> SelectionResult[SceneMixCandidateT]:
         """比率に従って候補を選択する."""
         if num <= 0 or not candidates:
             empty_counts = {label.value: 0 for label in self.SCENE_ORDER}
-            return SelectionResult([], 0, empty_counts, empty_counts)
+            return SelectionResult[SceneMixCandidateT](
+                [], 0, empty_counts, empty_counts
+            )
 
         targets = self._calculate_targets(num)
         annotations_by_path: dict[str, SelectionAnnotation] = {}
         scene_buckets = {
             label: [
-                candidate
-                for candidate in candidates
-                if candidate.scene_assessment.scene_label == label
+                candidate for candidate in candidates if candidate.scene_label == label
             ]
             for label in self.SCENE_ORDER
         }
@@ -60,7 +63,7 @@ class SceneMixSelector:
             for label in self.SCENE_ORDER
         }
 
-        selected: list[ScoredCandidate] = []
+        selected: list[SceneMixCandidateT] = []
         selected_ids: set[int] = set()
         selected_features: list[np.ndarray[Any, Any]] = []
         rejected_by_similarity_ids: set[int] = set()
@@ -102,9 +105,7 @@ class SceneMixSelector:
 
         actuals = {
             label.value: sum(
-                1
-                for candidate in selected
-                if candidate.scene_assessment.scene_label == label
+                1 for candidate in selected if candidate.scene_label == label
             )
             for label in self.SCENE_ORDER
         }
@@ -124,13 +125,13 @@ class SceneMixSelector:
 
     def _prepare_bucket(
         self,
-        candidates: list[ScoredCandidate],
+        candidates: list[SceneMixCandidateT],
         target: int,
         annotations_by_path: dict[str, SelectionAnnotation],
-    ) -> BucketPlan:
+    ) -> BucketPlan[SceneMixCandidateT]:
         """カテゴリ別の候補を band 分散選定向けに並べ替える."""
         if not candidates:
-            return BucketPlan([], [])
+            return BucketPlan[SceneMixCandidateT]([], [])
 
         eligible_candidates, outlier_candidates = self._exclude_outliers(
             candidates,
@@ -147,9 +148,9 @@ class SceneMixSelector:
 
     def _exclude_outliers(
         self,
-        candidates: list[ScoredCandidate],
+        candidates: list[SceneMixCandidateT],
         annotations_by_path: dict[str, SelectionAnnotation],
-    ) -> tuple[list[ScoredCandidate], list[ScoredCandidate]]:
+    ) -> tuple[list[SceneMixCandidateT], list[SceneMixCandidateT]]:
         """selection_score の外れ値を除外し、(適格候補, 外れ値候補) を返す."""
         if len(candidates) < self.MIN_OUTLIER_SAMPLES:
             return list(candidates), []
@@ -165,8 +166,8 @@ class SceneMixSelector:
 
         lower = float(q1 - 1.5 * iqr)
         upper = float(q3 + 1.5 * iqr)
-        eligible_candidates: list[ScoredCandidate] = []
-        outlier_candidates: list[ScoredCandidate] = []
+        eligible_candidates: list[SceneMixCandidateT] = []
+        outlier_candidates: list[SceneMixCandidateT] = []
         for candidate in candidates:
             score = candidate.selection_score
             if lower <= score <= upper:
@@ -181,16 +182,16 @@ class SceneMixSelector:
 
     def _build_band_queues(
         self,
-        candidates: list[ScoredCandidate],
+        candidates: list[SceneMixCandidateT],
         band_count: int,
         annotations_by_path: dict[str, SelectionAnnotation],
-    ) -> list[deque[ScoredCandidate]]:
+    ) -> list[deque[SceneMixCandidateT]]:
         """候補を score band ごとのキューに分ける."""
         if not candidates:
             return []
 
         ordered = sorted(candidates, key=lambda item: item.selection_score)
-        groups: list[list[ScoredCandidate]] = []
+        groups: list[list[SceneMixCandidateT]] = []
         base_size, remainder = divmod(len(ordered), band_count)
         start = 0
         for band_index in range(band_count):
@@ -198,7 +199,7 @@ class SceneMixSelector:
             groups.append(ordered[start : start + size])
             start += size
         band_names = self.BAND_LABELS[band_count]
-        band_queues: list[deque[ScoredCandidate]] = []
+        band_queues: list[deque[SceneMixCandidateT]] = []
         for band_name, group in zip(band_names, groups, strict=True):
             group_candidates = list(group)
             if not group_candidates:
@@ -224,13 +225,13 @@ class SceneMixSelector:
 
     @staticmethod
     def _round_robin_bands(
-        band_queues: list[deque[ScoredCandidate]],
-    ) -> list[ScoredCandidate]:
+        band_queues: list[deque[SceneMixCandidateT]],
+    ) -> list[SceneMixCandidateT]:
         """低 band から高 band へ均等に辿る順序を作る."""
         if not band_queues:
             return []
 
-        ordered: list[ScoredCandidate] = []
+        ordered: list[SceneMixCandidateT] = []
         queues = [deque(queue) for queue in band_queues]
         while any(queues):
             for queue in queues:
@@ -240,11 +241,11 @@ class SceneMixSelector:
 
     def _build_fallback_stream(
         self,
-        leftovers_by_label: list[list[ScoredCandidate]],
-    ) -> list[ScoredCandidate]:
+        leftovers_by_label: list[list[SceneMixCandidateT]],
+    ) -> list[SceneMixCandidateT]:
         """不足分を補うための共通ストリームを組み立てる."""
         streams = [deque(candidates) for candidates in leftovers_by_label if candidates]
-        ordered: list[ScoredCandidate] = []
+        ordered: list[SceneMixCandidateT] = []
         while any(streams):
             for stream in streams:
                 if stream:
@@ -253,11 +254,11 @@ class SceneMixSelector:
 
     def _select_from_stream(
         self,
-        ordered_candidates: list[ScoredCandidate],
+        ordered_candidates: list[SceneMixCandidateT],
         target: int,
         selected_ids: set[int],
         selected_features: list[np.ndarray[Any, Any]],
-    ) -> tuple[list[ScoredCandidate], set[int], list[ScoredCandidate]]:
+    ) -> tuple[list[SceneMixCandidateT], set[int], list[SceneMixCandidateT]]:
         """順序付け済みストリームから類似度を見ながら採用する."""
         if target <= 0 or not ordered_candidates:
             return [], set(), list(ordered_candidates)
@@ -293,10 +294,10 @@ class SceneMixSelector:
 
     @staticmethod
     def _extend_selection(
-        selected: list[ScoredCandidate],
+        selected: list[SceneMixCandidateT],
         selected_ids: set[int],
         selected_features: list[np.ndarray[Any, Any]],
-        additions: list[ScoredCandidate],
+        additions: list[SceneMixCandidateT],
     ) -> None:
         """選択結果と全体類似度チェック用の状態をまとめて更新する."""
         selected.extend(additions)

--- a/tests/services/test_scene_mix_selector.py
+++ b/tests/services/test_scene_mix_selector.py
@@ -1,5 +1,7 @@
 """SceneMixSelectorの単体テスト."""
 
+from types import SimpleNamespace
+
 from src.constants.scene_label import SceneLabel
 from src.models.scene_mix import SceneMix
 from src.models.selection_config import SelectionConfig
@@ -57,6 +59,54 @@ def test_scene_mix_selector_respects_play_event_ratio() -> None:
     assert len(result.selected) == 10
     assert result.target_counts == {"play": 7, "event": 3}
     assert result.actual_counts == {"play": 7, "event": 3}
+
+
+def test_scene_mix_selector_accepts_scene_mix_candidate_seam() -> None:
+    """scene mix選定に必要な候補情報だけで選定されること.
+
+    Arrange:
+        - full domain graphを持たないplay候補とevent候補がある
+        - scene_mix比率が50/50に設定されている
+    Act:
+        - 2件を選択する
+    Assert:
+        - playとeventが1件ずつ選ばれること
+        - score_band注釈が返されること
+    """
+    # Arrange
+    selector = SceneMixSelector(
+        SelectionConfig(scene_mix=SceneMix(play=0.5, event=0.5))
+    )
+    candidates = [
+        SimpleNamespace(
+            path="/tmp/play_seam.jpg",
+            scene_label=SceneLabel.PLAY,
+            quality_score=0.9,
+            selection_score=0.2,
+            combined_features=_feature(0),
+        ),
+        SimpleNamespace(
+            path="/tmp/event_seam.jpg",
+            scene_label=SceneLabel.EVENT,
+            quality_score=0.8,
+            selection_score=0.7,
+            combined_features=_feature(1),
+        ),
+    ]
+
+    # Act
+    result = selector.select(candidates, 2)
+
+    # Assert
+    assert [candidate.path for candidate in result.selected] == [
+        "/tmp/play_seam.jpg",
+        "/tmp/event_seam.jpg",
+    ]
+    assert result.target_counts == {"play": 1, "event": 1}
+    assert result.actual_counts == {"play": 1, "event": 1}
+    assert {
+        result.annotation_for(candidate).score_band for candidate in result.selected
+    } == {"mid"}
 
 
 def test_scene_mix_selector_keeps_similar_candidates_out_globally() -> None:


### PR DESCRIPTION
## Summary
- `SceneMixCandidate` Protocol を導入し、`SceneMixSelector` が `ScoredCandidate` 全体ではなく選定に必要な候補情報へ依存するように変更
- `SelectionResult` と `BucketPlan` を候補型に対して generic 化し、既存の `ScoredCandidate` 呼び出しの型を維持
- full domain graph を持たない候補で scene mix 選定できることをテストで追加検証

## Verification
- `uv run pytest tests/services/test_scene_mix_selector.py -q`
- `uv run task test` (`105 passed`)

Closes #118