### PR TITLE
perf: Ollama画像分類でthinkingを無効化

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,4 @@ Ollama host の優先順位は `--ollama-host`、`OLLAMA_HOST`、`[ollama].host`
 - `--max-memory-gb`: 大きいほどチャンクサイズが増え、GPU利用率が上がりやすくなります
 - `--batch-size`: 大きいほど高速ですが、VRAM消費量が増えます
 - `--result-max-workers`: CPU並列度を調整します
+- Ollamaの `/api/chat` には常に `think=false` を送信します。scene分類では最終JSONだけを使うため、thinking対応モデルでは推論trace生成を抑えて速度を優先します

--- a/src/services/ollama_scene_analyzer.py
+++ b/src/services/ollama_scene_analyzer.py
@@ -99,6 +99,7 @@ class OllamaSceneAnalyzer:
             "model": self.config.model,
             "stream": False,
             "format": "json",
+            "think": False,
             "messages": [
                 {
                     "role": "user",

--- a/tests/services/test_ollama_scene_analyzer.py
+++ b/tests/services/test_ollama_scene_analyzer.py
@@ -25,7 +25,7 @@ def test_generate_scene_catalog_posts_images_to_chat_api(
     Act:
         - scene catalogを作成する
     Assert:
-        - Ollama chat APIへモデル名、ヒント、base64画像が送信されること
+        - Ollama chat APIへモデル名、thinking無効、ヒント、base64画像が送信されること
     """
     # Arrange
     image_path = tmp_path / "screen.png"
@@ -79,6 +79,7 @@ def test_generate_scene_catalog_posts_images_to_chat_api(
     assert request.full_url == "http://ollama:11434/api/chat"
     payload = json.loads(request.data.decode("utf-8"))  # type: ignore[union-attr]
     assert payload["model"] == "gemma4"
+    assert payload["think"] is False
     assert "RPG" in payload["messages"][0]["content"]
     assert payload["messages"][0]["images"] == ["aW1hZ2UtYnl0ZXM="]
     assert result[0].slug == "battle"


### PR DESCRIPTION
## 変更内容
- Ollama `/api/chat` のリクエストに `think=false` を追加
- scene分類では最終JSONのみを利用するため、thinking対応モデルの推論trace生成を抑制
- READMEと回帰テストを更新

## 検証
- `uv run task test`
- 149 passed

## リスク
- GPT-OSSなど一部モデルでは `think=false` が完全な無効化として扱われない可能性があります。