### PR TITLE
feat: 処理開始時の進捗ログを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ uv run game-screen-pick --ollama-model gemma4 --reset-cache ./screenshots ./outp
 JSONレポートは常に `<出力フォルダ>/report.json` へ出力されます。
 選択画像は常に `battle0001.ext` や `conversation0001.ext` のように、scene slug と scene 内連番で出力されます。
 
+### コンソールログ
+
+通常実行では、入力画像の検索件数、中立解析キャッシュのhit/miss件数、未cache画像の解析開始、解析チャンク数、画像読み込み、CLIP特徴抽出の開始・完了がコンソールに出力されます。
+CLIPモデルの初回ロード前にも、画像読み込みやチャンク準備の進捗が出るため、処理が進んでいるかを確認できます。
+
 ### scene の意味
 
 - `scene_slug`: `battle`、`conversation`、`menu` など、ファイル名やJSONキーに使う英語slug

--- a/src/analyzers/batch_pipeline.py
+++ b/src/analyzers/batch_pipeline.py
@@ -138,13 +138,23 @@ class BatchPipeline:
             入力順に対応した解析結果のリスト。
             読み込みや解析に失敗した画像は `None` になる。
         """
+        if show_progress:
+            logger.info(
+                f"中立解析を開始します: {len(paths)}件 "
+                f"(batch_size={batch_size}, max_dim={self.config.max_dim})"
+            )
         results: list[AnalyzedImage | None] = [None] * len(paths)
+        if show_progress:
+            logger.info("解析チャンクを計算しています...")
         chunk_boundaries = self._compute_chunk_boundaries(
             paths,
             self.config.max_memory_gb,
             self.config.min_chunk_size,
             self.config.max_dim,
         )
+        total_chunks = len(chunk_boundaries)
+        if show_progress:
+            logger.info(f"解析チャンク: {total_chunks}個")
 
         preload_executor = self._get_preload_executor()
         preload_futures: dict[int, "BatchPipeline._PilImagesFuture"] = {}
@@ -153,6 +163,11 @@ class BatchPipeline:
         for chunk_idx in range(min(lookahead, len(chunk_boundaries))):
             chunk_start, chunk_end = chunk_boundaries[chunk_idx]
             chunk_paths = paths[chunk_start:chunk_end]
+            if show_progress:
+                logger.info(
+                    "画像読み込みを開始します: "
+                    f"chunk {chunk_idx + 1}/{total_chunks} ({len(chunk_paths)}件)"
+                )
             preload_futures[chunk_idx] = preload_executor.submit(
                 self.load_and_preprocess_images,
                 chunk_paths,
@@ -162,16 +177,35 @@ class BatchPipeline:
         for chunk_idx, (chunk_start, chunk_end) in enumerate(chunk_boundaries):
             chunk_paths = paths[chunk_start:chunk_end]
             pil_images = preload_futures[chunk_idx].result()
+            if show_progress:
+                logger.info(
+                    "画像読み込み完了: "
+                    f"chunk {chunk_idx + 1}/{total_chunks} ({len(chunk_paths)}件)"
+                )
             del preload_futures[chunk_idx]
 
             self._preload_next_chunks(
-                paths, chunk_boundaries, chunk_idx, lookahead, preload_futures
+                paths,
+                chunk_boundaries,
+                chunk_idx,
+                lookahead,
+                preload_futures,
+                show_progress,
             )
 
+            if show_progress:
+                valid_image_count = sum(image is not None for image in pil_images)
+                logger.info(
+                    "CLIP特徴抽出を開始します: "
+                    f"chunk {chunk_idx + 1}/{total_chunks} "
+                    f"({valid_image_count}/{len(chunk_paths)}件)"
+                )
             clip_features_list = self.feature_extractor.extract_clip_features_batch(
                 pil_images,
                 initial_batch_size=batch_size,
             )
+            if show_progress:
+                logger.info(f"CLIP特徴抽出完了: chunk {chunk_idx + 1}/{total_chunks}")
             clip_features_np_list = self._convert_batch_features_to_numpy(
                 clip_features_list
             )
@@ -202,12 +236,19 @@ class BatchPipeline:
         chunk_idx: int,
         lookahead: int,
         preload_futures: dict[int, "BatchPipeline._PilImagesFuture"],
+        show_progress: bool = False,
     ) -> None:
         """先読みチャンクをプリロードExecutorに投入する."""
         next_idx = chunk_idx + lookahead
         if next_idx < len(chunk_boundaries) and next_idx not in preload_futures:
             next_start, next_end = chunk_boundaries[next_idx]
             next_paths = paths[next_start:next_end]
+            if show_progress:
+                logger.info(
+                    "画像読み込みを開始します: "
+                    f"chunk {next_idx + 1}/{len(chunk_boundaries)} "
+                    f"({len(next_paths)}件)"
+                )
             preload_futures[next_idx] = self._get_preload_executor().submit(
                 self.load_and_preprocess_images,
                 next_paths,

--- a/src/analyzers/batch_pipeline.py
+++ b/src/analyzers/batch_pipeline.py
@@ -40,6 +40,11 @@ class BatchPipeline:
 
     PROGRESS_REPORT_INTERVAL: int = 500
 
+    @staticmethod
+    def _chunk_label(chunk_idx: int, total_chunks: int) -> str:
+        """ログ表示用のチャンク位置を返す."""
+        return f"chunk {chunk_idx + 1}/{total_chunks}"
+
     def __init__(
         self,
         feature_extractor: "FeatureExtractor",
@@ -164,9 +169,9 @@ class BatchPipeline:
             chunk_start, chunk_end = chunk_boundaries[chunk_idx]
             chunk_paths = paths[chunk_start:chunk_end]
             if show_progress:
+                chunk_label = self._chunk_label(chunk_idx, total_chunks)
                 logger.info(
-                    "画像読み込みを開始します: "
-                    f"chunk {chunk_idx + 1}/{total_chunks} ({len(chunk_paths)}件)"
+                    f"画像読み込みを開始します: {chunk_label} ({len(chunk_paths)}件)"
                 )
             preload_futures[chunk_idx] = preload_executor.submit(
                 self.load_and_preprocess_images,
@@ -177,11 +182,9 @@ class BatchPipeline:
         for chunk_idx, (chunk_start, chunk_end) in enumerate(chunk_boundaries):
             chunk_paths = paths[chunk_start:chunk_end]
             pil_images = preload_futures[chunk_idx].result()
+            chunk_label = self._chunk_label(chunk_idx, total_chunks)
             if show_progress:
-                logger.info(
-                    "画像読み込み完了: "
-                    f"chunk {chunk_idx + 1}/{total_chunks} ({len(chunk_paths)}件)"
-                )
+                logger.info(f"画像読み込み完了: {chunk_label} ({len(chunk_paths)}件)")
             del preload_futures[chunk_idx]
 
             self._preload_next_chunks(
@@ -190,6 +193,7 @@ class BatchPipeline:
                 chunk_idx,
                 lookahead,
                 preload_futures,
+                total_chunks,
                 show_progress,
             )
 
@@ -197,15 +201,14 @@ class BatchPipeline:
                 valid_image_count = sum(image is not None for image in pil_images)
                 logger.info(
                     "CLIP特徴抽出を開始します: "
-                    f"chunk {chunk_idx + 1}/{total_chunks} "
-                    f"({valid_image_count}/{len(chunk_paths)}件)"
+                    f"{chunk_label} ({valid_image_count}/{len(chunk_paths)}件)"
                 )
             clip_features_list = self.feature_extractor.extract_clip_features_batch(
                 pil_images,
                 initial_batch_size=batch_size,
             )
             if show_progress:
-                logger.info(f"CLIP特徴抽出完了: chunk {chunk_idx + 1}/{total_chunks}")
+                logger.info(f"CLIP特徴抽出完了: {chunk_label}")
             clip_features_np_list = self._convert_batch_features_to_numpy(
                 clip_features_list
             )
@@ -236,6 +239,7 @@ class BatchPipeline:
         chunk_idx: int,
         lookahead: int,
         preload_futures: dict[int, "BatchPipeline._PilImagesFuture"],
+        total_chunks: int,
         show_progress: bool = False,
     ) -> None:
         """先読みチャンクをプリロードExecutorに投入する."""
@@ -244,10 +248,9 @@ class BatchPipeline:
             next_start, next_end = chunk_boundaries[next_idx]
             next_paths = paths[next_start:next_end]
             if show_progress:
+                chunk_label = self._chunk_label(next_idx, total_chunks)
                 logger.info(
-                    "画像読み込みを開始します: "
-                    f"chunk {next_idx + 1}/{len(chunk_boundaries)} "
-                    f"({len(next_paths)}件)"
+                    f"画像読み込みを開始します: {chunk_label} ({len(next_paths)}件)"
                 )
             preload_futures[next_idx] = self._get_preload_executor().submit(
                 self.load_and_preprocess_images,

--- a/src/services/game_screen_picker.py
+++ b/src/services/game_screen_picker.py
@@ -1,5 +1,6 @@
 """ゲーム画面ピッカーの統合オーケストレーション."""
 
+import logging
 import re
 from pathlib import Path
 
@@ -11,6 +12,8 @@ from ..protocols.analyzer_like import AnalyzerLike
 from ..protocols.scene_analyzer_like import SceneAnalyzerLike
 from .analyzed_image_selector import AnalyzedImageSelector
 from .neutral_analysis_cache import NeutralAnalysisCache
+
+logger = logging.getLogger(__name__)
 
 
 class GameScreenPicker:
@@ -100,6 +103,8 @@ class GameScreenPicker:
         results: list[AnalyzedImage | None] = [None] * len(files)
         misses: list[Path] = []
         miss_indices: list[int] = []
+        if show_progress:
+            logger.info("中立解析cacheを確認しています...")
         for index, file_path in enumerate(files):
             cached = cache.read(file_path)
             if cached is None:
@@ -107,6 +112,10 @@ class GameScreenPicker:
                 miss_indices.append(index)
             else:
                 results[index] = cached
+
+        if show_progress:
+            cache_hits = len(files) - len(misses)
+            logger.info(f"中立解析cache: hit={cache_hits}件, miss={len(misses)}件")
 
         analyzed_misses = self._analyze_image_paths_with_cache(
             misses,
@@ -142,8 +151,12 @@ class GameScreenPicker:
     ) -> list[AnalyzedImage | None]:
         """画像path群を解析し、チャンク完了ごとにcacheへ保存する."""
         if not files:
+            if show_progress:
+                logger.info("未cache画像はありません。中立解析をスキップします。")
             return []
         paths = [str(file_path) for file_path in files]
+        if show_progress:
+            logger.info(f"未cache画像の中立解析を開始します: {len(paths)}件")
 
         def write_completed_chunk(
             chunk_results: list[AnalyzedImage | None],
@@ -206,8 +219,12 @@ class GameScreenPicker:
             2. 非選択になった候補
             3. 実行統計をまとめた `PickerStatistics`
         """
+        if show_progress:
+            logger.info("入力画像を検索しています...")
         files = GameScreenPicker.load_image_files(folder, recursive)
         total_files = len(files)
+        if show_progress:
+            logger.info(f"入力画像: {total_files}件")
 
         input_path = Path(folder)
         analyzed_images = self._analyze_images(files, input_path, show_progress)

--- a/src/services/game_screen_picker.py
+++ b/src/services/game_screen_picker.py
@@ -127,21 +127,6 @@ class GameScreenPicker:
             results[index] = analyzed_image
         return [result for result in results if result is not None]
 
-    def _analyze_image_paths(
-        self,
-        files: list[Path],
-        show_progress: bool,
-    ) -> list[AnalyzedImage | None]:
-        """画像path群をAnalyzerへ渡す."""
-        if not files:
-            return []
-        paths = [str(file_path) for file_path in files]
-        return self.analyzer.analyze_batch(
-            paths,
-            batch_size=self.config.batch_size,
-            show_progress=show_progress,
-        )
-
     def _analyze_image_paths_with_cache(
         self,
         files: list[Path],

--- a/tests/analyzers/test_batch_pipeline.py
+++ b/tests/analyzers/test_batch_pipeline.py
@@ -1,0 +1,57 @@
+"""BatchPipelineの単体テスト."""
+
+import logging
+from pathlib import Path
+from typing import cast
+
+import pytest
+from PIL import Image
+
+from src.analyzers.batch_pipeline import BatchPipeline
+from src.analyzers.feature_extractor import FeatureExtractor
+from src.analyzers.metric_calculator import MetricCalculator
+from src.models.analyzer_config import AnalyzerConfig
+from tests.fake_feature_extractor import FakeFeatureExtractor
+
+
+def test_process_batch_logs_chunk_preparation_before_clip_extraction(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """CLIP抽出前のチャンク準備状況が進捗ログに出力されること.
+
+    Arrange:
+        - 読み込み可能な画像ファイルがある
+        - 進捗表示が有効である
+    Act:
+        - BatchPipelineで中立解析される
+    Assert:
+        - チャンク準備、画像読み込み、CLIP特徴抽出開始がログ出力されること
+    """
+    # Arrange
+    image_path = tmp_path / "frame1.jpg"
+    Image.new("RGB", (16, 16), color=(120, 120, 120)).save(image_path)
+    config = AnalyzerConfig(
+        max_dim=16,
+        min_chunk_size=1,
+        result_max_workers=1,
+        io_max_workers=1,
+    )
+    pipeline = BatchPipeline(
+        cast(FeatureExtractor, FakeFeatureExtractor()),
+        MetricCalculator(config),
+        config,
+    )
+    caplog.set_level(logging.INFO)
+
+    # Act
+    try:
+        pipeline.process_batch([str(image_path)], show_progress=True)
+    finally:
+        pipeline.close()
+
+    # Assert
+    assert "中立解析を開始します: 1件" in caplog.text
+    assert "解析チャンク: 1個" in caplog.text
+    assert "画像読み込みを開始します: chunk 1/1" in caplog.text
+    assert "CLIP特徴抽出を開始します: chunk 1/1" in caplog.text

--- a/tests/fake_feature_extractor.py
+++ b/tests/fake_feature_extractor.py
@@ -1,7 +1,5 @@
 """BatchPipelineテスト用feature extractor."""
 
-from typing import Any
-
 import numpy as np
 import torch
 from PIL import Image
@@ -9,6 +7,12 @@ from PIL import Image
 
 class FakeFeatureExtractor:
     """BatchPipeline向けの軽量特徴抽出器."""
+
+    @staticmethod
+    def _hsv_features_or_default(hsv_features: np.ndarray | None) -> np.ndarray:
+        if hsv_features is not None:
+            return hsv_features
+        return np.ones(64, dtype=np.float32)
 
     @staticmethod
     def extract_clip_features_batch(
@@ -33,15 +37,15 @@ class FakeFeatureExtractor:
         hsv_features: np.ndarray | None = None,
     ) -> np.ndarray:
         del img
-        features = hsv_features if hsv_features is not None else np.ones(64)
+        features = FakeFeatureExtractor._hsv_features_or_default(hsv_features)
         return np.concatenate([features, clip_features])
 
     @staticmethod
     def extract_content_features(
         img: np.ndarray,
-        raw_metrics: Any,
+        raw_metrics: object,
         hsv_features: np.ndarray | None = None,
     ) -> np.ndarray:
         del img, raw_metrics
-        features = hsv_features if hsv_features is not None else np.ones(64)
+        features = FakeFeatureExtractor._hsv_features_or_default(hsv_features)
         return np.concatenate([features, np.ones(37, dtype=np.float32)])

--- a/tests/fake_feature_extractor.py
+++ b/tests/fake_feature_extractor.py
@@ -1,0 +1,47 @@
+"""BatchPipelineテスト用feature extractor."""
+
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+
+
+class FakeFeatureExtractor:
+    """BatchPipeline向けの軽量特徴抽出器."""
+
+    @staticmethod
+    def extract_clip_features_batch(
+        pil_images: list[Image.Image | None],
+        initial_batch_size: int = 32,
+    ) -> list[torch.Tensor | None]:
+        del initial_batch_size
+        return [
+            torch.ones(512, dtype=torch.float32) if image is not None else None
+            for image in pil_images
+        ]
+
+    @staticmethod
+    def extract_hsv_features(img: np.ndarray) -> np.ndarray:
+        del img
+        return np.ones(64, dtype=np.float32)
+
+    @staticmethod
+    def extract_combined_features(
+        img: np.ndarray,
+        clip_features: np.ndarray,
+        hsv_features: np.ndarray | None = None,
+    ) -> np.ndarray:
+        del img
+        features = hsv_features if hsv_features is not None else np.ones(64)
+        return np.concatenate([features, clip_features])
+
+    @staticmethod
+    def extract_content_features(
+        img: np.ndarray,
+        raw_metrics: Any,
+        hsv_features: np.ndarray | None = None,
+    ) -> np.ndarray:
+        del img, raw_metrics
+        features = hsv_features if hsv_features is not None else np.ones(64)
+        return np.concatenate([features, np.ones(37, dtype=np.float32)])

--- a/tests/services/test_game_screen_picker.py
+++ b/tests/services/test_game_screen_picker.py
@@ -1,6 +1,9 @@
 """GameScreenPickerの単体テスト."""
 
+import logging
 from pathlib import Path
+
+import pytest
 
 from src.models.analyzer_config import AnalyzerConfig
 from src.models.selection_config import SelectionConfig
@@ -103,6 +106,43 @@ def test_select_tracks_total_files_and_analysis_failures(tmp_path: Path) -> None
     assert stats.total_files == 3
     assert stats.analyzed_ok == 2
     assert stats.analyzed_fail == 1
+
+
+def test_select_logs_file_count_and_neutral_cache_summary(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """入力件数と中立解析cache状況が進捗ログに出力されること.
+
+    Arrange:
+        - 複数の画像ファイルを含むディレクトリがある
+        - 進捗表示が有効である
+    Act:
+        - GameScreenPickerで選定される
+    Assert:
+        - 入力画像件数と中立解析cacheのhit/miss件数がログ出力されること
+    """
+    # Arrange
+    for name in ["frame1.jpg", "frame2.jpg"]:
+        (tmp_path / name).write_bytes(b"\xff\xd8\xff")
+    analyzed_images = [
+        create_analyzed_image(path=str(tmp_path / "frame1.jpg")),
+        create_analyzed_image(path=str(tmp_path / "frame2.jpg")),
+    ]
+    picker = GameScreenPicker(
+        analyzer=FakeAnalyzer(analyzed_images),
+        config=SelectionConfig(),
+        scene_analyzer=FakeSceneAnalyzer(),
+    )
+    caplog.set_level(logging.INFO)
+
+    # Act
+    picker.select(str(tmp_path), num=2, recursive=False, show_progress=True)
+
+    # Assert
+    assert "入力画像: 2件" in caplog.text
+    assert "中立解析cache: hit=0件, miss=2件" in caplog.text
+    assert "未cache画像の中立解析を開始します: 2件" in caplog.text
 
 
 def test_select_reuses_neutral_analysis_cache_on_later_run(tmp_path: Path) -> None:


### PR DESCRIPTION
## 概要
- 処理開始直後に入力画像件数と中立解析cacheのhit/miss件数を出力
- チャンク計算、画像読み込み、CLIP特徴抽出の開始・完了ログを追加
- 進捗ログの挙動をテストし、READMEにコンソールログの説明を追加
- 進捗ログ周辺の重複した実装を整理

## 検証
- `uv run pytest tests/analyzers/test_batch_pipeline.py tests/services/test_game_screen_picker.py`
- `uv run task test`
- `git diff --check`

## 注意点
- `git push -u` 実行時、remote branch の作成は成功しましたが、sandbox制限によりローカルのupstream設定だけ書き込めませんでした。PR内容には影響ありません。