### PR TITLE
refactor: 解析済み画像の選定処理をdomain moduleに集約

### DIFF
--- a/src/services/analyzed_image_selector.py
+++ b/src/services/analyzed_image_selector.py
@@ -4,9 +4,11 @@ from ..analyzers.metric_calculator import MetricCalculator
 from ..constants.scene_label import SceneLabel
 from ..constants.selection_profiles import PROFILE_REGISTRY
 from ..models.analyzed_image import AnalyzedImage
+from ..models.content_filter_result import ContentFilterResult
 from ..models.picker_statistics import PickerStatistics
 from ..models.scored_candidate import ScoredCandidate
 from ..models.selection_config import SelectionConfig
+from ..models.selection_result import SelectionResult
 from .candidate_scorer import CandidateScorer
 from .content_filter import ContentFilter
 from .profile_resolver import ProfileResolver
@@ -40,14 +42,33 @@ class AnalyzedImageSelector:
     ) -> tuple[list[ScoredCandidate], list[ScoredCandidate], PickerStatistics]:
         """解析済み画像から候補を選択する."""
         content_filter_result = self._content_filter.filter(analyzed_images)
-        filtered_images = content_filter_result.kept_images
         candidates, resolved_profile, scene_distribution = self._score_candidates(
-            filtered_images
+            content_filter_result.kept_images
         )
         selection_result = self._scene_mix_selector.select(candidates, num)
         selected = selection_result.selected
+        rejected = self._build_rejected_candidates(candidates, selected)
+
+        stats = self._build_statistics(
+            analyzed_images=analyzed_images,
+            total_files=total_files,
+            analyzed_fail=analyzed_fail,
+            content_filter_result=content_filter_result,
+            selection_result=selection_result,
+            selected_count=len(selected),
+            resolved_profile=resolved_profile,
+            scene_distribution=scene_distribution,
+        )
+        return selected, rejected, stats
+
+    @staticmethod
+    def _build_rejected_candidates(
+        candidates: list[ScoredCandidate],
+        selected: list[ScoredCandidate],
+    ) -> list[ScoredCandidate]:
+        """非選択候補を選定スコア順に並べる."""
         selected_paths = {candidate.path for candidate in selected}
-        rejected = sorted(
+        return sorted(
             [
                 candidate
                 for candidate in candidates
@@ -57,15 +78,26 @@ class AnalyzedImageSelector:
             reverse=True,
         )
 
-        stats = PickerStatistics(
-            total_files=total_files
-            if total_files is not None
-            else len(analyzed_images),
+    def _build_statistics(
+        self,
+        analyzed_images: list[AnalyzedImage],
+        total_files: int | None,
+        analyzed_fail: int,
+        content_filter_result: ContentFilterResult,
+        selection_result: SelectionResult[ScoredCandidate],
+        selected_count: int,
+        resolved_profile: str,
+        scene_distribution: dict[str, int],
+    ) -> PickerStatistics:
+        """選定処理で得た中間結果から統計を組み立てる."""
+        input_total = total_files if total_files is not None else len(analyzed_images)
+        return PickerStatistics(
+            total_files=input_total,
             analyzed_ok=len(analyzed_images),
             analyzed_fail=analyzed_fail,
             rejected_by_similarity=selection_result.rejected_by_similarity,
             rejected_by_content_filter=content_filter_result.rejected_by_content_filter,
-            selected_count=len(selected),
+            selected_count=selected_count,
             resolved_profile=resolved_profile,
             scene_distribution=scene_distribution,
             scene_mix_target=selection_result.target_counts,
@@ -77,7 +109,6 @@ class AnalyzedImageSelector:
             whole_input_profile=content_filter_result.whole_input_profile,
             selection_annotations_by_path=selection_result.annotations_by_path,
         )
-        return selected, rejected, stats
 
     def _score_candidates(
         self,

--- a/src/services/analyzed_image_selector.py
+++ b/src/services/analyzed_image_selector.py
@@ -1,0 +1,117 @@
+"""解析済み画像から最終候補を選定する domain module."""
+
+from ..analyzers.metric_calculator import MetricCalculator
+from ..constants.scene_label import SceneLabel
+from ..constants.selection_profiles import PROFILE_REGISTRY
+from ..models.analyzed_image import AnalyzedImage
+from ..models.picker_statistics import PickerStatistics
+from ..models.scored_candidate import ScoredCandidate
+from ..models.selection_config import SelectionConfig
+from .candidate_scorer import CandidateScorer
+from .content_filter import ContentFilter
+from .profile_resolver import ProfileResolver
+from .scene_mix_selector import SceneMixSelector
+from .scene_scorer import SceneScorer
+from .whole_input_profiler import WholeInputProfiler
+
+
+class AnalyzedImageSelector:
+    """解析済み画像から play / event の最終選定結果を作る."""
+
+    def __init__(
+        self,
+        config: SelectionConfig,
+        metric_calculator: MetricCalculator,
+    ) -> None:
+        """selectorを初期化する."""
+        self.config = config
+        self._scene_scorer = SceneScorer()
+        self._profile_resolver = ProfileResolver()
+        self._candidate_scorer = CandidateScorer(metric_calculator)
+        self._scene_mix_selector = SceneMixSelector(config)
+        self._content_filter = ContentFilter(WholeInputProfiler())
+
+    def select(
+        self,
+        analyzed_images: list[AnalyzedImage],
+        num: int,
+        total_files: int | None = None,
+        analyzed_fail: int = 0,
+    ) -> tuple[list[ScoredCandidate], list[ScoredCandidate], PickerStatistics]:
+        """解析済み画像から候補を選択する."""
+        content_filter_result = self._content_filter.filter(analyzed_images)
+        filtered_images = content_filter_result.kept_images
+        candidates, resolved_profile, scene_distribution = self._score_candidates(
+            filtered_images
+        )
+        selection_result = self._scene_mix_selector.select(candidates, num)
+        selected = selection_result.selected
+        selected_paths = {candidate.path for candidate in selected}
+        rejected = sorted(
+            [
+                candidate
+                for candidate in candidates
+                if candidate.path not in selected_paths
+            ],
+            key=lambda item: item.selection_score,
+            reverse=True,
+        )
+
+        stats = PickerStatistics(
+            total_files=total_files
+            if total_files is not None
+            else len(analyzed_images),
+            analyzed_ok=len(analyzed_images),
+            analyzed_fail=analyzed_fail,
+            rejected_by_similarity=selection_result.rejected_by_similarity,
+            rejected_by_content_filter=content_filter_result.rejected_by_content_filter,
+            selected_count=len(selected),
+            resolved_profile=resolved_profile,
+            scene_distribution=scene_distribution,
+            scene_mix_target=selection_result.target_counts,
+            scene_mix_actual=selection_result.actual_counts,
+            threshold_relaxation_steps=self.config.compute_threshold_steps(
+                self.config.similarity_threshold
+            ),
+            content_filter_breakdown=content_filter_result.content_filter_breakdown,
+            whole_input_profile=content_filter_result.whole_input_profile,
+            selection_annotations_by_path=selection_result.annotations_by_path,
+        )
+        return selected, rejected, stats
+
+    def _score_candidates(
+        self,
+        analyzed_images: list[AnalyzedImage],
+    ) -> tuple[list[ScoredCandidate], str, dict[str, int]]:
+        """scene評価とprofile解決を行い、最終候補を作る."""
+        assessments = self._scene_scorer.assess_batch(
+            analyzed_images,
+            self.config.scene_mix,
+        )
+        resolved_profile, _profile_scores = self._profile_resolver.resolve(
+            self.config.profile,
+            analyzed_images,
+        )
+        profile = PROFILE_REGISTRY[resolved_profile]
+
+        candidates = [
+            self._candidate_scorer.score(
+                image,
+                assessment,
+                profile,
+            )
+            for image, assessment in zip(analyzed_images, assessments, strict=True)
+        ]
+        scene_distribution: dict[str, int] = {
+            SceneLabel.PLAY.value: sum(
+                1
+                for candidate in candidates
+                if candidate.scene_assessment.scene_label == SceneLabel.PLAY
+            ),
+            SceneLabel.EVENT.value: sum(
+                1
+                for candidate in candidates
+                if candidate.scene_assessment.scene_label == SceneLabel.EVENT
+            ),
+        }
+        return candidates, resolved_profile, scene_distribution

--- a/src/services/game_screen_picker.py
+++ b/src/services/game_screen_picker.py
@@ -3,26 +3,19 @@
 import re
 from pathlib import Path
 
-from ..constants.scene_label import SceneLabel
-from ..constants.selection_profiles import PROFILE_REGISTRY
 from ..models.analyzed_image import AnalyzedImage
 from ..models.picker_statistics import PickerStatistics
 from ..models.scored_candidate import ScoredCandidate
 from ..models.selection_config import SelectionConfig
 from ..protocols.analyzer_like import AnalyzerLike
-from ..services.candidate_scorer import CandidateScorer
-from ..services.content_filter import ContentFilter
-from ..services.profile_resolver import ProfileResolver
-from ..services.scene_mix_selector import SceneMixSelector
-from ..services.scene_scorer import SceneScorer
-from ..services.whole_input_profiler import WholeInputProfiler
+from .analyzed_image_selector import AnalyzedImageSelector
 
 
 class GameScreenPicker:
     """画像解析と選定を統合する.
 
-    フォルダ走査、解析、scene評価、profile解決、候補採点、
-    scene mix 選定、統計生成までをひとつの入り口として提供する。
+    フォルダ走査、Analyzer実行、解析済み画像選定moduleへの委譲を
+    ひとつの入り口として提供する。
     """
 
     SUPPORTED_EXTENSIONS: frozenset[str] = frozenset(
@@ -42,11 +35,10 @@ class GameScreenPicker:
         """
         self.analyzer = analyzer
         self.config = config or SelectionConfig()
-        self._scene_scorer = SceneScorer()
-        self._profile_resolver = ProfileResolver()
-        self._candidate_scorer = CandidateScorer(self.analyzer.metric_calculator)
-        self._scene_mix_selector = SceneMixSelector(self.config)
-        self._content_filter = ContentFilter(WholeInputProfiler())
+        self._analyzed_image_selector = AnalyzedImageSelector(
+            config=self.config,
+            metric_calculator=self.analyzer.metric_calculator,
+        )
 
     @staticmethod
     def load_image_files(
@@ -103,57 +95,6 @@ class GameScreenPicker:
         )
         return [result for result in results if result is not None]
 
-    def _score_candidates(
-        self,
-        analyzed_images: list[AnalyzedImage],
-    ) -> tuple[list[ScoredCandidate], str, dict[str, int]]:
-        """scene評価とprofile解決を行い、最終候補を作る.
-
-        各画像へ `SceneScorer` で画面種別スコアを付与し、
-        `ProfileResolver` で `auto` を `active` / `static` へ解決したうえで、
-        `CandidateScorer` により品質・最終選定スコアを計算する。
-        あわせて、レポート用のscene分布も集計する。
-
-        Args:
-            analyzed_images: scene判定前の中立解析結果。
-
-        Returns:
-            1. 最終スコア付き候補のリスト
-            2. 解決済みプロファイル名
-            3. scene labelごとの件数分布
-        """
-        assessments = self._scene_scorer.assess_batch(
-            analyzed_images,
-            self.config.scene_mix,
-        )
-        resolved_profile, _profile_scores = self._profile_resolver.resolve(
-            self.config.profile,
-            analyzed_images,
-        )
-        profile = PROFILE_REGISTRY[resolved_profile]
-
-        candidates = [
-            self._candidate_scorer.score(
-                image,
-                assessment,
-                profile,
-            )
-            for image, assessment in zip(analyzed_images, assessments, strict=True)
-        ]
-        scene_distribution: dict[str, int] = {
-            SceneLabel.PLAY.value: sum(
-                1
-                for candidate in candidates
-                if candidate.scene_assessment.scene_label == SceneLabel.PLAY
-            ),
-            SceneLabel.EVENT.value: sum(
-                1
-                for candidate in candidates
-                if candidate.scene_assessment.scene_label == SceneLabel.EVENT
-            ),
-        }
-        return candidates, resolved_profile, scene_distribution
-
     def select(
         self,
         folder: str,
@@ -202,8 +143,8 @@ class GameScreenPicker:
         """解析済み画像から候補を選択する.
 
         このメソッドはファイルI/Oを行わず、ドメインロジックだけを扱う。
-        scene判定、profile解決、候補採点、scene mix選定、統計生成を
-        純粋に組み合わせるため、単体テストや再選定処理の入り口として使える。
+        scene判定、profile解決、候補採点、scene mix選定、統計生成は
+        解析済み画像選定moduleへ委譲される。
 
         Args:
             analyzed_images: 解析済みの中立画像データ。
@@ -216,42 +157,9 @@ class GameScreenPicker:
             2. 非選択候補を選定スコア順に並べたリスト
             3. scene mix目標値と実績を含む `PickerStatistics`
         """
-        content_filter_result = self._content_filter.filter(analyzed_images)
-        filtered_images = content_filter_result.kept_images
-        candidates, resolved_profile, scene_distribution = self._score_candidates(
-            filtered_images
-        )
-        selection_result = self._scene_mix_selector.select(candidates, num)
-        selected = selection_result.selected
-        selected_paths = {candidate.path for candidate in selected}
-        rejected = sorted(
-            [
-                candidate
-                for candidate in candidates
-                if candidate.path not in selected_paths
-            ],
-            key=lambda item: item.selection_score,
-            reverse=True,
-        )
-
-        stats = PickerStatistics(
-            total_files=total_files
-            if total_files is not None
-            else len(analyzed_images),
-            analyzed_ok=len(analyzed_images),
+        return self._analyzed_image_selector.select(
+            analyzed_images=analyzed_images,
+            num=num,
+            total_files=total_files,
             analyzed_fail=analyzed_fail,
-            rejected_by_similarity=selection_result.rejected_by_similarity,
-            rejected_by_content_filter=content_filter_result.rejected_by_content_filter,
-            selected_count=len(selected),
-            resolved_profile=resolved_profile,
-            scene_distribution=scene_distribution,
-            scene_mix_target=selection_result.target_counts,
-            scene_mix_actual=selection_result.actual_counts,
-            threshold_relaxation_steps=self.config.compute_threshold_steps(
-                self.config.similarity_threshold
-            ),
-            content_filter_breakdown=content_filter_result.content_filter_breakdown,
-            whole_input_profile=content_filter_result.whole_input_profile,
-            selection_annotations_by_path=selection_result.annotations_by_path,
         )
-        return selected, rejected, stats

--- a/src/services/game_screen_picker.py
+++ b/src/services/game_screen_picker.py
@@ -123,13 +123,11 @@ class GameScreenPicker:
         total_files = len(files)
 
         analyzed_images = self._analyze_images(files, show_progress)
-        analyzed_ok = len(analyzed_images)
-        analyzed_fail = total_files - analyzed_ok
 
         return self.select_from_analyzed(
             analyzed_images=analyzed_images,
             total_files=total_files,
-            analyzed_fail=analyzed_fail,
+            analyzed_fail=total_files - len(analyzed_images),
             num=num,
         )
 

--- a/tests/services/test_analyzed_image_selector.py
+++ b/tests/services/test_analyzed_image_selector.py
@@ -1,0 +1,71 @@
+"""AnalyzedImageSelector の単体テスト."""
+
+from src.analyzers.metric_calculator import MetricCalculator
+from src.models.analyzer_config import AnalyzerConfig
+from src.models.scene_mix import SceneMix
+from src.models.selection_config import SelectionConfig
+from src.services.analyzed_image_selector import AnalyzedImageSelector
+from tests.conftest import _feature, create_analyzed_image
+
+
+def test_select_returns_filtered_scene_mix_and_statistics() -> None:
+    """解析済み画像から選定結果と統計が生成されること.
+
+    Arrange:
+        - content filter で除外される画像と選定対象の画像がある
+        - play/event を 1 枚ずつ選ぶ scene mix が指定されている
+    Act:
+        - AnalyzedImageSelectorで選定される
+    Assert:
+        - 除外画像を含まない選定結果が返されること
+        - 選定統計に content filter と scene mix の結果が反映されること
+    """
+    # Arrange
+    dark = create_analyzed_image(
+        path="/tmp/dark.jpg",
+        raw_metrics_dict={
+            "near_black_ratio": 0.98,
+            "luminance_entropy": 0.2,
+            "luminance_range": 10.0,
+        },
+        combined_features=_feature(0),
+    )
+    play = create_analyzed_image(
+        path="/tmp/play.jpg",
+        combined_features=_feature(1),
+    )
+    event = create_analyzed_image(
+        path="/tmp/event.jpg",
+        combined_features=_feature(100),
+    )
+    selector = AnalyzedImageSelector(
+        config=SelectionConfig(
+            profile="active",
+            scene_mix=SceneMix(play=0.5, event=0.5),
+        ),
+        metric_calculator=MetricCalculator(AnalyzerConfig()),
+    )
+
+    # Act
+    selected, rejected, stats = selector.select(
+        analyzed_images=[dark, play, event],
+        num=2,
+        total_files=4,
+        analyzed_fail=1,
+    )
+
+    # Assert
+    assert {candidate.path for candidate in selected} == {
+        "/tmp/play.jpg",
+        "/tmp/event.jpg",
+    }
+    assert rejected == []
+    assert stats.total_files == 4
+    assert stats.analyzed_ok == 3
+    assert stats.analyzed_fail == 1
+    assert stats.selected_count == 2
+    assert stats.rejected_by_content_filter == 1
+    assert stats.content_filter_breakdown["blackout"] == 1
+    assert stats.scene_mix_target == {"play": 1, "event": 1}
+    assert stats.scene_mix_actual == {"play": 1, "event": 1}
+    assert stats.resolved_profile == "active"


### PR DESCRIPTION
## Summary
- 解析済み画像からの content filter、scene assessment、profile scoring、scene mix selection、statistics assembly を `AnalyzedImageSelector` に集約
- `GameScreenPicker` を folder scan と analyzer orchestration から selector へ委譲する構成に整理
- selector の公開 interface 経由で選定結果と統計を検証するテストを追加

## Verification
- `uv run task test`（110 passed）

## Notes
- ユーザー向け CLI の挙動変更はありません。