### PR TITLE
feat: copy/report/console共通の出力recordを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ uv run game-screen-pick --config ./picker.toml --report-json ./report.json ./scr
 4. `density_score` が高い側を `play`、低い側を `event` として既定で 70/30 に割り当てる
 5. `play` / `event` ごとに外れ値を除外し、低スコア帯から高スコア帯まで均等に候補順を組む
 6. その順序を保ったまま、全カテゴリ横断で類似画像を除外しながら最終出力を決める
-7. 選ばれた画像を単一の出力フォルダへコピーする
+7. 選定結果を copy / console / JSON report 共通の出力recordへ変換する
+8. 選ばれた画像を単一の出力フォルダへコピーし、同じrecordから表示とJSONレポートを生成する
 
 ### `play` / `event` の意味
 

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ import cv2
 
 from .analyzers.image_quality_analyzer import ImageQualityAnalyzer
 from .models.analyzer_config import AnalyzerConfig
+from .models.output_record import OutputRecord
 from .models.scene_mix import SceneMix
 from .models.selection_config import SelectionConfig
 from .services.game_screen_picker import GameScreenPicker
@@ -389,20 +390,18 @@ def execute(
                 num=num,
                 recursive=recursive,
             )
-            copied_paths_by_path = FileUtils.copy_selected_items(
-                selected,
+            output_record = OutputRecord.from_selection(selected, rejected, stats)
+            output_record = FileUtils.copy_selected_items(
+                output_record,
                 output_dir,
                 rename=rename,
                 requested_num=num,
             )
-            ResultFormatter.display_results(selected, stats)
+            ResultFormatter.display_results(output_record)
             if report_json is not None:
                 ReportWriter.write(
                     report_json,
-                    selected,
-                    rejected,
-                    stats,
-                    output_paths_by_candidate_id=copied_paths_by_path,
+                    output_record,
                 )
 
     except click.ClickException:

--- a/src/models/output_candidate_record.py
+++ b/src/models/output_candidate_record.py
@@ -1,0 +1,54 @@
+"""出力adapter向けの候補record。"""
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from .scored_candidate import ScoredCandidate
+from .selection_annotation import SelectionAnnotation
+
+
+@dataclass(frozen=True)
+class OutputCandidateRecord:
+    """出力adapterが利用する候補1件分の安定した値."""
+
+    source_path: str
+    filename: str
+    suffix: str
+    scene_label: str
+    play_score: float
+    event_score: float
+    density_score: float
+    scene_confidence: float
+    quality_score: float
+    selection_score: float
+    score_band: str | None
+    outlier_rejected: bool
+    output_path: str | None = None
+
+    @classmethod
+    def from_scored_candidate(
+        cls,
+        candidate: ScoredCandidate,
+        selection_annotation: SelectionAnnotation | None = None,
+    ) -> "OutputCandidateRecord":
+        """選定内部候補を出力用recordへ射影する."""
+        annotation = selection_annotation or SelectionAnnotation()
+        path = Path(candidate.path)
+        return cls(
+            source_path=candidate.path,
+            filename=path.name,
+            suffix=path.suffix,
+            scene_label=candidate.scene_assessment.scene_label.value,
+            play_score=round(candidate.scene_assessment.play_score, 4),
+            event_score=round(candidate.scene_assessment.event_score, 4),
+            density_score=round(candidate.scene_assessment.density_score, 4),
+            scene_confidence=round(candidate.scene_assessment.scene_confidence, 4),
+            quality_score=round(candidate.quality_score, 4),
+            selection_score=round(candidate.selection_score, 4),
+            score_band=annotation.score_band,
+            outlier_rejected=annotation.outlier_rejected,
+        )
+
+    def with_output_path(self, output_path: str | None) -> "OutputCandidateRecord":
+        """出力先パスを反映したrecordを返す."""
+        return replace(self, output_path=output_path)

--- a/src/models/output_candidate_record.py
+++ b/src/models/output_candidate_record.py
@@ -34,15 +34,16 @@ class OutputCandidateRecord:
         """選定内部候補を出力用recordへ射影する."""
         annotation = selection_annotation or SelectionAnnotation()
         path = Path(candidate.path)
+        assessment = candidate.scene_assessment
         return cls(
             source_path=candidate.path,
             filename=path.name,
             suffix=path.suffix,
-            scene_label=candidate.scene_assessment.scene_label.value,
-            play_score=round(candidate.scene_assessment.play_score, 4),
-            event_score=round(candidate.scene_assessment.event_score, 4),
-            density_score=round(candidate.scene_assessment.density_score, 4),
-            scene_confidence=round(candidate.scene_assessment.scene_confidence, 4),
+            scene_label=assessment.scene_label.value,
+            play_score=round(assessment.play_score, 4),
+            event_score=round(assessment.event_score, 4),
+            density_score=round(assessment.density_score, 4),
+            scene_confidence=round(assessment.scene_confidence, 4),
             quality_score=round(candidate.quality_score, 4),
             selection_score=round(candidate.selection_score, 4),
             score_band=annotation.score_band,

--- a/src/models/output_record.py
+++ b/src/models/output_record.py
@@ -1,0 +1,119 @@
+"""copy / report / console に渡す出力record。"""
+
+from dataclasses import dataclass, replace
+
+from .metric_distribution import MetricDistribution
+from .output_candidate_record import OutputCandidateRecord
+from .picker_statistics import PickerStatistics
+from .scored_candidate import ScoredCandidate
+from .whole_input_profile import WholeInputProfile
+
+
+@dataclass(frozen=True)
+class OutputRecord:
+    """出力adapterが共有して利用する選定結果record."""
+
+    selected: list[OutputCandidateRecord]
+    rejected: list[OutputCandidateRecord]
+    total_files: int
+    analyzed_ok: int
+    analyzed_fail: int
+    rejected_by_similarity: int
+    rejected_by_content_filter: int
+    selected_count: int
+    resolved_profile: str
+    scene_distribution: dict[str, int]
+    scene_mix_target: dict[str, int]
+    scene_mix_actual: dict[str, int]
+    threshold_relaxation_steps: list[float]
+    content_filter_breakdown: dict[str, int]
+    whole_input_profile: dict[str, dict[str, float]] | None
+
+    @classmethod
+    def from_selection(
+        cls,
+        selected: list[ScoredCandidate],
+        rejected: list[ScoredCandidate],
+        stats: PickerStatistics,
+    ) -> "OutputRecord":
+        """選定結果と統計情報を出力用recordへ射影する."""
+        return cls(
+            selected=[
+                OutputCandidateRecord.from_scored_candidate(
+                    candidate,
+                    stats.selection_annotations_by_path.get(candidate.path),
+                )
+                for candidate in selected
+            ],
+            rejected=[
+                OutputCandidateRecord.from_scored_candidate(
+                    candidate,
+                    stats.selection_annotations_by_path.get(candidate.path),
+                )
+                for candidate in rejected
+            ],
+            total_files=stats.total_files,
+            analyzed_ok=stats.analyzed_ok,
+            analyzed_fail=stats.analyzed_fail,
+            rejected_by_similarity=stats.rejected_by_similarity,
+            rejected_by_content_filter=stats.rejected_by_content_filter,
+            selected_count=stats.selected_count,
+            resolved_profile=stats.resolved_profile,
+            scene_distribution=dict(stats.scene_distribution),
+            scene_mix_target=dict(stats.scene_mix_target),
+            scene_mix_actual=dict(stats.scene_mix_actual),
+            threshold_relaxation_steps=list(stats.threshold_relaxation_steps),
+            content_filter_breakdown=dict(stats.content_filter_breakdown),
+            whole_input_profile=cls._serialize_whole_input_profile(
+                stats.whole_input_profile
+            ),
+        )
+
+    def with_selected_output_paths(
+        self,
+        output_paths_by_source_path: dict[str, str],
+    ) -> "OutputRecord":
+        """コピー後の出力先パスを選択候補へ反映したrecordを返す."""
+        return replace(
+            self,
+            selected=[
+                candidate.with_output_path(
+                    output_paths_by_source_path.get(candidate.source_path)
+                )
+                for candidate in self.selected
+            ],
+        )
+
+    @staticmethod
+    def _serialize_distribution(
+        distribution: MetricDistribution,
+    ) -> dict[str, float]:
+        """分布プロフィールをJSON互換の値へ変換する."""
+        return {
+            "p10": round(distribution.p10, 4),
+            "p25": round(distribution.p25, 4),
+            "p50": round(distribution.p50, 4),
+            "p90": round(distribution.p90, 4),
+        }
+
+    @classmethod
+    def _serialize_whole_input_profile(
+        cls,
+        profile: WholeInputProfile | None,
+    ) -> dict[str, dict[str, float]] | None:
+        """入力全体分布プロフィールを出力record向けに変換する."""
+        if profile is None:
+            return None
+        return {
+            "brightness": cls._serialize_distribution(profile.brightness),
+            "contrast": cls._serialize_distribution(profile.contrast),
+            "edge_density": cls._serialize_distribution(profile.edge_density),
+            "action_intensity": cls._serialize_distribution(profile.action_intensity),
+            "luminance_entropy": cls._serialize_distribution(profile.luminance_entropy),
+            "luminance_range": cls._serialize_distribution(profile.luminance_range),
+            "near_black_ratio": cls._serialize_distribution(profile.near_black_ratio),
+            "near_white_ratio": cls._serialize_distribution(profile.near_white_ratio),
+            "dominant_tone_ratio": cls._serialize_distribution(
+                profile.dominant_tone_ratio
+            ),
+        }

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -5,7 +5,7 @@ import shutil
 from collections import defaultdict
 from pathlib import Path
 
-from ..models.scored_candidate import ScoredCandidate
+from ..models.output_record import OutputRecord
 
 logger = logging.getLogger(__name__)
 
@@ -75,43 +75,43 @@ class FileUtils:
 
     @staticmethod
     def copy_selected_items(
-        selected: list["ScoredCandidate"],
+        output_record: OutputRecord,
         dest_dir: str,
         rename: bool = False,
         requested_num: int | None = None,
-    ) -> dict[str, str]:
+    ) -> OutputRecord:
         """選択されたアイテムを出力ディレクトリにコピーする.
 
         Args:
-            selected: 選択された候補のリスト
+            output_record: 出力候補を含むrecord
             dest_dir: 出力先ディレクトリのパス
             rename: scene別の連番ファイル名で出力するかどうか
             requested_num: CLIで要求された出力枚数
 
         Returns:
-            candidate path から実際にコピーした絶対パスへの対応表
+            コピー先パスを反映した出力record
         """
         out = Path(dest_dir)
         out.mkdir(parents=True, exist_ok=True)
         scene_counters: dict[str, int] = defaultdict(int)
         copied_paths_by_path: dict[str, str] = {}
-        for res in selected:
+        for result in output_record.selected:
             if rename:
                 if requested_num is None:
                     msg = "rename=True の場合は requested_num の指定が必要です"
                     raise ValueError(msg)
-                scene_name = res.scene_assessment.scene_label.value
+                scene_name = result.scene_label
                 scene_counters[scene_name] += 1
                 filename = FileUtils.build_renamed_filename(
                     scene_name=scene_name,
                     index=scene_counters[scene_name],
-                    suffix=Path(res.path).suffix,
+                    suffix=result.suffix,
                     requested_num=requested_num,
                 )
             else:
-                filename = Path(res.path).name
+                filename = result.filename
             unique_dest = FileUtils.get_unique_destination(out, filename)
-            shutil.copy2(res.path, unique_dest)
-            copied_paths_by_path[res.path] = str(unique_dest.resolve())
-        logger.info(f"{len(selected)} 件を {dest_dir} に保存しました。")
-        return copied_paths_by_path
+            shutil.copy2(result.source_path, unique_dest)
+            copied_paths_by_path[result.source_path] = str(unique_dest.resolve())
+        logger.info(f"{len(output_record.selected)} 件を {dest_dir} に保存しました。")
+        return output_record.with_selected_output_paths(copied_paths_by_path)

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -93,13 +93,15 @@ class FileUtils:
         """
         out = Path(dest_dir)
         out.mkdir(parents=True, exist_ok=True)
+        if rename and requested_num is None:
+            msg = "rename=True の場合は requested_num の指定が必要です"
+            raise ValueError(msg)
+
         scene_counters: dict[str, int] = defaultdict(int)
         copied_paths_by_path: dict[str, str] = {}
         for result in output_record.selected:
             if rename:
-                if requested_num is None:
-                    msg = "rename=True の場合は requested_num の指定が必要です"
-                    raise ValueError(msg)
+                assert requested_num is not None
                 scene_name = result.scene_label
                 scene_counters[scene_name] += 1
                 filename = FileUtils.build_renamed_filename(

--- a/src/utils/report_writer.py
+++ b/src/utils/report_writer.py
@@ -3,10 +3,8 @@
 import json
 from pathlib import Path
 
-from ..models.metric_distribution import MetricDistribution
-from ..models.picker_statistics import PickerStatistics
-from ..models.scored_candidate import ScoredCandidate
-from ..models.selection_annotation import SelectionAnnotation
+from ..models.output_candidate_record import OutputCandidateRecord
+from ..models.output_record import OutputRecord
 
 
 class ReportWriter:
@@ -15,38 +13,25 @@ class ReportWriter:
     @staticmethod
     def write(
         path: str,
-        selected: list[ScoredCandidate],
-        rejected: list[ScoredCandidate],
-        stats: PickerStatistics,
-        output_paths_by_candidate_id: dict[str, str] | None = None,
+        output_record: OutputRecord,
     ) -> None:
         """JSONレポートを書き出す."""
-        output_paths_by_candidate_id = output_paths_by_candidate_id or {}
         payload = {
-            "resolved_profile": stats.resolved_profile,
-            "scene_distribution": stats.scene_distribution,
-            "scene_mix_target": stats.scene_mix_target,
-            "scene_mix_actual": stats.scene_mix_actual,
-            "threshold_relaxation_steps": stats.threshold_relaxation_steps,
-            "rejected_by_content_filter": stats.rejected_by_content_filter,
-            "content_filter_breakdown": stats.content_filter_breakdown,
-            "whole_input_profile": ReportWriter._serialize_whole_input_profile(stats),
+            "resolved_profile": output_record.resolved_profile,
+            "scene_distribution": output_record.scene_distribution,
+            "scene_mix_target": output_record.scene_mix_target,
+            "scene_mix_actual": output_record.scene_mix_actual,
+            "threshold_relaxation_steps": output_record.threshold_relaxation_steps,
+            "rejected_by_content_filter": output_record.rejected_by_content_filter,
+            "content_filter_breakdown": output_record.content_filter_breakdown,
+            "whole_input_profile": output_record.whole_input_profile,
             "selected": [
-                ReportWriter._serialize_candidate(
-                    candidate,
-                    output_paths_by_candidate_id.get(candidate.path),
-                    stats.selection_annotations_by_path.get(candidate.path),
-                )
-                for candidate in selected
+                ReportWriter._serialize_candidate(candidate)
+                for candidate in output_record.selected
             ],
             "rejected": [
-                ReportWriter._serialize_candidate(
-                    candidate,
-                    selection_annotation=stats.selection_annotations_by_path.get(
-                        candidate.path
-                    ),
-                )
-                for candidate in rejected
+                ReportWriter._serialize_candidate(candidate)
+                for candidate in output_record.rejected
             ],
         }
         report_path = Path(path)
@@ -58,68 +43,21 @@ class ReportWriter:
 
     @staticmethod
     def _serialize_candidate(
-        candidate: ScoredCandidate,
-        output_path: str | None = None,
-        selection_annotation: SelectionAnnotation | None = None,
+        candidate: OutputCandidateRecord,
     ) -> dict[str, object]:
         """候補1件を辞書へ変換する."""
-        annotation = selection_annotation or SelectionAnnotation()
         payload: dict[str, object] = {
-            "path": candidate.path,
-            "scene_label": candidate.scene_assessment.scene_label.value,
-            "play_score": round(candidate.scene_assessment.play_score, 4),
-            "event_score": round(candidate.scene_assessment.event_score, 4),
-            "density_score": round(candidate.scene_assessment.density_score, 4),
-            "scene_confidence": round(candidate.scene_assessment.scene_confidence, 4),
-            "quality_score": round(candidate.quality_score, 4),
-            "selection_score": round(candidate.selection_score, 4),
-            "score_band": annotation.score_band,
-            "outlier_rejected": annotation.outlier_rejected,
+            "path": candidate.source_path,
+            "scene_label": candidate.scene_label,
+            "play_score": candidate.play_score,
+            "event_score": candidate.event_score,
+            "density_score": candidate.density_score,
+            "scene_confidence": candidate.scene_confidence,
+            "quality_score": candidate.quality_score,
+            "selection_score": candidate.selection_score,
+            "score_band": candidate.score_band,
+            "outlier_rejected": candidate.outlier_rejected,
         }
-        if output_path is not None:
-            payload["output_path"] = output_path
+        if candidate.output_path is not None:
+            payload["output_path"] = candidate.output_path
         return payload
-
-    @staticmethod
-    def _serialize_distribution(
-        distribution: MetricDistribution,
-    ) -> dict[str, float]:
-        """分布プロフィールをJSON向け辞書へ変換する."""
-        return {
-            "p10": round(distribution.p10, 4),
-            "p25": round(distribution.p25, 4),
-            "p50": round(distribution.p50, 4),
-            "p90": round(distribution.p90, 4),
-        }
-
-    @staticmethod
-    def _serialize_whole_input_profile(
-        stats: PickerStatistics,
-    ) -> dict[str, dict[str, float]] | None:
-        """入力全体分布プロフィールをJSON向けに直列化する."""
-        profile = stats.whole_input_profile
-        if profile is None:
-            return None
-        return {
-            "brightness": ReportWriter._serialize_distribution(profile.brightness),
-            "contrast": ReportWriter._serialize_distribution(profile.contrast),
-            "edge_density": ReportWriter._serialize_distribution(profile.edge_density),
-            "action_intensity": ReportWriter._serialize_distribution(
-                profile.action_intensity
-            ),
-            "luminance_entropy": ReportWriter._serialize_distribution(
-                profile.luminance_entropy
-            ),
-            "luminance_range": ReportWriter._serialize_distribution(
-                profile.luminance_range
-            ),
-            "near_black_ratio": ReportWriter._serialize_distribution(
-                profile.near_black_ratio
-            ),
-            "near_white_ratio": ReportWriter._serialize_distribution(
-                profile.near_white_ratio
-            ),
-            "dominant_tone_ratio": ReportWriter._serialize_distribution(
-                profile.dominant_tone_ratio
-            ),
-        }

--- a/src/utils/result_formatter.py
+++ b/src/utils/result_formatter.py
@@ -1,10 +1,8 @@
 """結果フォーマットユーティリティクラス."""
 
 import logging
-from pathlib import Path
 
-from ..models.picker_statistics import PickerStatistics
-from ..models.scored_candidate import ScoredCandidate
+from ..models.output_record import OutputRecord
 
 logger = logging.getLogger(__name__)
 
@@ -13,32 +11,32 @@ class ResultFormatter:
     """選択結果と統計情報をコンソールに出力する."""
 
     @staticmethod
-    def display_results(
-        selected: list[ScoredCandidate], stats: PickerStatistics
-    ) -> None:
+    def display_results(output_record: OutputRecord) -> None:
         """選択結果を表示する."""
         logger.info("--- 選択された画像一覧 ---")
-        for i, res in enumerate(selected):
-            annotation = stats.selection_annotations_by_path.get(res.path)
-            score_band = annotation.score_band if annotation is not None else None
+        for i, result in enumerate(output_record.selected):
             logger.info(
-                f"[{i + 1}] {Path(res.path).name} "
-                f"(カテゴリ: {res.scene_assessment.scene_label.value}, "
-                f"band: {score_band}, "
-                f"play: {res.scene_assessment.play_score:.3f}, "
-                f"event: {res.scene_assessment.event_score:.3f}, "
-                f"density: {res.scene_assessment.density_score:.3f})"
+                f"[{i + 1}] {result.filename} "
+                f"(カテゴリ: {result.scene_label}, "
+                f"band: {result.score_band}, "
+                f"play: {result.play_score:.3f}, "
+                f"event: {result.event_score:.3f}, "
+                f"density: {result.density_score:.3f})"
             )
 
         logger.info("--- 統計情報 ---")
-        logger.info(f"総ファイル数: {stats.total_files}")
-        logger.info(f"解析成功: {stats.analyzed_ok}")
-        logger.info(f"解析失敗: {stats.analyzed_fail}")
-        logger.info(f"コンテンツフィルターで除外: {stats.rejected_by_content_filter}")
-        logger.info(f"コンテンツフィルター内訳: {stats.content_filter_breakdown}")
-        logger.info(f"類似度で除外: {stats.rejected_by_similarity}")
-        logger.info(f"選択数: {stats.selected_count}")
-        logger.info(f"プロファイル: {stats.resolved_profile}")
-        logger.info(f"画面分布(候補): {stats.scene_distribution}")
-        logger.info(f"画面分布(目標): {stats.scene_mix_target}")
-        logger.info(f"画面分布(実績): {stats.scene_mix_actual}")
+        logger.info(f"総ファイル数: {output_record.total_files}")
+        logger.info(f"解析成功: {output_record.analyzed_ok}")
+        logger.info(f"解析失敗: {output_record.analyzed_fail}")
+        logger.info(
+            f"コンテンツフィルターで除外: {output_record.rejected_by_content_filter}"
+        )
+        logger.info(
+            f"コンテンツフィルター内訳: {output_record.content_filter_breakdown}"
+        )
+        logger.info(f"類似度で除外: {output_record.rejected_by_similarity}")
+        logger.info(f"選択数: {output_record.selected_count}")
+        logger.info(f"プロファイル: {output_record.resolved_profile}")
+        logger.info(f"画面分布(候補): {output_record.scene_distribution}")
+        logger.info(f"画面分布(目標): {output_record.scene_mix_target}")
+        logger.info(f"画面分布(実績): {output_record.scene_mix_actual}")

--- a/tests/models/test_output_candidate_record.py
+++ b/tests/models/test_output_candidate_record.py
@@ -1,0 +1,45 @@
+"""output_candidate_record.py の単体テスト."""
+
+from src.constants.scene_label import SceneLabel
+from src.models.output_candidate_record import OutputCandidateRecord
+from src.models.selection_annotation import SelectionAnnotation
+from tests.conftest import create_scored_candidate
+
+
+def test_output_candidate_record_projects_scored_candidate() -> None:
+    """候補内部構造が出力adapter向けrecordへ射影されること.
+
+    Arrange:
+        - scene scoreと選定注釈を持つ候補がある
+    Act:
+        - OutputCandidateRecordへ射影される
+    Assert:
+        - 出力adapterに必要な値だけが丸め済みで保持されること
+    """
+    # Arrange
+    candidate = create_scored_candidate(
+        path="/tmp/play.jpg",
+        scene_label=SceneLabel.PLAY,
+        play_score=0.81234,
+        event_score=0.12345,
+        density_score=0.73456,
+        scene_confidence=0.56789,
+        quality_score=0.67891,
+        selection_score=0.65432,
+    )
+    annotation = SelectionAnnotation(score_band="high", outlier_rejected=True)
+
+    # Act
+    record = OutputCandidateRecord.from_scored_candidate(candidate, annotation)
+
+    # Assert
+    assert record.source_path == "/tmp/play.jpg"
+    assert record.filename == "play.jpg"
+    assert record.suffix == ".jpg"
+    assert record.scene_label == "play"
+    assert record.play_score == 0.8123
+    assert record.scene_confidence == 0.5679
+    assert record.quality_score == 0.6789
+    assert record.selection_score == 0.6543
+    assert record.score_band == "high"
+    assert record.outlier_rejected is True

--- a/tests/models/test_output_record.py
+++ b/tests/models/test_output_record.py
@@ -1,0 +1,85 @@
+"""output_record.py の単体テスト."""
+
+from src.constants.scene_label import SceneLabel
+from src.models.output_record import OutputRecord
+from src.models.picker_statistics import PickerStatistics
+from src.models.selection_annotation import SelectionAnnotation
+from tests.conftest import create_scored_candidate
+
+
+def test_output_record_projects_selection_for_output_adapters() -> None:
+    """出力adapterが利用する安定したrecordへ射影されること.
+
+    Arrange:
+        - 選択候補と除外候補にscene scoreが設定されている
+        - 統計情報に集計値と選定注釈が設定されている
+    Act:
+        - OutputRecordへ射影される
+        - コピー後の出力パスが反映される
+    Assert:
+        - 候補と統計情報の出力に必要な値がrecordから取得されること
+        - 出力パス付きのrecordが生成されること
+    """
+    # Arrange
+    selected = [
+        create_scored_candidate(
+            path="/tmp/play.jpg",
+            scene_label=SceneLabel.PLAY,
+            play_score=0.81234,
+            event_score=0.12345,
+            density_score=0.73456,
+            selection_score=0.65432,
+        )
+    ]
+    rejected = [
+        create_scored_candidate(
+            path="/tmp/event.jpg",
+            scene_label=SceneLabel.EVENT,
+            play_score=0.23456,
+            event_score=0.87654,
+            density_score=0.12345,
+            selection_score=0.54321,
+        )
+    ]
+    stats = PickerStatistics(
+        total_files=2,
+        analyzed_ok=2,
+        analyzed_fail=0,
+        rejected_by_similarity=1,
+        rejected_by_content_filter=0,
+        selected_count=1,
+        resolved_profile="active",
+        scene_distribution={"play": 1, "event": 1},
+        scene_mix_target={"play": 1, "event": 0},
+        scene_mix_actual={"play": 1, "event": 0},
+        threshold_relaxation_steps=[0.72],
+        content_filter_breakdown={"blackout": 0},
+        whole_input_profile=None,
+        selection_annotations_by_path={
+            "/tmp/play.jpg": SelectionAnnotation(score_band="high"),
+            "/tmp/event.jpg": SelectionAnnotation(
+                score_band="outlier",
+                outlier_rejected=True,
+            ),
+        },
+    )
+
+    # Act
+    record = OutputRecord.from_selection(selected, rejected, stats)
+    record_with_paths = record.with_selected_output_paths(
+        {"/tmp/play.jpg": "/tmp/output/play0001.jpg"}
+    )
+
+    # Assert
+    assert record.resolved_profile == "active"
+    assert record.scene_distribution == {"play": 1, "event": 1}
+    assert record.total_files == 2
+    assert record.selected[0].source_path == "/tmp/play.jpg"
+    assert record.selected[0].filename == "play.jpg"
+    assert record.selected[0].scene_label == "play"
+    assert record.selected[0].play_score == 0.8123
+    assert record.selected[0].score_band == "high"
+    assert record.rejected[0].scene_label == "event"
+    assert record.rejected[0].outlier_rejected is True
+    assert record_with_paths.selected[0].output_path == "/tmp/output/play0001.jpg"
+    assert record.selected[0].output_path is None

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -4,9 +4,57 @@ from pathlib import Path
 
 import pytest
 
-from src.constants.scene_label import SceneLabel
+from src.models.output_candidate_record import OutputCandidateRecord
+from src.models.output_record import OutputRecord
 from src.utils.file_utils import FileUtils
-from tests.conftest import create_scored_candidate
+
+
+def _build_candidate(
+    source_path: str,
+    scene_label: str = "play",
+) -> OutputCandidateRecord:
+    path = Path(source_path)
+    return OutputCandidateRecord(
+        source_path=source_path,
+        filename=path.name,
+        suffix=path.suffix,
+        scene_label=scene_label,
+        play_score=0.8,
+        event_score=0.3,
+        density_score=0.7,
+        scene_confidence=0.5,
+        quality_score=0.6,
+        selection_score=0.6,
+        score_band="high",
+        outlier_rejected=False,
+    )
+
+
+def _build_output_record(
+    source_paths: list[str],
+    scene_labels: list[str] | None = None,
+) -> OutputRecord:
+    scene_labels = scene_labels or ["play"] * len(source_paths)
+    return OutputRecord(
+        selected=[
+            _build_candidate(source_path, scene_label)
+            for source_path, scene_label in zip(source_paths, scene_labels, strict=True)
+        ],
+        rejected=[],
+        total_files=len(source_paths),
+        analyzed_ok=len(source_paths),
+        analyzed_fail=0,
+        rejected_by_similarity=0,
+        rejected_by_content_filter=0,
+        selected_count=len(source_paths),
+        resolved_profile="active",
+        scene_distribution={"play": len(source_paths), "event": 0},
+        scene_mix_target={"play": len(source_paths), "event": 0},
+        scene_mix_actual={"play": len(source_paths), "event": 0},
+        threshold_relaxation_steps=[0.72],
+        content_filter_breakdown={},
+        whole_input_profile=None,
+    )
 
 
 @pytest.mark.parametrize(
@@ -14,9 +62,7 @@ from tests.conftest import create_scored_candidate
     [
         ([], "image.jpg", "image.jpg"),
         (["image.jpg"], "image.jpg", "image_1.jpg"),
-        # 飛び番号がある場合の最小値取得
         (["image.jpg", "image_1.jpg", "image_3.jpg"], "image.jpg", "image_2.jpg"),
-        # 複数拡張子と特殊文字
         (["archive.tar.gz"], "archive.tar.gz", "archive.tar_1.gz"),
         (["画像ファイル.jpg"], "画像ファイル.jpg", "画像ファイル_1.jpg"),
     ],
@@ -37,8 +83,8 @@ def test_get_unique_destination_generates_unique_filename(
         - 適切なサフィックス付きのファイル名が返されること
     """
     # Arrange
-    for f in existing_files:
-        (tmp_path / f).touch()
+    for file_name in existing_files:
+        (tmp_path / file_name).touch()
 
     # Act
     result = FileUtils.get_unique_destination(tmp_path, filename)
@@ -72,7 +118,7 @@ def test_build_renamed_filename_uses_scene_prefix_and_padding(
         - scene名 + ゼロ埋め連番 + 拡張子の形式で返されること
         - 要求枚数が4桁以下なら4桁、それ以上なら要求枚数の桁数でゼロ埋めされること
     """
-    # Arrange — パラメタライズド引数からscene名、連番、拡張子、要求枚数を設定
+    # Arrange - パラメタライズド引数からscene名、連番、拡張子、要求枚数を設定
     # Act
     result = FileUtils.build_renamed_filename(
         scene_name=scene_name,
@@ -83,6 +129,37 @@ def test_build_renamed_filename_uses_scene_prefix_and_padding(
 
     # Assert
     assert result == expected
+
+
+def test_copy_selected_items_returns_output_record_with_copied_paths(
+    tmp_path: Path,
+) -> None:
+    """output recordの選択候補がコピーされ出力パスが反映されること.
+
+    Arrange:
+        - ソース画像ファイルを持つoutput recordがある
+        - コピー先ディレクトリを用意する
+    Act:
+        - copy_selected_itemsが実行される
+    Assert:
+        - ファイルがコピーされること
+        - 戻り値のoutput recordにコピー先パスが設定されること
+    """
+    # Arrange
+    src_file = tmp_path / "source" / "test.png"
+    src_file.parent.mkdir()
+    src_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+    dest_dir = tmp_path / "output"
+
+    # Act
+    result = FileUtils.copy_selected_items(
+        _build_output_record([str(src_file)]),
+        str(dest_dir),
+    )
+
+    # Assert
+    assert (dest_dir / "test.png").exists()
+    assert result.selected[0].output_path == str((dest_dir / "test.png").resolve())
 
 
 def test_copy_selected_items_rename_avoids_collision_and_counts_per_scene(
@@ -110,24 +187,14 @@ def test_copy_selected_items_rename_avoids_collision_and_counts_per_scene(
     for path in (gameplay1, gameplay2, event1):
         path.write_bytes(b"fake_image_data")
 
-    selected = [
-        create_scored_candidate(
-            path=str(gameplay1),
-            scene_label=SceneLabel.PLAY,
-        ),
-        create_scored_candidate(
-            path=str(event1),
-            scene_label=SceneLabel.EVENT,
-        ),
-        create_scored_candidate(
-            path=str(gameplay2),
-            scene_label=SceneLabel.PLAY,
-        ),
-    ]
+    record = _build_output_record(
+        [str(gameplay1), str(event1), str(gameplay2)],
+        ["play", "event", "play"],
+    )
 
     # Act
-    copied_paths = FileUtils.copy_selected_items(
-        selected,
+    result = FileUtils.copy_selected_items(
+        record,
         str(output_dir),
         rename=True,
         requested_num=3,
@@ -137,13 +204,13 @@ def test_copy_selected_items_rename_avoids_collision_and_counts_per_scene(
     assert (output_dir / "play0001_1.jpg").exists()
     assert (output_dir / "event0001.jpg").exists()
     assert (output_dir / "play0002.jpg").exists()
-    assert copied_paths[selected[0].path] == str(
+    assert result.selected[0].output_path == str(
         (output_dir / "play0001_1.jpg").resolve()
     )
-    assert copied_paths[selected[1].path] == str(
+    assert result.selected[1].output_path == str(
         (output_dir / "event0001.jpg").resolve()
     )
-    assert copied_paths[selected[2].path] == str(
+    assert result.selected[2].output_path == str(
         (output_dir / "play0002.jpg").resolve()
     )
 
@@ -154,67 +221,39 @@ def test_copy_selected_items_copies_files(tmp_path: Path) -> None:
     Arrange:
         - ソース画像ファイルを作成する
         - コピー先ディレクトリを用意する
-        - 候補画像を1件作成する
+        - output recordを作成する
     Act:
         - copy_selected_itemsを呼び出す
     Assert:
-        - 戻り値の件数が1件であること
+        - 戻り値の選択候補が1件であること
         - コピー先にファイルが存在すること
     """
     # Arrange
     src_file = tmp_path / "source" / "test.png"
     src_file.parent.mkdir()
     src_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
-
     dest_dir = tmp_path / "output"
-    candidate = create_scored_candidate(path=str(src_file))
 
     # Act
-    result = FileUtils.copy_selected_items([candidate], str(dest_dir))
+    result = FileUtils.copy_selected_items(
+        _build_output_record([str(src_file)]),
+        str(dest_dir),
+    )
 
     # Assert
-    assert len(result) == 1
+    assert len(result.selected) == 1
     assert (dest_dir / "test.png").exists()
 
 
-def test_copy_selected_items_returns_path_mapping(tmp_path: Path) -> None:
-    """戻り値が path → コピー先パス の対応表であること.
-
-    Arrange:
-        - ソース画像ファイルを作成する
-        - コピー先ディレクトリを用意する
-        - 候補画像を1件作成する
-    Act:
-        - copy_selected_itemsを呼び出す
-    Assert:
-        - 戻り値に元パスがキーとして含まれること
-        - 値がコピー先パスで元ファイル名で終わること
-    """
-    # Arrange
-    src_file = tmp_path / "source" / "test.png"
-    src_file.parent.mkdir()
-    src_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
-
-    dest_dir = tmp_path / "output"
-    candidate = create_scored_candidate(path=str(src_file))
-
-    # Act
-    result = FileUtils.copy_selected_items([candidate], str(dest_dir))
-
-    # Assert
-    assert candidate.path in result
-    assert result[candidate.path].endswith("test.png")
-
-
 def test_copy_selected_items_renames_by_scene(tmp_path: Path) -> None:
-    """rename=True の場合、scene別連番ファイル名が付けられること.
+    """rename=Trueの場合、scene別連番ファイル名が付けられること.
 
     Arrange:
         - 異なる拡張子の画像ファイルを2件作成する
         - コピー先ディレクトリを用意する
-        - 候補画像を2件作成する
+        - output recordを作成する
     Act:
-        - rename=True, requested_num=2 でcopy_selected_itemsを呼び出す
+        - rename=True, requested_num=2でcopy_selected_itemsを呼び出す
     Assert:
         - 戻り値が2件であること
         - コピー先にplay0001.png, play0002.jpgが生成されること
@@ -226,18 +265,23 @@ def test_copy_selected_items_renames_by_scene(tmp_path: Path) -> None:
         src_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
 
     dest_dir = tmp_path / "output"
-    candidates = [
-        create_scored_candidate(path=str(tmp_path / "source" / "a.png")),
-        create_scored_candidate(path=str(tmp_path / "source" / "b.jpg")),
-    ]
+    record = _build_output_record(
+        [
+            str(tmp_path / "source" / "a.png"),
+            str(tmp_path / "source" / "b.jpg"),
+        ]
+    )
 
     # Act
     result = FileUtils.copy_selected_items(
-        candidates, str(dest_dir), rename=True, requested_num=2
+        record,
+        str(dest_dir),
+        rename=True,
+        requested_num=2,
     )
 
     # Assert
-    assert len(result) == 2
+    assert len(result.selected) == 2
     files = sorted(dest_dir.iterdir())
     assert files[0].name == "play0001.png"
     assert files[1].name == "play0002.jpg"
@@ -246,12 +290,12 @@ def test_copy_selected_items_renames_by_scene(tmp_path: Path) -> None:
 def test_copy_selected_items_raises_when_rename_without_requested_num(
     tmp_path: Path,
 ) -> None:
-    """rename=True で requested_num=None の場合、ValueError が送出されること.
+    """rename=Trueでrequested_num=Noneの場合、ValueErrorが送出されること.
 
     Arrange:
         - ソース画像ファイルを作成する
         - コピー先ディレクトリを用意する
-        - 候補画像を1件作成する
+        - output recordを作成する
     Act:
         - rename=True, requested_num指定なしでcopy_selected_itemsを呼び出す
     Assert:
@@ -261,13 +305,15 @@ def test_copy_selected_items_raises_when_rename_without_requested_num(
     src_file = tmp_path / "source" / "test.png"
     src_file.parent.mkdir()
     src_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
-
     dest_dir = tmp_path / "output"
-    candidate = create_scored_candidate(path=str(src_file))
 
     # Act & Assert
     with pytest.raises(ValueError, match="requested_num"):
-        FileUtils.copy_selected_items([candidate], str(dest_dir), rename=True)
+        FileUtils.copy_selected_items(
+            _build_output_record([str(src_file)]),
+            str(dest_dir),
+            rename=True,
+        )
 
 
 def test_copy_selected_items_handles_duplicate_filenames(tmp_path: Path) -> None:
@@ -276,7 +322,7 @@ def test_copy_selected_items_handles_duplicate_filenames(tmp_path: Path) -> None
     Arrange:
         - 異なるディレクトリに同名の画像ファイルを2件作成する
         - コピー先ディレクトリを用意する
-        - 候補画像を2件作成する
+        - output recordを作成する
     Act:
         - copy_selected_itemsを呼び出す
     Assert:
@@ -285,25 +331,27 @@ def test_copy_selected_items_handles_duplicate_filenames(tmp_path: Path) -> None
         - 一方がtest.png、他方がtest_1.pngであること
     """
     # Arrange
-    for i, name in enumerate(["test.png", "test.png"]):
-        src_dir = tmp_path / f"source{i}"
+    for index, name in enumerate(["test.png", "test.png"]):
+        src_dir = tmp_path / f"source{index}"
         src_dir.mkdir()
         src_file = src_dir / name
         src_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
 
     dest_dir = tmp_path / "output"
-    candidates = [
-        create_scored_candidate(path=str(tmp_path / "source0" / "test.png")),
-        create_scored_candidate(path=str(tmp_path / "source1" / "test.png")),
-    ]
+    record = _build_output_record(
+        [
+            str(tmp_path / "source0" / "test.png"),
+            str(tmp_path / "source1" / "test.png"),
+        ]
+    )
 
     # Act
-    result = FileUtils.copy_selected_items(candidates, str(dest_dir))
+    result = FileUtils.copy_selected_items(record, str(dest_dir))
 
     # Assert
-    assert len(result) == 2
+    assert len(result.selected) == 2
     copied_files = list(dest_dir.iterdir())
     assert len(copied_files) == 2
-    names = {f.name for f in copied_files}
+    names = {file.name for file in copied_files}
     assert "test.png" in names
     assert "test_1.png" in names

--- a/tests/utils/test_report_writer.py
+++ b/tests/utils/test_report_writer.py
@@ -3,49 +3,46 @@
 import json
 from pathlib import Path
 
-from src.constants.scene_label import SceneLabel
-from src.models.picker_statistics import PickerStatistics
-from src.models.selection_annotation import SelectionAnnotation
+from src.models.output_candidate_record import OutputCandidateRecord
+from src.models.output_record import OutputRecord
 from src.utils.report_writer import ReportWriter
-from tests.conftest import (
-    build_whole_input_profile,
-    create_analyzed_image,
-    create_scored_candidate,
-)
 
 
-def _build_stats() -> PickerStatistics:
-    whole_input_profile = build_whole_input_profile(
-        create_analyzed_image(
-            path="/tmp/profile_0.jpg",
-            raw_metrics_dict={
-                "brightness": 95.0,
-                "contrast": 0.45,
-                "edge_density": 0.12,
-                "action_intensity": 0.08,
-                "luminance_entropy": 5.2,
-                "near_black_ratio": 0.08,
-                "near_white_ratio": 0.04,
-                "dominant_tone_ratio": 0.58,
-                "luminance_range": 32.0,
-            },
-        ),
-        create_analyzed_image(
-            path="/tmp/profile_1.jpg",
-            raw_metrics_dict={
-                "brightness": 125.0,
-                "contrast": 0.52,
-                "edge_density": 0.18,
-                "action_intensity": 0.15,
-                "luminance_entropy": 6.1,
-                "near_black_ratio": 0.02,
-                "near_white_ratio": 0.10,
-                "dominant_tone_ratio": 0.64,
-                "luminance_range": 40.0,
-            },
-        ),
+def _build_candidate(
+    *,
+    source_path: str = "/tmp/play.jpg",
+    filename: str = "play.jpg",
+    scene_label: str = "play",
+    score_band: str | None = "high",
+    outlier_rejected: bool = False,
+    output_path: str | None = None,
+) -> OutputCandidateRecord:
+    return OutputCandidateRecord(
+        source_path=source_path,
+        filename=filename,
+        suffix=Path(filename).suffix,
+        scene_label=scene_label,
+        play_score=0.8,
+        event_score=0.2,
+        density_score=0.8,
+        scene_confidence=0.5,
+        quality_score=0.6,
+        selection_score=0.8,
+        score_band=score_band,
+        outlier_rejected=outlier_rejected,
+        output_path=output_path,
     )
-    return PickerStatistics(
+
+
+def _build_output_record(
+    *,
+    selected: list[OutputCandidateRecord] | None = None,
+    rejected: list[OutputCandidateRecord] | None = None,
+    whole_input_profile: dict[str, dict[str, float]] | None = None,
+) -> OutputRecord:
+    return OutputRecord(
+        selected=selected if selected is not None else [_build_candidate()],
+        rejected=rejected if rejected is not None else [],
         total_files=4,
         analyzed_ok=4,
         analyzed_fail=0,
@@ -68,66 +65,51 @@ def _build_stats() -> PickerStatistics:
     )
 
 
-def test_report_writer_serializes_play_event_fields(tmp_path: Path) -> None:
-    """play/eventフィールドが正しくシリアライズされること.
+def test_report_writer_serializes_output_record_fields(tmp_path: Path) -> None:
+    """output recordから既存JSONフィールドが出力されること.
 
     Arrange:
-        - play候補にplay_score/event_score/density_scoreが設定されている
-        - 統計情報にscore_band/outlier_rejectedの選定注釈がある
-        - 統計情報にscene_distribution/scene_mix_targetがある
+        - 出力候補と統計値を持つoutput recordがある
     Act:
         - ReportWriterでJSONレポートを出力する
     Assert:
-        - 各スコアフィールドが正しく出力されること
-        - output_pathが正しく記録されること
-        - outlier_rejectedがTrueで出力されること
+        - 既存の候補フィールドと統計フィールドが維持されること
     """
     # Arrange
     report_path = tmp_path / "report.json"
     selected = [
-        create_scored_candidate(
-            path="/tmp/play.jpg",
-            scene_label=SceneLabel.PLAY,
-            play_score=0.8,
-            event_score=0.2,
-            density_score=0.8,
-            selection_score=0.8,
+        _build_candidate(
+            source_path="/tmp/play.jpg",
+            filename="play.jpg",
+            output_path="/tmp/output/play0001.jpg",
         )
     ]
     rejected = [
-        create_scored_candidate(
-            path="/tmp/event.jpg",
-            scene_label=SceneLabel.EVENT,
-            play_score=0.2,
-            event_score=0.8,
-            density_score=0.2,
-            selection_score=0.8,
-        )
-    ]
-    stats = _build_stats()
-    stats.selection_annotations_by_path = {
-        selected[0].path: SelectionAnnotation(score_band="high"),
-        rejected[0].path: SelectionAnnotation(
+        _build_candidate(
+            source_path="/tmp/event.jpg",
+            filename="event.jpg",
+            scene_label="event",
             score_band="low",
             outlier_rejected=True,
-        ),
-    }
+        )
+    ]
 
     # Act
     ReportWriter.write(
-        path=str(report_path),
-        selected=selected,
-        rejected=rejected,
-        stats=stats,
-        output_paths_by_candidate_id={
-            selected[0].path: "/tmp/output/play0001.jpg",
-        },
+        str(report_path),
+        _build_output_record(selected=selected, rejected=rejected),
     )
 
     # Assert
     payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["resolved_profile"] == "static"
     assert payload["scene_distribution"] == {"play": 2, "event": 2}
     assert payload["scene_mix_target"] == {"play": 1, "event": 1}
+    assert payload["threshold_relaxation_steps"] == [0.72]
+    assert payload["rejected_by_content_filter"] == 2
+    assert payload["content_filter_breakdown"]["fade_transition"] == 2
+    assert payload["selected"][0]["path"] == "/tmp/play.jpg"
+    assert payload["selected"][0]["scene_label"] == "play"
     assert payload["selected"][0]["play_score"] == 0.8
     assert payload["selected"][0]["event_score"] == 0.2
     assert payload["selected"][0]["density_score"] == 0.8
@@ -136,141 +118,50 @@ def test_report_writer_serializes_play_event_fields(tmp_path: Path) -> None:
     assert payload["rejected"][0]["outlier_rejected"] is True
 
 
-def test_report_writer_serializes_selection_annotations_from_stats(
-    tmp_path: Path,
-) -> None:
-    """選定注釈が統計情報からJSONへ出力されること.
-
-    Arrange:
-        - 候補にはscore_band/outlier_rejectedが設定されていない
-        - 統計情報に候補パスごとの選定注釈がある
-    Act:
-        - ReportWriterでJSONレポートを出力する
-    Assert:
-        - score_bandとoutlier_rejectedが選定注釈から出力されること
-    """
-    # Arrange
-    report_path = tmp_path / "report.json"
-    selected = [create_scored_candidate(path="/tmp/annotated_play.jpg")]
-    rejected = [create_scored_candidate(path="/tmp/annotated_event.jpg")]
-    stats = _build_stats()
-    stats.selection_annotations_by_path = {
-        "/tmp/annotated_play.jpg": SelectionAnnotation(score_band="high"),
-        "/tmp/annotated_event.jpg": SelectionAnnotation(
-            score_band="outlier",
-            outlier_rejected=True,
-        ),
-    }
-
-    # Act
-    ReportWriter.write(
-        path=str(report_path),
-        selected=selected,
-        rejected=rejected,
-        stats=stats,
-    )
-
-    # Assert
-    payload = json.loads(report_path.read_text(encoding="utf-8"))
-    assert payload["selected"][0]["score_band"] == "high"
-    assert payload["selected"][0]["outlier_rejected"] is False
-    assert payload["rejected"][0]["score_band"] == "outlier"
-    assert payload["rejected"][0]["outlier_rejected"] is True
-
-
 def test_report_writer_keeps_whole_input_profile(tmp_path: Path) -> None:
     """whole_input_profileが保持されること.
 
     Arrange:
-        - 統計情報にwhole_input_profileが含まれている
-        - content_filter_breakdownにfade_transition=2がある
-        - rejected_by_content_filter=2がある
+        - output recordにwhole_input_profileが含まれている
     Act:
         - ReportWriterでJSONレポートを出力する
     Assert:
         - whole_input_profileが出力されること
-        - content_filter_breakdownが正しく出力されること
         - scene_diagnostics_summaryが含まれないこと
     """
     # Arrange
     report_path = tmp_path / "report.json"
-    selected = [create_scored_candidate(path="/tmp/selected.jpg")]
+    profile = {
+        "brightness": {"p10": 95.0, "p25": 100.0, "p50": 110.0, "p90": 125.0},
+        "contrast": {"p10": 0.45, "p25": 0.5, "p50": 0.52, "p90": 0.55},
+    }
 
     # Act
     ReportWriter.write(
-        path=str(report_path),
-        selected=selected,
-        rejected=[],
-        stats=_build_stats(),
+        str(report_path),
+        _build_output_record(whole_input_profile=profile),
     )
 
     # Assert
     payload = json.loads(report_path.read_text(encoding="utf-8"))
-    assert payload["rejected_by_content_filter"] == 2
-    assert payload["content_filter_breakdown"]["fade_transition"] == 2
-    assert payload["whole_input_profile"] is not None
-    profile = payload["whole_input_profile"]
-    assert "contrast" in profile
-    assert "edge_density" in profile
-    assert "action_intensity" in profile
-    assert "luminance_entropy" in profile
+    assert payload["whole_input_profile"] == profile
     assert "scene_diagnostics_summary" not in payload
     assert "score_band" in payload["selected"][0]
 
 
 def test_write_creates_json_file(tmp_path: Path) -> None:
-    """JSON レポートファイルが作成されること."""
+    """JSONレポートファイルが作成されること."""
     # Arrange
     report_path = tmp_path / "report.json"
-    candidate = create_scored_candidate(path="/tmp/selected.jpg")
-    profile = build_whole_input_profile(
-        create_analyzed_image(
-            path="/tmp/profile.jpg",
-            raw_metrics_dict={
-                "brightness": 100.0,
-                "contrast": 0.5,
-                "edge_density": 0.1,
-                "action_intensity": 0.1,
-                "luminance_entropy": 5.0,
-                "near_black_ratio": 0.05,
-                "near_white_ratio": 0.05,
-                "dominant_tone_ratio": 0.5,
-                "luminance_range": 40.0,
-            },
-        ),
-    )
-
-    stats = PickerStatistics(
-        total_files=1,
-        analyzed_ok=1,
-        analyzed_fail=0,
-        rejected_by_similarity=0,
-        rejected_by_content_filter=0,
-        selected_count=1,
-        resolved_profile="active",
-        scene_distribution={"play": 1, "event": 0},
-        scene_mix_target={"play": 1, "event": 0},
-        scene_mix_actual={"play": 1, "event": 0},
-        threshold_relaxation_steps=[0.7, 0.75, 0.8],
-        content_filter_breakdown={"blackout": 0},
-        whole_input_profile=profile,
-    )
 
     # Act
-    ReportWriter.write(
-        str(report_path),
-        [candidate],
-        [],
-        stats,
-        output_paths_by_candidate_id={candidate.path: "/output/test.png"},
-    )
+    ReportWriter.write(str(report_path), _build_output_record())
 
     # Assert
     assert report_path.exists()
-    data = json.loads(report_path.read_text())
+    data = json.loads(report_path.read_text(encoding="utf-8"))
     assert "selected" in data
     assert len(data["selected"]) == 1
-    assert data["selected"][0]["output_path"] == "/output/test.png"
 
 
 def test_write_handles_empty_selected(tmp_path: Path) -> None:
@@ -278,26 +169,13 @@ def test_write_handles_empty_selected(tmp_path: Path) -> None:
     # Arrange
     report_path = tmp_path / "report.json"
 
-    stats = PickerStatistics(
-        total_files=0,
-        analyzed_ok=0,
-        analyzed_fail=0,
-        rejected_by_similarity=0,
-        rejected_by_content_filter=0,
-        selected_count=0,
-        resolved_profile="active",
-        scene_distribution={"play": 0, "event": 0},
-        scene_mix_target={"play": 0, "event": 0},
-        scene_mix_actual={"play": 0, "event": 0},
-        threshold_relaxation_steps=[0.7],
-        content_filter_breakdown={},
-        whole_input_profile=None,
+    # Act
+    ReportWriter.write(
+        str(report_path),
+        _build_output_record(selected=[], rejected=[]),
     )
 
-    # Act
-    ReportWriter.write(str(report_path), [], [], stats)
-
     # Assert
-    data = json.loads(report_path.read_text())
+    data = json.loads(report_path.read_text(encoding="utf-8"))
     assert data["selected"] == []
     assert data["whole_input_profile"] is None

--- a/tests/utils/test_report_writer.py
+++ b/tests/utils/test_report_writer.py
@@ -11,12 +11,12 @@ from src.utils.report_writer import ReportWriter
 def _build_candidate(
     *,
     source_path: str = "/tmp/play.jpg",
-    filename: str = "play.jpg",
     scene_label: str = "play",
     score_band: str | None = "high",
     outlier_rejected: bool = False,
     output_path: str | None = None,
 ) -> OutputCandidateRecord:
+    filename = Path(source_path).name
     return OutputCandidateRecord(
         source_path=source_path,
         filename=filename,
@@ -80,14 +80,12 @@ def test_report_writer_serializes_output_record_fields(tmp_path: Path) -> None:
     selected = [
         _build_candidate(
             source_path="/tmp/play.jpg",
-            filename="play.jpg",
             output_path="/tmp/output/play0001.jpg",
         )
     ]
     rejected = [
         _build_candidate(
             source_path="/tmp/event.jpg",
-            filename="event.jpg",
             scene_label="event",
             score_band="low",
             outlier_rejected=True,

--- a/tests/utils/test_result_formatter.py
+++ b/tests/utils/test_result_formatter.py
@@ -1,86 +1,87 @@
-"""ResultFormatter のテスト."""
+"""result_formatter.py の単体テスト."""
 
-from io import StringIO
 from unittest.mock import patch
 
-from src.models.picker_statistics import PickerStatistics
-from src.models.selection_annotation import SelectionAnnotation
+from src.models.output_candidate_record import OutputCandidateRecord
+from src.models.output_record import OutputRecord
 from src.utils.result_formatter import ResultFormatter
-from tests.conftest import create_scored_candidate
+
+
+def _build_output_record() -> OutputRecord:
+    return OutputRecord(
+        selected=[
+            OutputCandidateRecord(
+                source_path="/tmp/test_image.jpg",
+                filename="test_image.jpg",
+                suffix=".jpg",
+                scene_label="play",
+                play_score=0.8,
+                event_score=0.3,
+                density_score=0.7,
+                scene_confidence=0.5,
+                quality_score=0.6,
+                selection_score=0.6,
+                score_band="high",
+                outlier_rejected=False,
+            )
+        ],
+        rejected=[],
+        total_files=1,
+        analyzed_ok=1,
+        analyzed_fail=0,
+        rejected_by_similarity=0,
+        rejected_by_content_filter=0,
+        selected_count=1,
+        resolved_profile="active",
+        scene_distribution={"play": 1, "event": 0},
+        scene_mix_target={"play": 1, "event": 0},
+        scene_mix_actual={"play": 1, "event": 0},
+        threshold_relaxation_steps=[0.7],
+        content_filter_breakdown={},
+        whole_input_profile=None,
+    )
 
 
 def test_display_results_runs_without_error() -> None:
-    """display_results がエラーなく実行されること.
+    """display_resultsがエラーなく実行されること.
 
     Arrange:
-        - 候補画像と統計情報を用意する
+        - 候補画像と統計情報を持つoutput recordを用意する
     Act:
-        - display_results を呼び出す
+        - display_resultsを呼び出す
     Assert:
         - 例外が発生せずに完了されること
     """
     # Arrange
-    candidate = create_scored_candidate(path="/tmp/test_image.jpg")
-
-    stats = PickerStatistics(
-        total_files=1,
-        analyzed_ok=1,
-        analyzed_fail=0,
-        rejected_by_similarity=0,
-        rejected_by_content_filter=0,
-        selected_count=1,
-        resolved_profile="active",
-        scene_distribution={"play": 1, "event": 0},
-        scene_mix_target={"play": 1, "event": 0},
-        scene_mix_actual={"play": 1, "event": 0},
-        threshold_relaxation_steps=[0.7],
-        content_filter_breakdown={},
-        whole_input_profile=None,
-    )
+    record = _build_output_record()
 
     # Act
-    with patch("sys.stdout", new_callable=StringIO):
-        ResultFormatter.display_results([candidate], stats)
+    ResultFormatter.display_results(record)
 
-    # Assert — 例外なく完了すればOK
+    # Assert - 例外なく完了すればOK
 
 
-def test_display_results_uses_selection_annotations_from_stats() -> None:
-    """選定注釈のscore_bandが表示に使われること.
+def test_display_results_uses_output_record() -> None:
+    """output recordから既存の表示内容が出力されること.
 
     Arrange:
-        - 候補にはscore_bandが設定されていない
-        - 統計情報に候補パスごとの選定注釈がある
+        - 選択候補と統計値を持つoutput recordがある
     Act:
         - display_resultsが実行される
     Assert:
-        - 表示ログに選定注釈のscore_bandが含まれること
+        - 候補情報と統計情報がログへ出力されること
     """
     # Arrange
-    candidate = create_scored_candidate(path="/tmp/test_image.jpg")
-    stats = PickerStatistics(
-        total_files=1,
-        analyzed_ok=1,
-        analyzed_fail=0,
-        rejected_by_similarity=0,
-        rejected_by_content_filter=0,
-        selected_count=1,
-        resolved_profile="active",
-        scene_distribution={"play": 1, "event": 0},
-        scene_mix_target={"play": 1, "event": 0},
-        scene_mix_actual={"play": 1, "event": 0},
-        threshold_relaxation_steps=[0.7],
-        content_filter_breakdown={},
-        whole_input_profile=None,
-        selection_annotations_by_path={
-            candidate.path: SelectionAnnotation(score_band="high")
-        },
-    )
+    record = _build_output_record()
 
     # Act
     with patch("src.utils.result_formatter.logger") as logger:
-        ResultFormatter.display_results([candidate], stats)
+        ResultFormatter.display_results(record)
 
     # Assert
     messages = [call.args[0] for call in logger.info.call_args_list]
+    assert any("[1] test_image.jpg" in message for message in messages)
     assert any("band: high" in message for message in messages)
+    assert "総ファイル数: 1" in messages
+    assert "解析成功: 1" in messages
+    assert "プロファイル: active" in messages


### PR DESCRIPTION
## Summary
- `OutputRecord` / `OutputCandidateRecord` を追加し、copy / report / console が共通の出力recordを利用するように変更
- JSON report と console display の既存出力内容を維持したまま、出力adapterの selection 内部構造への依存を削減
- output record ベースのテストへ整理し、README の処理フローを更新

## Verification
- `uv run task test` を実行
- lint / type check 通過
- pytest: 106 passed

## Notes
- 既存JSONフィールドとconsole表示内容は維持しています。