### PR TITLE
refactor: config解決をCLIから分離

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,12 +8,10 @@ import click
 import cv2
 
 from .analyzers.image_quality_analyzer import ImageQualityAnalyzer
-from .models.analyzer_config import AnalyzerConfig
 from .models.output_record import OutputRecord
 from .models.scene_mix import SceneMix
-from .models.selection_config import SelectionConfig
 from .services.game_screen_picker import GameScreenPicker
-from .utils.config_loader import ConfigLoader
+from .utils.config_resolver import ConfigResolver
 from .utils.file_utils import FileUtils
 from .utils.report_writer import ReportWriter
 from .utils.result_formatter import ResultFormatter
@@ -153,70 +151,6 @@ def parse_scene_mix(value: str | None) -> SceneMix | None:
         raise click.BadParameter(str(error)) from error
 
 
-def _resolve_configs(
-    config_path: str | None,
-    profile: str | None,
-    scene_mix: SceneMix | None,
-    similarity: float | None,
-    batch_size: int | None,
-    result_max_workers: int | None,
-    max_dim: int,
-    max_memory_gb: int,
-) -> tuple[AnalyzerConfig, SelectionConfig]:
-    """解析設定と選択設定を構築する."""
-    analyzer_config = AnalyzerConfig.from_cli_args(
-        result_max_workers=result_max_workers,
-        max_dim=max_dim,
-        max_memory_gb=max_memory_gb,
-    )
-    selection_config = build_selection_config(
-        config_path=config_path,
-        profile=profile,
-        scene_mix=scene_mix,
-        similarity=similarity,
-        batch_size=batch_size,
-    )
-    return analyzer_config, selection_config
-
-
-def build_selection_config(
-    *,
-    config_path: str | None,
-    profile: str | None,
-    scene_mix: SceneMix | None,
-    similarity: float | None,
-    batch_size: int | None,
-) -> SelectionConfig:
-    """設定ファイルとCLI引数から `SelectionConfig` を作成する.
-
-    優先順位は `CLI override > config file > built-in default` とする。
-    このメソッドは設定ファイルを部分的な辞書へ変換したうえで、
-    CLIで明示指定された値だけを上書きし、最終的な設定モデルを組み立てる。
-
-    Args:
-        config_path: TOML設定ファイルへのパス。
-        profile: CLIから明示指定された実行プロファイル。
-        scene_mix: CLIから明示指定されたscene mix比率。
-        similarity: CLIから明示指定された類似度しきい値。
-        batch_size: CLIから明示指定されたCLIPバッチサイズ。
-
-    Returns:
-        実行時にそのまま使える `SelectionConfig` 。
-    """
-    config_values = ConfigLoader.load(config_path)
-    cli_overrides = {
-        "profile": profile,
-        "scene_mix": scene_mix,
-        "similarity_threshold": similarity,
-        "batch_size": batch_size,
-    }
-    merged = {
-        **config_values,
-        **{key: value for key, value in cli_overrides.items() if value is not None},
-    }
-    return SelectionConfig.from_cli_args(**merged)
-
-
 @click.command()
 @click.option(
     "-n",
@@ -324,8 +258,8 @@ def execute(
     入力パスの検証、Analyzer / Picker の初期化、画像選定、
     出力フォルダへのコピー、標準出力への集計表示、
     必要に応じたJSONレポート出力までを一括で行う。
-    選択設定は `build_selection_config` を経由して解決されるため、
-    優先順位は常に `CLI > config file > built-in default` になる。
+    実行時設定は config resolver を経由して解決されるため、
+    CLIはオプション変換と入力検証に集中する。
 
     \b
     使用例:
@@ -370,7 +304,7 @@ def execute(
                 param_hint="input_dir",
             )
 
-        analyzer_config, selection_config = _resolve_configs(
+        analyzer_config, selection_config = ConfigResolver.resolve_configs(
             config_path=config_path,
             profile=profile,
             scene_mix=scene_mix,

--- a/src/utils/config_loader.py
+++ b/src/utils/config_loader.py
@@ -24,7 +24,7 @@ class ConfigLoader:
 
         `[selection]`, `[scene_mix]`, `[thresholds]` のうち、
         実行時に必要な項目だけを抽出して返す。
-        優先順位の解決自体は行わず、後段の `build_selection_config`
+        優先順位の解決自体は行わず、後段の `ConfigResolver`
         で CLI override と合成する前提の補助メソッドである。
 
         Args:

--- a/src/utils/config_resolver.py
+++ b/src/utils/config_resolver.py
@@ -1,0 +1,62 @@
+"""実行時設定の解決."""
+
+from typing import Any
+
+from ..models.analyzer_config import AnalyzerConfig
+from ..models.scene_mix import SceneMix
+from ..models.selection_config import SelectionConfig
+from .config_loader import ConfigLoader
+
+
+class ConfigResolver:
+    """設定ファイル値とCLI上書き値から実行時設定を構築する."""
+
+    @staticmethod
+    def resolve_configs(
+        *,
+        config_path: str | None,
+        profile: str | None,
+        scene_mix: SceneMix | None,
+        similarity: float | None,
+        batch_size: int | None,
+        result_max_workers: int | None,
+        max_dim: int,
+        max_memory_gb: int,
+    ) -> tuple[AnalyzerConfig, SelectionConfig]:
+        """解析設定と選択設定を構築する."""
+        analyzer_config = AnalyzerConfig.from_cli_args(
+            result_max_workers=result_max_workers,
+            max_dim=max_dim,
+            max_memory_gb=max_memory_gb,
+        )
+        selection_config = ConfigResolver.resolve_selection_config(
+            config_path=config_path,
+            profile=profile,
+            scene_mix=scene_mix,
+            similarity=similarity,
+            batch_size=batch_size,
+        )
+        return analyzer_config, selection_config
+
+    @staticmethod
+    def resolve_selection_config(
+        *,
+        config_path: str | None,
+        profile: str | None,
+        scene_mix: SceneMix | None,
+        similarity: float | None,
+        batch_size: int | None,
+    ) -> SelectionConfig:
+        """設定ファイル値とCLI上書き値から選択設定を構築する."""
+        config_values = ConfigLoader.load(config_path)
+        cli_overrides: dict[str, Any] = {
+            "profile": profile,
+            "scene_mix": scene_mix,
+            "similarity_threshold": similarity,
+            "batch_size": batch_size,
+        }
+        merged = {
+            **config_values,
+            **{key: value for key, value in cli_overrides.items() if value is not None},
+        }
+        return SelectionConfig.from_cli_args(**merged)

--- a/src/utils/config_resolver.py
+++ b/src/utils/config_resolver.py
@@ -1,7 +1,5 @@
 """実行時設定の解決."""
 
-from typing import Any
-
 from ..models.analyzer_config import AnalyzerConfig
 from ..models.scene_mix import SceneMix
 from ..models.selection_config import SelectionConfig
@@ -49,14 +47,14 @@ class ConfigResolver:
     ) -> SelectionConfig:
         """設定ファイル値とCLI上書き値から選択設定を構築する."""
         config_values = ConfigLoader.load(config_path)
-        cli_overrides: dict[str, Any] = {
+        cli_overrides = {
             "profile": profile,
             "scene_mix": scene_mix,
             "similarity_threshold": similarity,
             "batch_size": batch_size,
         }
-        merged = {
-            **config_values,
-            **{key: value for key, value in cli_overrides.items() if value is not None},
-        }
+        merged = dict(config_values)
+        for key, value in cli_overrides.items():
+            if value is not None:
+                merged[key] = value
         return SelectionConfig.from_cli_args(**merged)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from src.constants.scene_label import SceneLabel
-from src.main import build_selection_config, run, validate_similarity_range
+from src.main import run, validate_similarity_range
 from src.models.picker_statistics import PickerStatistics
 from src.models.selection_annotation import SelectionAnnotation
 from src.services.game_screen_picker import GameScreenPicker
@@ -283,43 +283,6 @@ def test_cli_renames_outputs_by_scene(
     assert (output_dir / "play0001.png").exists()
     assert (output_dir / "event0001.jpg").exists()
     assert (output_dir / "play0002.jpg").exists()
-
-
-def test_build_selection_config_prefers_cli_over_config(tmp_path: Path) -> None:
-    """CLIオプションが設定ファイルより優先されること.
-
-    Arrange:
-        - 設定ファイルにprofile=static/similarity=0.66が書かれている
-        - CLIオプションでprofile=active/similarity=0.8が指定されている
-    Act:
-        - build_selection_configを呼び出す
-    Assert:
-        - profileはCLIのactiveが優先されること
-        - similarityはCLIの0.8が優先されること
-        - scene_mixは設定ファイルの値が使用されること
-    """
-    # Arrange
-    config_path = tmp_path / "picker.toml"
-    config_path.write_text(
-        '[selection]\nprofile = "static"\n'
-        "[scene_mix]\nplay = 0.6\nevent = 0.4\n"
-        "[thresholds]\nsimilarity = 0.66\n",
-        encoding="utf-8",
-    )
-
-    # Act
-    config = build_selection_config(
-        config_path=str(config_path),
-        profile="active",
-        scene_mix=None,
-        similarity=0.8,
-        batch_size=None,
-    )
-
-    # Assert
-    assert config.profile == "active"
-    assert config.similarity_threshold == 0.8
-    assert config.scene_mix.play == 0.6
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_config_resolver.py
+++ b/tests/utils/test_config_resolver.py
@@ -1,0 +1,121 @@
+"""ConfigResolver の単体テスト."""
+
+from pathlib import Path
+
+from src.models.scene_mix import SceneMix
+from src.utils.config_resolver import ConfigResolver
+
+
+def test_resolve_selection_config_prefers_cli_over_config_file(
+    tmp_path: Path,
+) -> None:
+    """CLI上書き値が設定ファイル値より優先されること.
+
+    Arrange:
+        - 設定ファイルに profile / scene_mix / similarity が設定されている
+        - CLI上書き値に profile / similarity が指定されている
+    Act:
+        - SelectionConfig が解決される
+    Assert:
+        - profile と similarity はCLI値が使用されること
+        - scene_mix は設定ファイル値が使用されること
+    """
+    # Arrange
+    config_path = tmp_path / "picker.toml"
+    config_path.write_text(
+        '[selection]\nprofile = "static"\n'
+        "[scene_mix]\nplay = 0.6\nevent = 0.4\n"
+        "[thresholds]\nsimilarity = 0.66\n",
+        encoding="utf-8",
+    )
+
+    # Act
+    config = ConfigResolver.resolve_selection_config(
+        config_path=str(config_path),
+        profile="active",
+        scene_mix=None,
+        similarity=0.8,
+        batch_size=None,
+    )
+
+    # Assert
+    assert config.profile == "active"
+    assert config.similarity_threshold == 0.8
+    assert config.scene_mix.play == 0.6
+    assert config.scene_mix.event == 0.4
+
+
+def test_resolve_selection_config_uses_defaults_when_values_are_absent() -> None:
+    """未指定値に組み込みデフォルトが使用されること.
+
+    Arrange:
+        - 設定ファイルとCLI上書き値が指定されていない
+    Act:
+        - SelectionConfig が解決される
+    Assert:
+        - SelectionConfig のデフォルト値が返されること
+    """
+    # Arrange
+    config_path = None
+
+    # Act
+    config = ConfigResolver.resolve_selection_config(
+        config_path=config_path,
+        profile=None,
+        scene_mix=None,
+        similarity=None,
+        batch_size=None,
+    )
+
+    # Assert
+    assert config.profile == "auto"
+    assert config.similarity_threshold == 0.72
+    assert config.scene_mix.play == 0.7
+    assert config.scene_mix.event == 0.3
+    assert config.batch_size == 32
+
+
+def test_resolve_configs_returns_analyzer_and_selection_configs_from_cli_values(
+    tmp_path: Path,
+) -> None:
+    """AnalyzerConfig と SelectionConfig がCLI値から解決されること.
+
+    Arrange:
+        - 設定ファイルに selection 設定が指定されている
+        - CLI上書き値に analyzer 設定と selection 設定が指定されている
+    Act:
+        - 実行時設定がまとめて解決される
+    Assert:
+        - analyzer 設定にCLI値が反映されること
+        - selection 設定に優先順位どおりの値が反映されること
+    """
+    # Arrange
+    config_path = tmp_path / "picker.toml"
+    config_path.write_text(
+        '[selection]\nprofile = "static"\n'
+        "[scene_mix]\nplay = 0.6\nevent = 0.4\n"
+        "[thresholds]\nsimilarity = 0.66\n",
+        encoding="utf-8",
+    )
+
+    # Act
+    analyzer_config, selection_config = ConfigResolver.resolve_configs(
+        config_path=str(config_path),
+        profile=None,
+        scene_mix=SceneMix(play=0.8, event=0.2),
+        similarity=None,
+        batch_size=64,
+        result_max_workers=2,
+        max_dim=1080,
+        max_memory_gb=4,
+    )
+
+    # Assert
+    assert analyzer_config.result_max_workers == 2
+    assert analyzer_config.max_dim == 1080
+    assert analyzer_config.max_memory_gb == 4
+    assert selection_config.profile == "static"
+    assert selection_config.similarity_threshold == 0.66
+    assert selection_config.scene_mix.play == 0.8
+    assert selection_config.scene_mix.event == 0.2
+    assert selection_config.batch_size == 64


### PR DESCRIPTION
## Summary
- ConfigResolver を追加し、設定ファイル値と CLI override の統合責務を CLI adapter から分離
- main.py は入力検証とオプション変換に寄せ、AnalyzerConfig / SelectionConfig の構築を resolver 経由に変更
- config resolver の優先順位と analyzer / selection config 構築をテストで固定

## Verification
- uv run task test

## Notes
- ユーザー向けの設定ファイル形式や CLI option は変更していません。