### PR TITLE
feat: 出力フォルダが空でない場合は処理開始前に失敗させる

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,10 @@ _Avoid_: localized category name
 選択された画像に付ける標準の出力ファイル名。scene slug と scene 内の連番で構成される。
 _Avoid_: original filename output, optional rename mode
 
+**Output Folder**:
+選択された画像とレポートを書き出す実行ごとの保存先。処理開始前に空である必要がある。
+_Avoid_: append destination, overwrite target, resumable output
+
 **Scene Display Name**:
 scene を人が読みやすいように表す日本語名。ブログ用の画像選択やレポート表示で使われる。
 _Avoid_: filename prefix, report key

--- a/README.md
+++ b/README.md
@@ -72,11 +72,12 @@ uv run game-screen-pick --ollama-model gemma4 --reset-cache ./screenshots ./outp
 6. 同じ scene 内で見た目や構図が近い画像を variant group にまとめ、原則として各 group から代表画像を1枚だけ選ぶ
 7. scene ごとの自動均等配分、画質、分類信頼度、類似度除外を組み合わせて最終出力を決める
 8. 選定結果を copy / console / JSON report 共通の出力recordへ変換する
-9. `OutputPlanner` が scene slug別連番、同名衝突回避、report用 `output_path` をcopyなしで計画する
+9. `OutputPlanner` が scene slug別連番とreport用 `output_path` をcopyなしで計画する
 10. 計画済みの出力先へ画像をコピーし、同じrecordから表示と `<出力フォルダ>/report.json` のJSONレポートを生成する
 
-JSONレポートは常に `<出力フォルダ>/report.json` へ出力され、既存ファイルがある場合は上書きされます。
-選択画像は常に `battle0001.ext` や `conversation0001.ext` のように、scene slug と scene 内連番で出力されます。既存画像ファイルと同名になる場合は上書きせず、`battle0001_1.ext` のように衝突回避名で保存されます。
+出力フォルダが存在する場合は、処理開始前に空である必要があります。既存ファイル、既存フォルダ、`report.json` などが1件でもある場合は失敗します。
+JSONレポートは常に `<出力フォルダ>/report.json` へ出力されます。
+選択画像は常に `battle0001.ext` や `conversation0001.ext` のように、scene slug と scene 内連番で出力されます。
 
 ### scene の意味
 

--- a/src/application/run.py
+++ b/src/application/run.py
@@ -29,6 +29,7 @@ def run_application(request: ApplicationRunRequest) -> None:
 
     try:
         input_path = _resolve_input_path(request.input_dir)
+        _ensure_output_dir_is_empty(request.output_dir)
         output_record = _select_output_record(request, input_path)
         output_record = FileUtils.copy_selected_items(
             output_record,
@@ -83,6 +84,14 @@ def _resolve_input_path(input_dir: str) -> Path:
             param_hint="input_dir",
         )
     return input_path
+
+
+def _ensure_output_dir_is_empty(output_dir: str) -> None:
+    """出力ディレクトリが存在する場合は空であることを検証する."""
+    try:
+        FileUtils.ensure_output_dir_is_empty(output_dir)
+    except ValueError as error:
+        raise click.ClickException(str(error)) from error
 
 
 def _select_output_record(

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -36,7 +36,7 @@ class FileUtils:
 
     @staticmethod
     def ensure_output_dir_is_empty(dest_dir: str) -> None:
-        """出力ディレクトリが存在する場合は空であることを検証する.
+        """出力先が存在する場合は空のディレクトリであることを検証する.
 
         Args:
             dest_dir: 出力先ディレクトリのパス
@@ -44,13 +44,13 @@ class FileUtils:
         Raises:
             ValueError: 出力先がファイル、または空でないディレクトリの場合
         """
-        out = Path(dest_dir)
-        if not out.exists():
+        output_dir = Path(dest_dir)
+        if not output_dir.exists():
             return
-        if not out.is_dir():
+        if not output_dir.is_dir():
             msg = f"出力先はフォルダである必要があります: {dest_dir}"
             raise ValueError(msg)
-        if any(out.iterdir()):
+        if any(output_dir.iterdir()):
             msg = f"出力フォルダは空である必要があります: {dest_dir}"
             raise ValueError(msg)
 
@@ -70,9 +70,9 @@ class FileUtils:
         Returns:
             コピー先パスを反映した出力record
         """
-        out = Path(dest_dir)
         FileUtils.ensure_output_dir_is_empty(dest_dir)
-        out.mkdir(parents=True, exist_ok=True)
+        output_dir = Path(dest_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
         planned_output_record = OutputPlanner.plan_selected_outputs(
             output_record,
             dest_dir,

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -35,6 +35,26 @@ class FileUtils:
             shutil.copy2(result.source_path, output_path)
 
     @staticmethod
+    def ensure_output_dir_is_empty(dest_dir: str) -> None:
+        """出力ディレクトリが存在する場合は空であることを検証する.
+
+        Args:
+            dest_dir: 出力先ディレクトリのパス
+
+        Raises:
+            ValueError: 出力先がファイル、または空でないディレクトリの場合
+        """
+        out = Path(dest_dir)
+        if not out.exists():
+            return
+        if not out.is_dir():
+            msg = f"出力先はフォルダである必要があります: {dest_dir}"
+            raise ValueError(msg)
+        if any(out.iterdir()):
+            msg = f"出力フォルダは空である必要があります: {dest_dir}"
+            raise ValueError(msg)
+
+    @staticmethod
     def copy_selected_items(
         output_record: OutputRecord,
         dest_dir: str,
@@ -51,12 +71,13 @@ class FileUtils:
             コピー先パスを反映した出力record
         """
         out = Path(dest_dir)
+        FileUtils.ensure_output_dir_is_empty(dest_dir)
         out.mkdir(parents=True, exist_ok=True)
         planned_output_record = OutputPlanner.plan_selected_outputs(
             output_record,
             dest_dir,
             requested_num=requested_num,
-            existing_filenames=[path.name for path in out.iterdir()],
+            existing_filenames=[],
         )
         FileUtils.copy_planned_outputs(planned_output_record)
         logger.info(f"{len(output_record.selected)} 件を {dest_dir} に保存しました。")

--- a/tests/application/test_run.py
+++ b/tests/application/test_run.py
@@ -279,6 +279,44 @@ def test_run_application_writes_scene_numbered_outputs(
     assert (output_dir / "battle0002.jpg").exists()
 
 
+def test_run_application_rejects_non_empty_output_dir_before_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """出力フォルダが空でない場合は画像選定前に失敗されること.
+
+    Arrange:
+        - 入力ディレクトリが存在する
+        - 出力フォルダに既存ファイルがある
+    Act:
+        - applicationが実行される
+    Assert:
+        - click.ClickExceptionが送出されること
+        - 画像選定処理が開始されないこと
+    """
+    # Arrange
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    (output_dir / "report.json").write_text("existing", encoding="utf-8")
+
+    def fail_if_analyzer_is_created(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("画像選定処理が開始されました")
+
+    monkeypatch.setattr(
+        "src.application.run.ImageQualityAnalyzer",
+        fail_if_analyzer_is_created,
+    )
+
+    # Act & Assert
+    with pytest.raises(
+        click.ClickException,
+        match="出力フォルダは空である必要があります",
+    ):
+        run_application(_build_request(input_dir, output_dir))
+
+
 def test_run_application_resolves_configs_and_constructs_picker(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -123,19 +123,19 @@ def test_copy_planned_outputs_creates_output_parent_directories(
     assert (dest_dir / "test.png").exists()
 
 
-def test_copy_selected_items_avoids_collision_and_counts_per_scene(
+def test_copy_selected_items_rejects_non_empty_output_dir(
     tmp_path: Path,
 ) -> None:
-    """scene別連番で出力しつつ既存ファイルとの衝突を回避できること.
+    """出力ディレクトリが空でない場合はコピーされないこと.
 
     Arrange:
         - 出力ディレクトリに既存ファイル（play0001.jpg）がある
-        - play 2件、event 1件の選択画像がある
+        - 選択画像がある
     Act:
         - copy_selected_itemsを実行する
     Assert:
-        - 既存ファイルとの衝突を回避してサフィックス付きで出力されること
-        - scene別に連番が振られること
+        - ValueErrorが送出されること
+        - 既存ファイル以外はコピーされないこと
     """
     # Arrange
     output_dir = tmp_path / "output"
@@ -143,36 +143,18 @@ def test_copy_selected_items_avoids_collision_and_counts_per_scene(
     (output_dir / "play0001.jpg").write_bytes(b"existing")
 
     gameplay1 = tmp_path / "play1.jpg"
-    gameplay2 = tmp_path / "play2.jpg"
-    event1 = tmp_path / "event1.jpg"
-    for path in (gameplay1, gameplay2, event1):
-        path.write_bytes(b"fake_image_data")
+    gameplay1.write_bytes(b"fake_image_data")
 
-    record = _build_output_record(
-        [str(gameplay1), str(event1), str(gameplay2)],
-        ["play", "event", "play"],
-    )
+    record = _build_output_record([str(gameplay1)], ["play"])
 
-    # Act
-    result = FileUtils.copy_selected_items(
-        record,
-        str(output_dir),
-        requested_num=3,
-    )
-
-    # Assert
-    assert (output_dir / "play0001_1.jpg").exists()
-    assert (output_dir / "event0001.jpg").exists()
-    assert (output_dir / "play0002.jpg").exists()
-    assert result.selected[0].output_path == str(
-        (output_dir / "play0001_1.jpg").resolve()
-    )
-    assert result.selected[1].output_path == str(
-        (output_dir / "event0001.jpg").resolve()
-    )
-    assert result.selected[2].output_path == str(
-        (output_dir / "play0002.jpg").resolve()
-    )
+    # Act & Assert
+    with pytest.raises(ValueError, match="出力フォルダは空である必要があります"):
+        FileUtils.copy_selected_items(
+            record,
+            str(output_dir),
+            requested_num=1,
+        )
+    assert sorted(path.name for path in output_dir.iterdir()) == ["play0001.jpg"]
 
 
 def test_copy_selected_items_copies_files(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- 出力フォルダが存在していて空でない場合、画像選定を開始する前に失敗するようにしました
- 低レベルのコピー処理でも非空の出力先を拒否する検証を追加しました
- README と CONTEXT.md に Output Folder の空フォルダ要件を反映しました

## Verification
- `uv run task test`