### PR TITLE
feat: content filter の reject reason を明示化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ uv run game-screen-pick --config ./picker.toml --report-json ./report.json ./scr
 現在の実装は次の流れです。
 
 1. 入力画像をすべて解析し、CLIP特徴・結合特徴・画質メトリクスを作る
-2. 解析結果をもとに `content filter` を実施し、暗転・白飛び・単色・遷移フレームを除外する
+2. 解析結果をもとに `content filter` を実施し、暗転・白飛び・単色・遷移フレームを明示的な reject reason 付きで除外する
 3. 残った画像について、画像全体の中でどれだけ近傍類似画像が多いかを `density_score` として計算する
 4. `density_score` が高い側を `play`、低い側を `event` として既定で 70/30 に割り当てる
 5. `play` / `event` ごとに外れ値を除外し、低スコア帯から高スコア帯まで均等に候補順を組む

--- a/src/models/content_filter_result.py
+++ b/src/models/content_filter_result.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from .adaptive_scores import AdaptiveScores
 from .analyzed_image import AnalyzedImage
+from .content_reject_reason import ContentRejectReason
 from .whole_input_profile import WholeInputProfile
 
 
@@ -15,4 +16,5 @@ class ContentFilterResult:
     adaptive_scores_by_path: dict[str, AdaptiveScores]
     rejected_by_content_filter: int
     content_filter_breakdown: dict[str, int]
+    rejected_reason_by_path: dict[str, ContentRejectReason]
     whole_input_profile: WholeInputProfile

--- a/src/models/content_reject_reason.py
+++ b/src/models/content_reject_reason.py
@@ -1,0 +1,18 @@
+"""content filter の hard reject 理由."""
+
+from enum import StrEnum
+
+
+class ContentRejectReason(StrEnum):
+    """content filter が画像を除外した理由."""
+
+    BLACKOUT = "blackout"
+    WHITEOUT = "whiteout"
+    SINGLE_TONE = "single_tone"
+    FADE_TRANSITION = "fade_transition"
+    TEMPORAL_TRANSITION = "temporal_transition"
+
+    @classmethod
+    def empty_breakdown(cls) -> dict[str, int]:
+        """全理由を0件で初期化したbreakdownを返す."""
+        return {reason.value: 0 for reason in cls}

--- a/src/services/content_filter.py
+++ b/src/services/content_filter.py
@@ -9,6 +9,7 @@ from ..constants.content_filter_thresholds import (
 from ..models.adaptive_scores import AdaptiveScores
 from ..models.analyzed_image import AnalyzedImage
 from ..models.content_filter_result import ContentFilterResult
+from ..models.content_reject_reason import ContentRejectReason
 from ..utils.vector_utils import VectorUtils
 from .static_reject_classifier import StaticRejectClassifier
 from .whole_input_profiler import WholeInputProfiler
@@ -16,14 +17,6 @@ from .whole_input_profiler import WholeInputProfiler
 
 class ContentFilter:
     """真っ暗・真っ白・単色・暗転途中を hard reject する."""
-
-    REJECTION_REASONS = (
-        "blackout",
-        "whiteout",
-        "single_tone",
-        "fade_transition",
-        "temporal_transition",
-    )
 
     def __init__(self, profiler: WholeInputProfiler):
         """ContentFilterを初期化する."""
@@ -34,7 +27,7 @@ class ContentFilter:
         """入力全体の分布を使って hard reject を適用する."""
         profile = self.profiler.build_profile(images)
         adaptive_scores = self.profiler.score_images(images)
-        breakdown = dict.fromkeys(self.REJECTION_REASONS, 0)
+        breakdown = ContentRejectReason.empty_breakdown()
         rejected_reasons_by_index = {
             index: self._static_classifier.classify(
                 image=image,
@@ -49,21 +42,24 @@ class ContentFilter:
             rejected_reasons_by_index,
         )
         kept_images: list[AnalyzedImage] = []
+        rejected_reason_by_path: dict[str, ContentRejectReason] = {}
 
         for index, image in enumerate(images):
             reason = rejected_reasons_by_index[index]
             if reason is None and index in temporal_rejected_indices:
-                reason = "temporal_transition"
+                reason = ContentRejectReason.TEMPORAL_TRANSITION
             if reason is None:
                 kept_images.append(image)
                 continue
-            breakdown[reason] += 1
+            breakdown[reason.value] += 1
+            rejected_reason_by_path[image.path] = reason
 
         return ContentFilterResult(
             kept_images=kept_images,
             adaptive_scores_by_path=adaptive_scores,
             rejected_by_content_filter=sum(breakdown.values()),
             content_filter_breakdown=breakdown,
+            rejected_reason_by_path=rejected_reason_by_path,
             whole_input_profile=profile,
         )
 
@@ -71,7 +67,7 @@ class ContentFilter:
         self,
         images: list[AnalyzedImage],
         adaptive_scores: dict[str, AdaptiveScores],
-        static_reasons_by_index: dict[int, str | None],
+        static_reasons_by_index: dict[int, ContentRejectReason | None],
     ) -> set[int]:
         """前後関係から暗転途中フレームを検出する."""
         if len(images) < 3:

--- a/src/services/static_reject_classifier.py
+++ b/src/services/static_reject_classifier.py
@@ -51,6 +51,7 @@ from ..constants.content_filter_thresholds import (
 )
 from ..models.adaptive_scores import AdaptiveScores
 from ..models.analyzed_image import AnalyzedImage
+from ..models.content_reject_reason import ContentRejectReason
 from ..models.raw_metrics import RawMetrics
 from ..models.whole_input_profile import WholeInputProfile
 from ..utils.transition_metrics import TransitionMetrics
@@ -64,7 +65,7 @@ class StaticRejectClassifier:
         image: AnalyzedImage,
         profile: WholeInputProfile,
         adaptive_scores: AdaptiveScores,
-    ) -> str | None:
+    ) -> ContentRejectReason | None:
         """固定条件に従って hard reject 理由を返す."""
         raw = image.raw_metrics
         p10_range = max(LUMINANCE_RANGE_P10_MIN, profile.luminance_range.p10)
@@ -135,19 +136,22 @@ class StaticRejectClassifier:
             veiled_transition_score,
             system_ui_signal,
         ):
-            return "fade_transition"
+            return ContentRejectReason.FADE_TRANSITION
 
         return None
 
     @staticmethod
-    def _detect_blackout(raw: RawMetrics, p10_range: float) -> str | None:
+    def _detect_blackout(
+        raw: RawMetrics,
+        p10_range: float,
+    ) -> ContentRejectReason | None:
         """ブラックアウトを検出する."""
         if (
             raw.near_black_ratio >= BLACKOUT_NEAR_BLACK_RATIO
             and raw.luminance_entropy <= BLACKOUT_LUMINANCE_ENTROPY_MAX
             and raw.luminance_range <= p10_range
         ):
-            return "blackout"
+            return ContentRejectReason.BLACKOUT
         return None
 
     @staticmethod
@@ -156,7 +160,7 @@ class StaticRejectClassifier:
         profile: WholeInputProfile,
         adaptive_scores: AdaptiveScores,
         bright_washout_score: float,
-    ) -> str | None:
+    ) -> ContentRejectReason | None:
         """ホワイトアウトを検出する（3条件）."""
 
         if (
@@ -165,7 +169,7 @@ class StaticRejectClassifier:
             and raw.luminance_range
             <= max(WHITEOUT_LUMINANCE_RANGE_MIN, profile.luminance_range.p25)
         ):
-            return "whiteout"
+            return ContentRejectReason.WHITEOUT
 
         if (
             raw.brightness >= WHITEOUT_BRIGHTNESS_THRESHOLD
@@ -174,7 +178,7 @@ class StaticRejectClassifier:
             <= max(WHITEOUT_MAX_EDGE_DENSITY, profile.edge_density.p10)
             and raw.dominant_tone_ratio >= WHITEOUT_MIN_DOMINANT_TONE_RATIO
         ):
-            return "whiteout"
+            return ContentRejectReason.WHITEOUT
 
         if (
             bright_washout_score >= WHITEOUT_BRIGHT_WASHOUT_THRESHOLD
@@ -184,7 +188,7 @@ class StaticRejectClassifier:
             <= max(WHITEOUT_RELAXED_MAX_EDGE_DENSITY, profile.edge_density.p25)
             and adaptive_scores.visibility_score <= WHITEOUT_RELAXED_MAX_VISIBILITY
         ):
-            return "whiteout"
+            return ContentRejectReason.WHITEOUT
 
         return None
 
@@ -193,7 +197,7 @@ class StaticRejectClassifier:
         raw: RawMetrics,
         profile: WholeInputProfile,
         p10_range: float,
-    ) -> str | None:
+    ) -> ContentRejectReason | None:
         """単色画像を検出する."""
         if (
             raw.dominant_tone_ratio >= SINGLE_TONE_DOMINANT_RATIO
@@ -201,7 +205,7 @@ class StaticRejectClassifier:
             and raw.contrast <= profile.contrast.p25
             and raw.edge_density <= profile.edge_density.p25
         ):
-            return "single_tone"
+            return ContentRejectReason.SINGLE_TONE
         return None
 
     @staticmethod
@@ -211,7 +215,7 @@ class StaticRejectClassifier:
         adaptive_scores: AdaptiveScores,
         bright_washout_score: float,
         relative_bright_transition_score: float,
-    ) -> str | None:
+    ) -> ContentRejectReason | None:
         """相対的な明転遷移を検出する."""
         if (
             relative_bright_transition_score >= RELATIVE_BRIGHT_TRANSITION_THRESHOLD
@@ -228,8 +232,8 @@ class StaticRejectClassifier:
                 relative_bright_transition_score >= RELATIVE_BRIGHT_EXTREME_TRANSITION
                 or raw.near_white_ratio >= RELATIVE_BRIGHT_EXTREME_THRESHOLD
             ):
-                return "whiteout"
-            return "fade_transition"
+                return ContentRejectReason.WHITEOUT
+            return ContentRejectReason.FADE_TRANSITION
         return None
 
     @staticmethod
@@ -238,14 +242,14 @@ class StaticRejectClassifier:
         adaptive_scores: AdaptiveScores,
         profile: WholeInputProfile,
         relative_dark_transition_score: float,
-    ) -> str | None:
+    ) -> ContentRejectReason | None:
         """相対的な暗転遷移を検出する."""
         if (
             relative_dark_transition_score >= RELATIVE_DARK_TRANSITION_THRESHOLD
             and adaptive_scores.visibility_score <= RELATIVE_DARK_VISIBILITY_MAX
             and raw.brightness <= profile.brightness.p25
         ):
-            return "fade_transition"
+            return ContentRejectReason.FADE_TRANSITION
         return None
 
     @classmethod

--- a/tests/services/test_content_filter.py
+++ b/tests/services/test_content_filter.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from src.models.content_filter_result import ContentFilterResult
+from src.models.content_reject_reason import ContentRejectReason
 from src.services.content_filter import ContentFilter
 from src.services.whole_input_profiler import WholeInputProfiler
 from tests.conftest import create_analyzed_image
@@ -202,6 +203,52 @@ def test_content_filter_rejects_flat_frames_and_keeps_informative_dark_frames() 
         result.adaptive_scores_by_path[dark_gameplay.path].visibility_score
         > result.adaptive_scores_by_path[fade_transition.path].visibility_score
     )
+
+
+def test_content_filter_result_exposes_rejected_reasons_by_path() -> None:
+    """除外された画像の理由が結果から明示的に参照されること.
+
+    Arrange:
+        - 正常フレームとブラックアウトフレームがある
+    Act:
+        - ContentFilterでフィルタリングされる
+    Assert:
+        - 除外された画像のpathとreasonが結果から取得されること
+        - 既存のbreakdownも同じ理由で集計されること
+    """
+    # Arrange
+    # Act
+    result = _filter_two_images(
+        kept_path="/tmp/good_gameplay.jpg",
+        kept_raw_metrics={
+            "brightness": 110.0,
+            "contrast": 18.0,
+            "edge_density": 0.20,
+            "action_intensity": 14.0,
+            "luminance_entropy": 1.3,
+            "luminance_range": 36.0,
+            "near_black_ratio": 0.12,
+            "dominant_tone_ratio": 0.60,
+        },
+        rejected_path="/tmp/blackout.jpg",
+        rejected_raw_metrics={
+            "brightness": 1.0,
+            "contrast": 0.2,
+            "edge_density": 0.001,
+            "action_intensity": 0.1,
+            "luminance_entropy": 0.05,
+            "luminance_range": 1.0,
+            "near_black_ratio": 0.99,
+            "near_white_ratio": 0.0,
+            "dominant_tone_ratio": 1.0,
+        },
+    )
+
+    # Assert
+    assert result.rejected_reason_by_path == {
+        "/tmp/blackout.jpg": ContentRejectReason.BLACKOUT
+    }
+    assert result.content_filter_breakdown["blackout"] == 1
 
 
 def test_content_filter_rejects_mid_fade_frames_with_70_percent_dark_ratio() -> None:
@@ -612,14 +659,14 @@ def test_content_filter_rejects_temporal_transition_only_for_middle_frame() -> N
     mid_transition = create_analyzed_image(
         path="/tmp/frame_002.jpg",
         raw_metrics_dict={
-            "brightness": 38.0,
-            "contrast": 9.5,
-            "edge_density": 0.08,
-            "action_intensity": 4.5,
-            "luminance_entropy": 0.8,
-            "luminance_range": 28.0,
-            "near_black_ratio": 0.18,
-            "dominant_tone_ratio": 0.62,
+            "brightness": 100.0,
+            "contrast": 8.0,
+            "edge_density": 0.04,
+            "action_intensity": 3.0,
+            "luminance_entropy": 0.6,
+            "luminance_range": 15.0,
+            "near_black_ratio": 0.10,
+            "dominant_tone_ratio": 0.58,
         },
         content_features=_feature(11),
         combined_features=np.pad(_feature(11), (0, 475)),
@@ -649,11 +696,10 @@ def test_content_filter_rejects_temporal_transition_only_for_middle_frame() -> N
         "/tmp/frame_001.jpg",
         "/tmp/frame_003.jpg",
     }
-    assert (
-        result.content_filter_breakdown["fade_transition"]
-        + result.content_filter_breakdown["temporal_transition"]
-        == 1
-    )
+    assert result.rejected_reason_by_path == {
+        "/tmp/frame_002.jpg": ContentRejectReason.TEMPORAL_TRANSITION
+    }
+    assert result.content_filter_breakdown["temporal_transition"] == 1
 
 
 def test_temporal_transition_not_triggered_for_dissimilar_neighbors() -> None:

--- a/tests/services/test_content_filter.py
+++ b/tests/services/test_content_filter.py
@@ -217,31 +217,34 @@ def test_content_filter_result_exposes_rejected_reasons_by_path() -> None:
         - 既存のbreakdownも同じ理由で集計されること
     """
     # Arrange
+    kept_raw_metrics = {
+        "brightness": 110.0,
+        "contrast": 18.0,
+        "edge_density": 0.20,
+        "action_intensity": 14.0,
+        "luminance_entropy": 1.3,
+        "luminance_range": 36.0,
+        "near_black_ratio": 0.12,
+        "dominant_tone_ratio": 0.60,
+    }
+    rejected_raw_metrics = {
+        "brightness": 1.0,
+        "contrast": 0.2,
+        "edge_density": 0.001,
+        "action_intensity": 0.1,
+        "luminance_entropy": 0.05,
+        "luminance_range": 1.0,
+        "near_black_ratio": 0.99,
+        "near_white_ratio": 0.0,
+        "dominant_tone_ratio": 1.0,
+    }
+
     # Act
     result = _filter_two_images(
         kept_path="/tmp/good_gameplay.jpg",
-        kept_raw_metrics={
-            "brightness": 110.0,
-            "contrast": 18.0,
-            "edge_density": 0.20,
-            "action_intensity": 14.0,
-            "luminance_entropy": 1.3,
-            "luminance_range": 36.0,
-            "near_black_ratio": 0.12,
-            "dominant_tone_ratio": 0.60,
-        },
+        kept_raw_metrics=kept_raw_metrics,
         rejected_path="/tmp/blackout.jpg",
-        rejected_raw_metrics={
-            "brightness": 1.0,
-            "contrast": 0.2,
-            "edge_density": 0.001,
-            "action_intensity": 0.1,
-            "luminance_entropy": 0.05,
-            "luminance_range": 1.0,
-            "near_black_ratio": 0.99,
-            "near_white_ratio": 0.0,
-            "dominant_tone_ratio": 1.0,
-        },
+        rejected_raw_metrics=rejected_raw_metrics,
     )
 
     # Assert
@@ -631,7 +634,7 @@ def test_relative_transition_uses_whole_input_brightness_tendency() -> None:
 
 
 def test_content_filter_rejects_temporal_transition_only_for_middle_frame() -> None:
-    """通常 -> 暗転途中 -> 通常 の中央だけが temporal 判定で落ちること.
+    """通常 -> 低視認フレーム -> 通常 の中央だけが temporal 判定で落ちること.
 
     Arrange:
         - 通常フレーム、遷移途中フレーム、通常フレームの順序で画像群がある

--- a/tests/services/test_static_reject_classifier.py
+++ b/tests/services/test_static_reject_classifier.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from src.models.adaptive_scores import AdaptiveScores
 from src.models.analyzed_image import AnalyzedImage
+from src.models.content_reject_reason import ContentRejectReason
 from src.services.static_reject_classifier import StaticRejectClassifier
 from tests.conftest import build_whole_input_profile, create_analyzed_image
 
@@ -143,8 +144,8 @@ def test_static_reject_classifier_classifies_low_information_frames() -> None:
     # Assert
     assert reasons == {
         "/tmp/informative.jpg": None,
-        "/tmp/blackout.jpg": "blackout",
-        "/tmp/whiteout.jpg": "whiteout",
-        "/tmp/single_tone.jpg": "single_tone",
-        "/tmp/fade_transition.jpg": "fade_transition",
+        "/tmp/blackout.jpg": ContentRejectReason.BLACKOUT,
+        "/tmp/whiteout.jpg": ContentRejectReason.WHITEOUT,
+        "/tmp/single_tone.jpg": ContentRejectReason.SINGLE_TONE,
+        "/tmp/fade_transition.jpg": ContentRejectReason.FADE_TRANSITION,
     }


### PR DESCRIPTION
## Summary

- content filter の reject reason を `ContentRejectReason` enum として明示化
- `ContentFilterResult` から path ごとの reject reason を参照できるように変更
- 既存の `content_filter_breakdown` と report 出力の互換性を維持
- static / temporal rejection の公開挙動をテストで明確化
- README の処理フローを更新

Closes #121

## Verification

- `uv run task test` で 109 件通過

## Notes

- report JSON の `content_filter_breakdown` は従来どおり文字列キーのままです。