### PR TITLE
feat: Ollama分類の進捗をコンソールに出力する

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ uv run game-screen-pick --ollama-model gemma4 \
 - 分類結果は入力画像のあるフォルダ配下の `.game-screen-pick/cache/ollama-scenes.json` に保存されます
 - キャッシュキーには画像パス、更新時刻、サイズ、モデル名、scene catalog が含まれます
 - キャッシュを使わない場合は `--no-ollama-cache` を指定します
+- コンソールには scene catalog 作成開始・完了、画像分類の対象件数、分類済み件数、成功・失敗件数が出力されます
 - scene catalog 応答が不正な場合は、代表画像数を減らして再試行します
 - scene catalog 作成が最終的に失敗した場合は、`fallback` sceneで選定を継続し、console / JSON report に `ollama_catalog_fallback_used` と `ollama_catalog_fallback_reason` を出力します
 - `ollama_classification_failed` は、scene catalog 作成後に個別画像を catalog 内の scene へ分類できなかった件数です。catalog 作成失敗による `fallback` とは別に集計されます

--- a/src/services/analyzed_image_selector.py
+++ b/src/services/analyzed_image_selector.py
@@ -2,8 +2,7 @@
 
 import logging
 from collections.abc import Sequence
-from concurrent.futures import ThreadPoolExecutor
-from itertools import repeat
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from ..analyzers.metric_calculator import MetricCalculator
 from ..models.analyzed_image import AnalyzedImage
@@ -139,10 +138,14 @@ class AnalyzedImageSelector:
 
         representative_paths = self._build_representative_paths(analyzed_images)
         try:
+            logger.info(
+                f"Ollama scene catalog作成中: 代表画像 {len(representative_paths)} 件"
+            )
             scene_catalog = self._scene_analyzer.generate_scene_catalog(
                 representative_paths,
                 self.config.scene_hint,
             )
+            logger.info(f"Ollama scene catalog作成完了: scene {len(scene_catalog)} 件")
         except (OSError, ValueError) as error:
             fallback_reason = f"{type(error).__name__}: {error}"
             logger.debug(
@@ -162,6 +165,13 @@ class AnalyzedImageSelector:
             )
 
         classifications = self._classify_images(analyzed_images, scene_catalog)
+        failed_count = sum(
+            1 for classification in classifications if classification is None
+        )
+        logger.info(
+            "Ollama画像分類完了: "
+            f"成功 {len(classifications) - failed_count} 件, 失敗 {failed_count} 件"
+        )
         return self._score_classifications(
             analyzed_images,
             scene_catalog,
@@ -242,19 +252,31 @@ class AnalyzedImageSelector:
         """画像ごとのscene分類を実行する."""
         max_workers = self.config.ollama.max_workers if self.config.ollama else 1
         image_paths = [image.path for image in analyzed_images]
+        logger.info(
+            f"Ollama画像分類開始: 対象 {len(image_paths)} 件, worker {max_workers}"
+        )
         if max_workers == 1 or len(analyzed_images) <= 1:
-            return [
-                self._classify_image_path(image_path, scene_catalog)
-                for image_path in image_paths
-            ]
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            return list(
-                executor.map(
-                    self._classify_image_path,
-                    image_paths,
-                    repeat(scene_catalog),
+            classifications: list[SceneClassification | None] = []
+            for completed_count, image_path in enumerate(image_paths, start=1):
+                classifications.append(
+                    self._classify_image_path(image_path, scene_catalog)
                 )
-            )
+                logger.info(f"Ollama画像分類進捗: {completed_count}/{len(image_paths)}")
+            return classifications
+        classifications = [None] * len(image_paths)
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {
+                executor.submit(
+                    self._classify_image_path,
+                    image_path,
+                    scene_catalog,
+                ): index
+                for index, image_path in enumerate(image_paths)
+            }
+            for completed_count, future in enumerate(as_completed(futures), start=1):
+                classifications[futures[future]] = future.result()
+                logger.info(f"Ollama画像分類進捗: {completed_count}/{len(image_paths)}")
+        return classifications
 
     def _classify_image_path(
         self,

--- a/src/services/analyzed_image_selector.py
+++ b/src/services/analyzed_image_selector.py
@@ -252,18 +252,36 @@ class AnalyzedImageSelector:
         """画像ごとのscene分類を実行する."""
         max_workers = self.config.ollama.max_workers if self.config.ollama else 1
         image_paths = [image.path for image in analyzed_images]
-        logger.info(
-            f"Ollama画像分類開始: 対象 {len(image_paths)} 件, worker {max_workers}"
+        total_count = len(image_paths)
+        logger.info(f"Ollama画像分類開始: 対象 {total_count} 件, worker {max_workers}")
+        if max_workers == 1 or total_count <= 1:
+            return self._classify_images_sequentially(image_paths, scene_catalog)
+        return self._classify_images_concurrently(
+            image_paths,
+            scene_catalog,
+            max_workers,
         )
-        if max_workers == 1 or len(analyzed_images) <= 1:
-            classifications: list[SceneClassification | None] = []
-            for completed_count, image_path in enumerate(image_paths, start=1):
-                classifications.append(
-                    self._classify_image_path(image_path, scene_catalog)
-                )
-                logger.info(f"Ollama画像分類進捗: {completed_count}/{len(image_paths)}")
-            return classifications
-        classifications = [None] * len(image_paths)
+
+    def _classify_images_sequentially(
+        self,
+        image_paths: list[str],
+        scene_catalog: list[SceneCatalogEntry],
+    ) -> list[SceneClassification | None]:
+        """画像を1件ずつscene分類する."""
+        classifications: list[SceneClassification | None] = []
+        for completed_count, image_path in enumerate(image_paths, start=1):
+            classifications.append(self._classify_image_path(image_path, scene_catalog))
+            self._log_classification_progress(completed_count, len(image_paths))
+        return classifications
+
+    def _classify_images_concurrently(
+        self,
+        image_paths: list[str],
+        scene_catalog: list[SceneCatalogEntry],
+        max_workers: int,
+    ) -> list[SceneClassification | None]:
+        """画像を並列にscene分類する."""
+        classifications: list[SceneClassification | None] = [None] * len(image_paths)
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = {
                 executor.submit(
@@ -275,8 +293,13 @@ class AnalyzedImageSelector:
             }
             for completed_count, future in enumerate(as_completed(futures), start=1):
                 classifications[futures[future]] = future.result()
-                logger.info(f"Ollama画像分類進捗: {completed_count}/{len(image_paths)}")
+                self._log_classification_progress(completed_count, len(image_paths))
         return classifications
+
+    @staticmethod
+    def _log_classification_progress(completed_count: int, total_count: int) -> None:
+        """Ollama画像分類の進捗を出力する."""
+        logger.info(f"Ollama画像分類進捗: {completed_count}/{total_count}")
 
     def _classify_image_path(
         self,

--- a/tests/services/test_analyzed_image_selector.py
+++ b/tests/services/test_analyzed_image_selector.py
@@ -2,6 +2,7 @@
 
 import threading
 import time
+from unittest.mock import patch
 
 from src.analyzers.metric_calculator import MetricCalculator
 from src.models.analyzer_config import AnalyzerConfig
@@ -141,6 +142,67 @@ def test_select_classifies_images_with_configured_ollama_workers() -> None:
 
     # Assert
     assert scene_analyzer.max_active >= 2
+
+
+def test_select_logs_ollama_progress() -> None:
+    """Ollamaによるcatalog作成と画像分類の進捗が出力されること.
+
+    Arrange:
+        - 複数の選定対象画像がある
+        - fake scene analyzer が全画像を分類する
+    Act:
+        - AnalyzedImageSelectorで選定される
+    Assert:
+        - catalog作成と画像分類の進捗ログが出力されること
+    """
+    # Arrange
+    first = create_analyzed_image(
+        path="/tmp/first.jpg",
+        combined_features=_feature(1),
+    )
+    second = create_analyzed_image(
+        path="/tmp/second.jpg",
+        combined_features=_feature(100),
+    )
+    scene_analyzer = _FakeSceneAnalyzer(
+        classifications_by_path={
+            "/tmp/first.jpg": SceneClassification(
+                scene_slug="battle",
+                scene_display_name="戦闘",
+                scene_description="敵との戦闘場面",
+                confidence=0.9,
+            ),
+            "/tmp/second.jpg": SceneClassification(
+                scene_slug="conversation",
+                scene_display_name="会話",
+                scene_description="人物同士の会話場面",
+                confidence=0.8,
+            ),
+        }
+    )
+    selector = AnalyzedImageSelector(
+        config=SelectionConfig(
+            ollama=OllamaConfig(model="gemma4", max_workers=2),
+        ),
+        metric_calculator=MetricCalculator(AnalyzerConfig()),
+        scene_analyzer=scene_analyzer,
+    )
+
+    # Act
+    with patch("src.services.analyzed_image_selector.logger") as logger:
+        selector.select(
+            analyzed_images=[first, second],
+            num=2,
+        )
+
+    # Assert
+    messages = [call.args[0] for call in logger.info.call_args_list]
+    assert "Ollama scene catalog作成中: 代表画像 2 件" in messages
+    assert "Ollama scene catalog作成完了: scene 3 件" in messages
+    assert "Ollama画像分類開始: 対象 2 件, worker 2" in messages
+    assert "Ollama画像分類進捗: 1/2" in messages
+    assert "Ollama画像分類進捗: 2/2" in messages
+    assert "Ollama画像分類完了: 成功 2 件, 失敗 0 件" in messages
 
 
 def test_select_uses_fallback_scene_when_catalog_generation_fails() -> None:


### PR DESCRIPTION
## 概要
- Ollama scene catalog 作成の開始・完了ログを追加
- Ollama 画像分類の開始、分類済み件数、成功・失敗件数をコンソールに出力
- 並列分類時も完了順に進捗を出しつつ、分類結果の返却順は維持
- README にコンソール進捗の説明を追加

## 検証
- uv run task test

## リスク
- Ollama API 自体は stream=false のため、モデル内部のトークン単位進捗ではなく、このツール側の処理段階と分類件数の進捗表示です。