### PR TITLE
fix: Ollama catalog fallbackの発生理由を出力する

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,3 +47,7 @@ _Avoid_: scene, duplicate file
 **Ollama Classification Failure**:
 blog candidate を scene catalog の scene に分類できなかった状態。other に分類された画像とは区別され、最終選択の対象にはならない。
 _Avoid_: other scene, rejected by content filter
+
+**Ollama Catalog Fallback**:
+scene catalog を作成できないときに、処理継続のため全 blog candidate を fallback scene に割り当てる代替状態。Ollama Classification Failure とは区別される。
+_Avoid_: per-image classification failure, other scene

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ uv run game-screen-pick --ollama-model gemma4 \
 - キャッシュキーには画像パス、更新時刻、サイズ、モデル名、scene catalog が含まれます
 - キャッシュを使わない場合は `--no-ollama-cache` を指定します
 - scene catalog 応答が不正な場合は、代表画像数を減らして再試行します
-- scene catalog 作成が最終的に失敗した場合は、`fallback` sceneで選定を継続します
+- scene catalog 作成が最終的に失敗した場合は、`fallback` sceneで選定を継続し、console / JSON report に `ollama_catalog_fallback_used` と `ollama_catalog_fallback_reason` を出力します
+- `ollama_classification_failed` は、scene catalog 作成後に個別画像を catalog 内の scene へ分類できなかった件数です。catalog 作成失敗による `fallback` とは別に集計されます
 
 ## 設定ファイル
 

--- a/src/models/output_record.py
+++ b/src/models/output_record.py
@@ -28,6 +28,8 @@ class OutputRecord:
     content_filter_breakdown: dict[str, int]
     whole_input_profile: dict[str, dict[str, float]] | None
     scene_catalog: list[dict[str, str]]
+    ollama_catalog_fallback_used: bool
+    ollama_catalog_fallback_reason: str | None
     ollama_classification_failed: int
     ollama_classification_failure_rate: float
 
@@ -76,6 +78,8 @@ class OutputRecord:
                 }
                 for scene in stats.scene_catalog
             ],
+            ollama_catalog_fallback_used=stats.ollama_catalog_fallback_used,
+            ollama_catalog_fallback_reason=stats.ollama_catalog_fallback_reason,
             ollama_classification_failed=stats.ollama_classification_failed,
             ollama_classification_failure_rate=round(
                 stats.ollama_classification_failure_rate,

--- a/src/models/picker_statistics.py
+++ b/src/models/picker_statistics.py
@@ -26,6 +26,8 @@ class PickerStatistics:
         whole_input_profile: 入力全体の明暗傾向プロフィール
         selection_annotations_by_path: 候補パスごとのscene mix選定注釈
         scene_catalog: 実行で使われたscene catalog
+        ollama_catalog_fallback_used: Ollama scene catalog fallbackが使われたか
+        ollama_catalog_fallback_reason: fallbackが使われた理由
         ollama_classification_failed: Ollama分類に失敗したblog candidate数
         ollama_classification_failure_rate: Ollama分類失敗率
     """
@@ -46,5 +48,7 @@ class PickerStatistics:
         default_factory=dict
     )
     scene_catalog: list[SceneCatalogEntry] = field(default_factory=list)
+    ollama_catalog_fallback_used: bool = False
+    ollama_catalog_fallback_reason: str | None = None
     ollama_classification_failed: int = 0
     ollama_classification_failure_rate: float = 0.0

--- a/src/models/scored_scene_candidates.py
+++ b/src/models/scored_scene_candidates.py
@@ -15,5 +15,5 @@ class ScoredSceneCandidates:
     scene_catalog: list[SceneCatalogEntry]
     classification_failed: int
     classification_failure_rate: float
-    catalog_fallback_used: bool = False
-    catalog_fallback_reason: str | None = None
+    ollama_catalog_fallback_used: bool = False
+    ollama_catalog_fallback_reason: str | None = None

--- a/src/models/scored_scene_candidates.py
+++ b/src/models/scored_scene_candidates.py
@@ -15,3 +15,5 @@ class ScoredSceneCandidates:
     scene_catalog: list[SceneCatalogEntry]
     classification_failed: int
     classification_failure_rate: float
+    catalog_fallback_used: bool = False
+    catalog_fallback_reason: str | None = None

--- a/src/services/analyzed_image_selector.py
+++ b/src/services/analyzed_image_selector.py
@@ -117,6 +117,8 @@ class AnalyzedImageSelector:
             whole_input_profile=content_filter_result.whole_input_profile,
             selection_annotations_by_path=selection_result.annotations_by_path,
             scene_catalog=scored.scene_catalog,
+            ollama_catalog_fallback_used=scored.catalog_fallback_used,
+            ollama_catalog_fallback_reason=scored.catalog_fallback_reason,
             ollama_classification_failed=scored.classification_failed,
             ollama_classification_failure_rate=scored.classification_failure_rate,
         )
@@ -142,9 +144,10 @@ class AnalyzedImageSelector:
                 self.config.scene_hint,
             )
         except (OSError, ValueError) as error:
+            fallback_reason = self._format_exception(error)
             logger.debug(
                 "Ollama scene catalog作成に失敗したためfallback sceneで選定します: "
-                f"{type(error).__name__}: {error}"
+                f"{fallback_reason}"
             )
             scene_catalog = self._fallback_scene_catalog()
             classifications: Sequence[SceneClassification | None] = (
@@ -154,6 +157,8 @@ class AnalyzedImageSelector:
                 analyzed_images,
                 scene_catalog,
                 classifications,
+                catalog_fallback_used=True,
+                catalog_fallback_reason=fallback_reason,
             )
 
         classifications = self._classify_images(analyzed_images, scene_catalog)
@@ -168,6 +173,8 @@ class AnalyzedImageSelector:
         analyzed_images: list[AnalyzedImage],
         scene_catalog: list[SceneCatalogEntry],
         classifications: Sequence[SceneClassification | None],
+        catalog_fallback_used: bool = False,
+        catalog_fallback_reason: str | None = None,
     ) -> ScoredSceneCandidates:
         """scene分類結果から候補scoreと統計を作る."""
         candidates: list[ScoredCandidate] = []
@@ -196,7 +203,14 @@ class AnalyzedImageSelector:
             scene_catalog=scene_catalog,
             classification_failed=classification_failed,
             classification_failure_rate=failure_rate,
+            catalog_fallback_used=catalog_fallback_used,
+            catalog_fallback_reason=catalog_fallback_reason,
         )
+
+    @staticmethod
+    def _format_exception(error: Exception) -> str:
+        """統計表示用に例外を短い文字列へ変換する."""
+        return f"{type(error).__name__}: {error}"
 
     @staticmethod
     def _fallback_scene_catalog() -> list[SceneCatalogEntry]:

--- a/src/services/analyzed_image_selector.py
+++ b/src/services/analyzed_image_selector.py
@@ -117,8 +117,8 @@ class AnalyzedImageSelector:
             whole_input_profile=content_filter_result.whole_input_profile,
             selection_annotations_by_path=selection_result.annotations_by_path,
             scene_catalog=scored.scene_catalog,
-            ollama_catalog_fallback_used=scored.catalog_fallback_used,
-            ollama_catalog_fallback_reason=scored.catalog_fallback_reason,
+            ollama_catalog_fallback_used=scored.ollama_catalog_fallback_used,
+            ollama_catalog_fallback_reason=scored.ollama_catalog_fallback_reason,
             ollama_classification_failed=scored.classification_failed,
             ollama_classification_failure_rate=scored.classification_failure_rate,
         )
@@ -144,7 +144,7 @@ class AnalyzedImageSelector:
                 self.config.scene_hint,
             )
         except (OSError, ValueError) as error:
-            fallback_reason = self._format_exception(error)
+            fallback_reason = f"{type(error).__name__}: {error}"
             logger.debug(
                 "Ollama scene catalog作成に失敗したためfallback sceneで選定します: "
                 f"{fallback_reason}"
@@ -203,14 +203,9 @@ class AnalyzedImageSelector:
             scene_catalog=scene_catalog,
             classification_failed=classification_failed,
             classification_failure_rate=failure_rate,
-            catalog_fallback_used=catalog_fallback_used,
-            catalog_fallback_reason=catalog_fallback_reason,
+            ollama_catalog_fallback_used=catalog_fallback_used,
+            ollama_catalog_fallback_reason=catalog_fallback_reason,
         )
-
-    @staticmethod
-    def _format_exception(error: Exception) -> str:
-        """統計表示用に例外を短い文字列へ変換する."""
-        return f"{type(error).__name__}: {error}"
 
     @staticmethod
     def _fallback_scene_catalog() -> list[SceneCatalogEntry]:

--- a/src/utils/report_writer.py
+++ b/src/utils/report_writer.py
@@ -21,6 +21,12 @@ class ReportWriter:
             "scene_mix_target": output_record.scene_mix_target,
             "scene_mix_actual": output_record.scene_mix_actual,
             "scene_catalog": output_record.scene_catalog,
+            "ollama_catalog_fallback_used": (
+                output_record.ollama_catalog_fallback_used
+            ),
+            "ollama_catalog_fallback_reason": (
+                output_record.ollama_catalog_fallback_reason
+            ),
             "ollama_classification_failed": (
                 output_record.ollama_classification_failed
             ),

--- a/src/utils/report_writer.py
+++ b/src/utils/report_writer.py
@@ -21,15 +21,11 @@ class ReportWriter:
             "scene_mix_target": output_record.scene_mix_target,
             "scene_mix_actual": output_record.scene_mix_actual,
             "scene_catalog": output_record.scene_catalog,
-            "ollama_catalog_fallback_used": (
-                output_record.ollama_catalog_fallback_used
-            ),
+            "ollama_catalog_fallback_used": output_record.ollama_catalog_fallback_used,
             "ollama_catalog_fallback_reason": (
                 output_record.ollama_catalog_fallback_reason
             ),
-            "ollama_classification_failed": (
-                output_record.ollama_classification_failed
-            ),
+            "ollama_classification_failed": output_record.ollama_classification_failed,
             "ollama_classification_failure_rate": (
                 output_record.ollama_classification_failure_rate
             ),

--- a/src/utils/result_formatter.py
+++ b/src/utils/result_formatter.py
@@ -38,6 +38,15 @@ class ResultFormatter:
         logger.info(f"画面分布(候補): {output_record.scene_distribution}")
         logger.info(f"画面分布(目標): {output_record.scene_mix_target}")
         logger.info(f"画面分布(実績): {output_record.scene_mix_actual}")
+        logger.info(
+            "Ollama catalog fallback: "
+            f"{'あり' if output_record.ollama_catalog_fallback_used else 'なし'}"
+        )
+        if output_record.ollama_catalog_fallback_reason is not None:
+            logger.info(
+                "Ollama catalog fallback理由: "
+                f"{output_record.ollama_catalog_fallback_reason}"
+            )
         logger.info(f"Ollama分類失敗: {output_record.ollama_classification_failed}")
         logger.info(
             "Ollama分類失敗率: "

--- a/tests/models/test_output_record.py
+++ b/tests/models/test_output_record.py
@@ -83,6 +83,8 @@ def test_output_record_projects_selection_for_output_adapters() -> None:
     assert record.scene_catalog[0]["slug"] == "battle"
     assert record.ollama_classification_failed == 1
     assert record.ollama_classification_failure_rate == 0.25
+    assert record.ollama_catalog_fallback_used is False
+    assert record.ollama_catalog_fallback_reason is None
     assert record.total_files == 2
     assert record.selected[0].source_path == "/tmp/battle.jpg"
     assert record.selected[0].filename == "battle.jpg"

--- a/tests/services/test_analyzed_image_selector.py
+++ b/tests/services/test_analyzed_image_selector.py
@@ -152,6 +152,7 @@ def test_select_uses_fallback_scene_when_catalog_generation_fails() -> None:
         - AnalyzedImageSelectorで選定される
     Assert:
         - 例外を送出せずfallback sceneで候補が選定されること
+        - catalog fallbackの発生理由が統計に記録されること
     """
     # Arrange
     first = create_analyzed_image(
@@ -185,6 +186,8 @@ def test_select_uses_fallback_scene_when_catalog_generation_fails() -> None:
     assert stats.selected_count == 2
     assert stats.ollama_classification_failed == 0
     assert stats.ollama_classification_failure_rate == 0.0
+    assert stats.ollama_catalog_fallback_used is True
+    assert stats.ollama_catalog_fallback_reason == "OSError: timed out"
     assert stats.scene_catalog[0].slug == "fallback"
     assert stats.scene_distribution == {"fallback": 2}
 

--- a/tests/services/test_output_planner.py
+++ b/tests/services/test_output_planner.py
@@ -55,6 +55,8 @@ def _build_output_record(
         content_filter_breakdown={},
         whole_input_profile=None,
         scene_catalog=[],
+        ollama_catalog_fallback_used=False,
+        ollama_catalog_fallback_reason=None,
         ollama_classification_failed=0,
         ollama_classification_failure_rate=0.0,
     )

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -54,6 +54,8 @@ def _build_output_record(
         content_filter_breakdown={},
         whole_input_profile=None,
         scene_catalog=[],
+        ollama_catalog_fallback_used=False,
+        ollama_catalog_fallback_reason=None,
         ollama_classification_failed=0,
         ollama_classification_failure_rate=0.0,
     )

--- a/tests/utils/test_report_writer.py
+++ b/tests/utils/test_report_writer.py
@@ -83,6 +83,8 @@ def _build_output_record(
         ],
         ollama_classification_failed=1,
         ollama_classification_failure_rate=0.25,
+        ollama_catalog_fallback_used=True,
+        ollama_catalog_fallback_reason="OSError: timed out",
     )
 
 
@@ -130,6 +132,8 @@ def test_report_writer_serializes_output_record_fields(tmp_path: Path) -> None:
     assert payload["scene_catalog"][0]["display_name"] == "戦闘"
     assert payload["ollama_classification_failed"] == 1
     assert payload["ollama_classification_failure_rate"] == 0.25
+    assert payload["ollama_catalog_fallback_used"] is True
+    assert payload["ollama_catalog_fallback_reason"] == "OSError: timed out"
     assert payload["threshold_relaxation_steps"] == [0.72]
     assert payload["rejected_by_content_filter"] == 2
     assert payload["content_filter_breakdown"]["fade_transition"] == 2

--- a/tests/utils/test_result_formatter.py
+++ b/tests/utils/test_result_formatter.py
@@ -47,6 +47,8 @@ def _build_output_record() -> OutputRecord:
         ],
         ollama_classification_failed=1,
         ollama_classification_failure_rate=0.25,
+        ollama_catalog_fallback_used=True,
+        ollama_catalog_fallback_reason="OSError: timed out",
     )
 
 
@@ -93,6 +95,8 @@ def test_display_results_uses_output_record() -> None:
     assert any("band: high" in message for message in messages)
     assert "総ファイル数: 1" in messages
     assert "解析成功: 1" in messages
+    assert "Ollama catalog fallback: あり" in messages
+    assert "Ollama catalog fallback理由: OSError: timed out" in messages
     assert "Ollama分類失敗: 1" in messages
     assert "Ollama分類失敗率: 25.00%" in messages
     assert not any("プロファイル:" in message for message in messages)


### PR DESCRIPTION
## 概要
- scene catalog作成失敗時のfallbackを、個別画像のOllama分類失敗とは別の統計として記録
- consoleとJSON reportにfallback有無と理由を出力
- READMEとCONTEXT.mdにfallbackと分類失敗の違いを追記

## 検証
- uv run pytest tests/services/test_analyzed_image_selector.py::test_select_uses_fallback_scene_when_catalog_generation_fails tests/utils/test_report_writer.py::test_report_writer_serializes_output_record_fields
- uv run task test

## リスク
- JSON reportに新しいフィールドが追加されます: ollama_catalog_fallback_used, ollama_catalog_fallback_reason