### PR TITLE
feat: 出力計画とファイルコピーを分離する

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ uv run game-screen-pick --config ./picker.toml --report-json ./report.json ./scr
 5. `play` / `event` ごとに外れ値を除外し、低スコア帯から高スコア帯まで均等に候補順を組む
 6. その順序を保ったまま、全カテゴリ横断で類似画像を除外しながら最終出力を決める
 7. 選定結果を copy / console / JSON report 共通の出力recordへ変換する
-8. 選ばれた画像を単一の出力フォルダへコピーし、同じrecordから表示とJSONレポートを生成する
+8. `OutputPlanner` が `--rename`、scene別連番、同名衝突回避、report用 `output_path` をcopyなしで計画する
+9. 計画済みの出力先へ画像をコピーし、同じrecordから表示とJSONレポートを生成する
 
 ### `play` / `event` の意味
 

--- a/src/services/output_planner.py
+++ b/src/services/output_planner.py
@@ -1,0 +1,102 @@
+"""出力先計画を純粋に決定する."""
+
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+
+from ..models.output_record import OutputRecord
+
+
+class OutputPlanner:
+    """選択候補の出力先パスを計画する."""
+
+    @staticmethod
+    def plan_selected_outputs(
+        output_record: OutputRecord,
+        dest_dir: str,
+        rename: bool = False,
+        requested_num: int | None = None,
+        existing_filenames: Iterable[str] = (),
+    ) -> OutputRecord:
+        """選択候補の出力先パスをcopyなしで計画する.
+
+        Args:
+            output_record: 出力候補を含むrecord。
+            dest_dir: 出力先ディレクトリのパス。
+            rename: scene別の連番ファイル名で出力するかどうか。
+            requested_num: CLIで要求された出力枚数。
+            existing_filenames: 出力先に既に存在するファイル名。
+
+        Returns:
+            出力先パスを反映したrecord。
+
+        Raises:
+            ValueError: rename=True かつ requested_num が未指定の場合。
+        """
+        if rename and requested_num is None:
+            msg = "rename=True の場合は requested_num の指定が必要です"
+            raise ValueError(msg)
+
+        out = Path(dest_dir)
+        reserved_filenames = set(existing_filenames)
+        scene_counters: dict[str, int] = defaultdict(int)
+        planned_paths_by_source_path: dict[str, str] = {}
+
+        for result in output_record.selected:
+            if rename:
+                assert requested_num is not None
+                scene_counters[result.scene_label] += 1
+                filename = OutputPlanner.build_renamed_filename(
+                    scene_name=result.scene_label,
+                    index=scene_counters[result.scene_label],
+                    suffix=result.suffix,
+                    requested_num=requested_num,
+                )
+            else:
+                filename = result.filename
+
+            unique_filename = OutputPlanner.get_unique_filename(
+                filename,
+                reserved_filenames,
+            )
+            reserved_filenames.add(unique_filename)
+            planned_paths_by_source_path[result.source_path] = str(
+                (out / unique_filename).resolve()
+            )
+
+        return output_record.with_selected_output_paths(planned_paths_by_source_path)
+
+    @staticmethod
+    def build_renamed_filename(
+        scene_name: str,
+        index: int,
+        suffix: str,
+        requested_num: int,
+    ) -> str:
+        """scene名と連番から出力ファイル名を構築する."""
+        if requested_num < 1:
+            msg = f"requested_numは正の整数である必要があります: {requested_num}"
+            raise ValueError(msg)
+        width = max(4, len(str(requested_num)))
+        return f"{scene_name}{index:0{width}d}{suffix}"
+
+    @staticmethod
+    def get_unique_filename(
+        filename: str,
+        reserved_filenames: Iterable[str],
+    ) -> str:
+        """予約済みファイル名と衝突しないファイル名を生成する."""
+        reserved = set(reserved_filenames)
+        if filename not in reserved:
+            return filename
+
+        dest_path = Path(filename)
+        stem = dest_path.stem
+        suffix = dest_path.suffix
+
+        counter = 1
+        while True:
+            new_filename = f"{stem}_{counter}{suffix}"
+            if new_filename not in reserved:
+                return new_filename
+            counter += 1

--- a/src/services/output_planner.py
+++ b/src/services/output_planner.py
@@ -38,7 +38,7 @@ class OutputPlanner:
             rename,
             requested_num,
         )
-        reserved_filename_keys = OutputPlanner._build_reserved_filename_keys(
+        reserved_collision_keys = OutputPlanner._build_reserved_collision_keys(
             existing_filenames
         )
         scene_counters: dict[str, int] = defaultdict(int)
@@ -56,11 +56,11 @@ class OutputPlanner:
             else:
                 filename = candidate.filename
 
-            unique_filename = OutputPlanner._get_unique_filename_from_reserved_keys(
+            unique_filename = OutputPlanner._get_unique_filename_from_collision_keys(
                 filename,
-                reserved_filename_keys,
+                reserved_collision_keys,
             )
-            reserved_filename_keys.add(
+            reserved_collision_keys.add(
                 OutputPlanner._build_collision_key(unique_filename)
             )
             planned_paths_by_source_path[candidate.source_path] = str(
@@ -102,18 +102,18 @@ class OutputPlanner:
         reserved_filenames: Iterable[str],
     ) -> str:
         """予約済みファイル名と衝突しないファイル名を生成する."""
-        return OutputPlanner._get_unique_filename_from_reserved_keys(
+        return OutputPlanner._get_unique_filename_from_collision_keys(
             filename,
-            OutputPlanner._build_reserved_filename_keys(reserved_filenames),
+            OutputPlanner._build_reserved_collision_keys(reserved_filenames),
         )
 
     @staticmethod
-    def _get_unique_filename_from_reserved_keys(
+    def _get_unique_filename_from_collision_keys(
         filename: str,
-        reserved_filename_keys: set[str],
+        reserved_collision_keys: set[str],
     ) -> str:
-        """予約済みファイル名keyから衝突しないファイル名を生成する."""
-        if OutputPlanner._build_collision_key(filename) not in reserved_filename_keys:
+        """予約済み衝突keyから衝突しないファイル名を生成する."""
+        if OutputPlanner._build_collision_key(filename) not in reserved_collision_keys:
             return filename
 
         dest_path = Path(filename)
@@ -125,13 +125,13 @@ class OutputPlanner:
             new_filename = f"{stem}_{counter}{suffix}"
             if (
                 OutputPlanner._build_collision_key(new_filename)
-                not in reserved_filename_keys
+                not in reserved_collision_keys
             ):
                 return new_filename
             counter += 1
 
     @staticmethod
-    def _build_reserved_filename_keys(filenames: Iterable[str]) -> set[str]:
+    def _build_reserved_collision_keys(filenames: Iterable[str]) -> set[str]:
         """予約済みファイル名を衝突判定用keyへ変換する."""
         return {OutputPlanner._build_collision_key(filename) for filename in filenames}
 

--- a/src/services/output_planner.py
+++ b/src/services/output_planner.py
@@ -1,7 +1,7 @@
 """出力先計画を純粋に決定する."""
 
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 from pathlib import Path
 
 from ..models.output_record import OutputRecord
@@ -33,38 +33,50 @@ class OutputPlanner:
         Raises:
             ValueError: rename=True かつ requested_num が未指定の場合。
         """
-        if rename and requested_num is None:
-            msg = "rename=True の場合は requested_num の指定が必要です"
-            raise ValueError(msg)
-
         out = Path(dest_dir)
+        rename_requested_num = OutputPlanner._resolve_rename_requested_num(
+            rename,
+            requested_num,
+        )
         reserved_filenames = set(existing_filenames)
         scene_counters: dict[str, int] = defaultdict(int)
         planned_paths_by_source_path: dict[str, str] = {}
 
-        for result in output_record.selected:
+        for candidate in output_record.selected:
             if rename:
-                assert requested_num is not None
-                scene_counters[result.scene_label] += 1
+                scene_counters[candidate.scene_label] += 1
                 filename = OutputPlanner.build_renamed_filename(
-                    scene_name=result.scene_label,
-                    index=scene_counters[result.scene_label],
-                    suffix=result.suffix,
-                    requested_num=requested_num,
+                    scene_name=candidate.scene_label,
+                    index=scene_counters[candidate.scene_label],
+                    suffix=candidate.suffix,
+                    requested_num=rename_requested_num,
                 )
             else:
-                filename = result.filename
+                filename = candidate.filename
 
-            unique_filename = OutputPlanner.get_unique_filename(
+            unique_filename = OutputPlanner._get_unique_filename_from_reserved(
                 filename,
                 reserved_filenames,
             )
             reserved_filenames.add(unique_filename)
-            planned_paths_by_source_path[result.source_path] = str(
+            planned_paths_by_source_path[candidate.source_path] = str(
                 (out / unique_filename).resolve()
             )
 
         return output_record.with_selected_output_paths(planned_paths_by_source_path)
+
+    @staticmethod
+    def _resolve_rename_requested_num(
+        rename: bool,
+        requested_num: int | None,
+    ) -> int:
+        """rename時に必要な要求枚数を解決する."""
+        if requested_num is None:
+            if rename:
+                msg = "rename=True の場合は requested_num の指定が必要です"
+                raise ValueError(msg)
+            return 0
+        return requested_num
 
     @staticmethod
     def build_renamed_filename(
@@ -86,8 +98,18 @@ class OutputPlanner:
         reserved_filenames: Iterable[str],
     ) -> str:
         """予約済みファイル名と衝突しないファイル名を生成する."""
-        reserved = set(reserved_filenames)
-        if filename not in reserved:
+        return OutputPlanner._get_unique_filename_from_reserved(
+            filename,
+            set(reserved_filenames),
+        )
+
+    @staticmethod
+    def _get_unique_filename_from_reserved(
+        filename: str,
+        reserved_filenames: Collection[str],
+    ) -> str:
+        """予約済みファイル名collectionから衝突しないファイル名を生成する."""
+        if filename not in reserved_filenames:
             return filename
 
         dest_path = Path(filename)
@@ -97,6 +119,6 @@ class OutputPlanner:
         counter = 1
         while True:
             new_filename = f"{stem}_{counter}{suffix}"
-            if new_filename not in reserved:
+            if new_filename not in reserved_filenames:
                 return new_filename
             counter += 1

--- a/src/services/output_planner.py
+++ b/src/services/output_planner.py
@@ -1,7 +1,7 @@
 """出力先計画を純粋に決定する."""
 
 from collections import defaultdict
-from collections.abc import Collection, Iterable
+from collections.abc import Iterable
 from pathlib import Path
 
 from ..models.output_record import OutputRecord
@@ -38,7 +38,9 @@ class OutputPlanner:
             rename,
             requested_num,
         )
-        reserved_filenames = set(existing_filenames)
+        reserved_filename_keys = OutputPlanner._build_reserved_filename_keys(
+            existing_filenames
+        )
         scene_counters: dict[str, int] = defaultdict(int)
         planned_paths_by_source_path: dict[str, str] = {}
 
@@ -54,11 +56,13 @@ class OutputPlanner:
             else:
                 filename = candidate.filename
 
-            unique_filename = OutputPlanner._get_unique_filename_from_reserved(
+            unique_filename = OutputPlanner._get_unique_filename_from_reserved_keys(
                 filename,
-                reserved_filenames,
+                reserved_filename_keys,
             )
-            reserved_filenames.add(unique_filename)
+            reserved_filename_keys.add(
+                OutputPlanner._build_collision_key(unique_filename)
+            )
             planned_paths_by_source_path[candidate.source_path] = str(
                 (out / unique_filename).resolve()
             )
@@ -98,18 +102,18 @@ class OutputPlanner:
         reserved_filenames: Iterable[str],
     ) -> str:
         """予約済みファイル名と衝突しないファイル名を生成する."""
-        return OutputPlanner._get_unique_filename_from_reserved(
+        return OutputPlanner._get_unique_filename_from_reserved_keys(
             filename,
-            set(reserved_filenames),
+            OutputPlanner._build_reserved_filename_keys(reserved_filenames),
         )
 
     @staticmethod
-    def _get_unique_filename_from_reserved(
+    def _get_unique_filename_from_reserved_keys(
         filename: str,
-        reserved_filenames: Collection[str],
+        reserved_filename_keys: set[str],
     ) -> str:
-        """予約済みファイル名collectionから衝突しないファイル名を生成する."""
-        if filename not in reserved_filenames:
+        """予約済みファイル名keyから衝突しないファイル名を生成する."""
+        if OutputPlanner._build_collision_key(filename) not in reserved_filename_keys:
             return filename
 
         dest_path = Path(filename)
@@ -119,6 +123,19 @@ class OutputPlanner:
         counter = 1
         while True:
             new_filename = f"{stem}_{counter}{suffix}"
-            if new_filename not in reserved_filenames:
+            if (
+                OutputPlanner._build_collision_key(new_filename)
+                not in reserved_filename_keys
+            ):
                 return new_filename
             counter += 1
+
+    @staticmethod
+    def _build_reserved_filename_keys(filenames: Iterable[str]) -> set[str]:
+        """予約済みファイル名を衝突判定用keyへ変換する."""
+        return {OutputPlanner._build_collision_key(filename) for filename in filenames}
+
+    @staticmethod
+    def _build_collision_key(filename: str) -> str:
+        """filesystem上の大小文字差による衝突を避けるkeyを生成する."""
+        return filename.casefold()

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -2,10 +2,10 @@
 
 import logging
 import shutil
-from collections import defaultdict
 from pathlib import Path
 
 from ..models.output_record import OutputRecord
+from ..services.output_planner import OutputPlanner
 
 logger = logging.getLogger(__name__)
 
@@ -30,21 +30,13 @@ class FileUtils:
         Returns:
             出力ディレクトリ内で一意なファイルパス
         """
-        dest_path = dest_dir / filename
-
-        if not dest_path.exists():
-            return dest_path
-
-        stem = dest_path.stem
-        suffix = dest_path.suffix
-
-        counter = 1
-        while True:
-            new_filename = f"{stem}_{counter}{suffix}"
-            new_path = dest_dir / new_filename
-            if not new_path.exists():
-                return new_path
-            counter += 1
+        existing_filenames = (
+            [path.name for path in dest_dir.iterdir()] if dest_dir.exists() else []
+        )
+        return dest_dir / OutputPlanner.get_unique_filename(
+            filename,
+            existing_filenames,
+        )
 
     @staticmethod
     def build_renamed_filename(
@@ -67,11 +59,28 @@ class FileUtils:
         Raises:
             ValueError: requested_num が1未満の場合
         """
-        if requested_num < 1:
-            msg = f"requested_numは正の整数である必要があります: {requested_num}"
-            raise ValueError(msg)
-        width = max(4, len(str(requested_num)))
-        return f"{scene_name}{index:0{width}d}{suffix}"
+        return OutputPlanner.build_renamed_filename(
+            scene_name=scene_name,
+            index=index,
+            suffix=suffix,
+            requested_num=requested_num,
+        )
+
+    @staticmethod
+    def copy_planned_outputs(output_record: OutputRecord) -> None:
+        """計画済みの出力パスへ選択候補をコピーする.
+
+        Args:
+            output_record: output_path が設定済みの出力record
+
+        Raises:
+            ValueError: 選択候補に output_path が設定されていない場合
+        """
+        for result in output_record.selected:
+            if result.output_path is None:
+                msg = "コピー対象の output_path が設定されていません"
+                raise ValueError(msg)
+            shutil.copy2(result.source_path, result.output_path)
 
     @staticmethod
     def copy_selected_items(
@@ -93,27 +102,13 @@ class FileUtils:
         """
         out = Path(dest_dir)
         out.mkdir(parents=True, exist_ok=True)
-        if rename and requested_num is None:
-            msg = "rename=True の場合は requested_num の指定が必要です"
-            raise ValueError(msg)
-
-        scene_counters: dict[str, int] = defaultdict(int)
-        copied_paths_by_path: dict[str, str] = {}
-        for result in output_record.selected:
-            if rename:
-                assert requested_num is not None
-                scene_name = result.scene_label
-                scene_counters[scene_name] += 1
-                filename = FileUtils.build_renamed_filename(
-                    scene_name=scene_name,
-                    index=scene_counters[scene_name],
-                    suffix=result.suffix,
-                    requested_num=requested_num,
-                )
-            else:
-                filename = result.filename
-            unique_dest = FileUtils.get_unique_destination(out, filename)
-            shutil.copy2(result.source_path, unique_dest)
-            copied_paths_by_path[result.source_path] = str(unique_dest.resolve())
+        planned_output_record = OutputPlanner.plan_selected_outputs(
+            output_record,
+            dest_dir,
+            rename=rename,
+            requested_num=requested_num,
+            existing_filenames=[path.name for path in out.iterdir()],
+        )
+        FileUtils.copy_planned_outputs(planned_output_record)
         logger.info(f"{len(output_record.selected)} 件を {dest_dir} に保存しました。")
-        return output_record.with_selected_output_paths(copied_paths_by_path)
+        return planned_output_record

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -80,6 +80,7 @@ class FileUtils:
             if result.output_path is None:
                 msg = "コピー対象の output_path が設定されていません"
                 raise ValueError(msg)
+            Path(result.output_path).parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(result.source_path, result.output_path)
 
     @staticmethod

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -80,8 +80,9 @@ class FileUtils:
             if result.output_path is None:
                 msg = "コピー対象の output_path が設定されていません"
                 raise ValueError(msg)
-            Path(result.output_path).parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(result.source_path, result.output_path)
+            output_path = Path(result.output_path)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(result.source_path, output_path)
 
     @staticmethod
     def copy_selected_items(

--- a/tests/services/test_output_planner.py
+++ b/tests/services/test_output_planner.py
@@ -1,0 +1,136 @@
+"""output_planner.py の単体テスト."""
+
+from pathlib import Path
+
+from src.models.output_candidate_record import OutputCandidateRecord
+from src.models.output_record import OutputRecord
+from src.services.output_planner import OutputPlanner
+
+
+def _build_candidate(
+    source_path: str,
+    scene_label: str = "play",
+) -> OutputCandidateRecord:
+    path = Path(source_path)
+    return OutputCandidateRecord(
+        source_path=source_path,
+        filename=path.name,
+        suffix=path.suffix,
+        scene_label=scene_label,
+        play_score=0.8,
+        event_score=0.3,
+        density_score=0.7,
+        scene_confidence=0.5,
+        quality_score=0.6,
+        selection_score=0.6,
+        score_band="high",
+        outlier_rejected=False,
+    )
+
+
+def _build_output_record(
+    source_paths: list[str],
+    scene_labels: list[str],
+) -> OutputRecord:
+    return OutputRecord(
+        selected=[
+            _build_candidate(source_path, scene_label)
+            for source_path, scene_label in zip(source_paths, scene_labels, strict=True)
+        ],
+        rejected=[],
+        total_files=len(source_paths),
+        analyzed_ok=len(source_paths),
+        analyzed_fail=0,
+        rejected_by_similarity=0,
+        rejected_by_content_filter=0,
+        selected_count=len(source_paths),
+        resolved_profile="active",
+        scene_distribution={"play": 2, "event": 1},
+        scene_mix_target={"play": 2, "event": 1},
+        scene_mix_actual={"play": 2, "event": 1},
+        threshold_relaxation_steps=[0.72],
+        content_filter_breakdown={},
+        whole_input_profile=None,
+    )
+
+
+def test_output_planner_plans_renamed_paths_without_copying_files(
+    tmp_path: Path,
+) -> None:
+    """コピーなしでscene別連番と衝突回避済み出力パスが計画されること.
+
+    Arrange:
+        - play 2件、event 1件のoutput recordがある
+        - 出力先には既存のplay0001.jpgがあるものとして扱われる
+    Act:
+        - rename=Trueで出力計画が作成される
+    Assert:
+        - scene別連番の出力パスが選択候補に反映されること
+        - 既存ファイル名との衝突が回避されること
+        - filesystem copyが実行されないこと
+    """
+    # Arrange
+    source_paths = [
+        str(tmp_path / "play1.jpg"),
+        str(tmp_path / "event1.jpg"),
+        str(tmp_path / "play2.jpg"),
+    ]
+    record = _build_output_record(source_paths, ["play", "event", "play"])
+    output_dir = tmp_path / "output"
+
+    # Act
+    result = OutputPlanner.plan_selected_outputs(
+        record,
+        str(output_dir),
+        rename=True,
+        requested_num=3,
+        existing_filenames=["play0001.jpg"],
+    )
+
+    # Assert
+    assert result.selected[0].output_path == str(
+        (output_dir / "play0001_1.jpg").resolve()
+    )
+    assert result.selected[1].output_path == str(
+        (output_dir / "event0001.jpg").resolve()
+    )
+    assert result.selected[2].output_path == str(
+        (output_dir / "play0002.jpg").resolve()
+    )
+    assert not output_dir.exists()
+
+
+def test_output_planner_plans_duplicate_filenames_without_rename(
+    tmp_path: Path,
+) -> None:
+    """通常出力で同名ファイルが衝突しない出力パスに計画されること.
+
+    Arrange:
+        - 異なるsource_pathに同じfilenameを持つoutput recordがある
+    Act:
+        - rename=Falseで出力計画が作成される
+    Assert:
+        - 1件目は元のファイル名で計画されること
+        - 2件目はサフィックス付きのファイル名で計画されること
+        - filesystem copyが実行されないこと
+    """
+    # Arrange
+    source_paths = [
+        str(tmp_path / "source1" / "screen.png"),
+        str(tmp_path / "source2" / "screen.png"),
+    ]
+    record = _build_output_record(source_paths, ["play", "event"])
+    output_dir = tmp_path / "output"
+
+    # Act
+    result = OutputPlanner.plan_selected_outputs(
+        record,
+        str(output_dir),
+    )
+
+    # Assert
+    assert result.selected[0].output_path == str((output_dir / "screen.png").resolve())
+    assert result.selected[1].output_path == str(
+        (output_dir / "screen_1.png").resolve()
+    )
+    assert not output_dir.exists()

--- a/tests/services/test_output_planner.py
+++ b/tests/services/test_output_planner.py
@@ -138,3 +138,36 @@ def test_output_planner_plans_duplicate_filenames_without_rename(
         (output_dir / "screen_1.png").resolve()
     )
     assert not output_dir.exists()
+
+
+def test_output_planner_avoids_case_insensitive_filename_collision(
+    tmp_path: Path,
+) -> None:
+    """大文字小文字だけが異なる既存ファイルとの衝突が回避されること.
+
+    Arrange:
+        - 出力先には既存のScreen.pngがあるものとして扱われる
+        - 選択候補のファイル名はscreen.pngである
+    Act:
+        - rename=Falseで出力計画が作成される
+    Assert:
+        - 大文字小文字を区別しないfilesystemで上書きされない出力パスに計画されること
+        - filesystem copyが実行されないこと
+    """
+    # Arrange
+    source_path = str(tmp_path / "source" / "screen.png")
+    record = _build_output_record([source_path], ["play"])
+    output_dir = tmp_path / "output"
+
+    # Act
+    result = OutputPlanner.plan_selected_outputs(
+        record,
+        str(output_dir),
+        existing_filenames=["Screen.png"],
+    )
+
+    # Assert
+    assert result.selected[0].output_path == str(
+        (output_dir / "screen_1.png").resolve()
+    )
+    assert not output_dir.exists()

--- a/tests/services/test_output_planner.py
+++ b/tests/services/test_output_planner.py
@@ -32,6 +32,10 @@ def _build_output_record(
     source_paths: list[str],
     scene_labels: list[str],
 ) -> OutputRecord:
+    play_count = scene_labels.count("play")
+    event_count = scene_labels.count("event")
+    scene_counts = {"play": play_count, "event": event_count}
+
     return OutputRecord(
         selected=[
             _build_candidate(source_path, scene_label)
@@ -45,9 +49,9 @@ def _build_output_record(
         rejected_by_content_filter=0,
         selected_count=len(source_paths),
         resolved_profile="active",
-        scene_distribution={"play": 2, "event": 1},
-        scene_mix_target={"play": 2, "event": 1},
-        scene_mix_actual={"play": 2, "event": 1},
+        scene_distribution=dict(scene_counts),
+        scene_mix_target=dict(scene_counts),
+        scene_mix_actual=dict(scene_counts),
         threshold_relaxation_steps=[0.72],
         content_filter_breakdown={},
         whole_input_profile=None,

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -162,6 +162,36 @@ def test_copy_selected_items_returns_output_record_with_copied_paths(
     assert result.selected[0].output_path == str((dest_dir / "test.png").resolve())
 
 
+def test_copy_planned_outputs_creates_output_parent_directories(
+    tmp_path: Path,
+) -> None:
+    """計画済みcopy adapterが出力先親ディレクトリを作成すること.
+
+    Arrange:
+        - ソース画像ファイルを持つoutput recordがある
+        - 存在しない出力ディレクトリへのoutput_pathが計画されている
+    Act:
+        - copy_planned_outputsが実行される
+    Assert:
+        - 出力先親ディレクトリが作成されること
+        - 計画済みの出力パスへファイルがコピーされること
+    """
+    # Arrange
+    src_file = tmp_path / "source" / "test.png"
+    src_file.parent.mkdir()
+    src_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+    dest_dir = tmp_path / "missing" / "output"
+    output_record = _build_output_record([str(src_file)]).with_selected_output_paths(
+        {str(src_file): str((dest_dir / "test.png").resolve())}
+    )
+
+    # Act
+    FileUtils.copy_planned_outputs(output_record)
+
+    # Assert
+    assert (dest_dir / "test.png").exists()
+
+
 def test_copy_selected_items_rename_avoids_collision_and_counts_per_scene(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- `OutputPlanner` を追加し、rename policy、scene 別連番、同名衝突回避、report 用 `output_path` mapping を copy なしで計画できるようにしました。
- `FileUtils` を計画済み `output_path` への filesystem copy adapter として整理し、既存の `--rename` / 通常コピー / JSON report の挙動を維持しました。
- output planning の pure test と README の処理フロー説明を追加しました。

## Verification
- `uv run task test`

## Related Issue
- Closes #123