### PR TITLE
chore: Copierテンプレートの更新を反映

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,4 +1,4 @@
-_commit: 7086d9b
+_commit: 88e3afd
 _src_path: git@github.com:mizucopo/repo-template.git
 author_email: mizu.copo@gmail.com
 author_name: みず

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  checks: write
 
 jobs:
   quality-checks:
@@ -34,12 +34,13 @@ jobs:
         timeout-minutes: 10
         run: |
           uv run pytest --tb=short -v 2>&1 | tee pytest_output.txt
-          if [ ${PIPESTATUS[0]} -eq 0 ]; then
+          PYTEST_EXIT=${PIPESTATUS[0]}
+          if [ "$PYTEST_EXIT" -eq 0 ]; then
             RESULT="✅ 成功"
           else
-            RESULT="❌ 失敗 (終了コード: ${PIPESTATUS[0]})"
+            RESULT="❌ 失敗 (終了コード: $PYTEST_EXIT)"
           fi
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
 
       - name: Run mypy
         id: mypy
@@ -50,7 +51,7 @@ jobs:
           else
             RESULT="❌ 失敗"
           fi
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
 
       - name: Run ruff format check
         id: ruff-format
@@ -61,7 +62,7 @@ jobs:
           else
             RESULT="❌ 失敗"
           fi
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
 
       - name: Run ruff check
         id: ruff-check
@@ -72,15 +73,14 @@ jobs:
           else
             RESULT="❌ 失敗"
           fi
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
 
-      - name: Comment on PR
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Build quality check summary
+        id: quality-report
+        if: always()
         run: |
-          gh pr comment ${{ github.event.number }} --body "
-          ## 🔍 Quality Checks Result
+          cat > quality_report.md <<'EOF'
+          ## Quality Checks Result
 
           | Item | Result |
           |-------------|------|
@@ -88,4 +88,52 @@ jobs:
           | mypy | ${{ steps.mypy.outputs.result }} |
           | ruff format | ${{ steps.ruff-format.outputs.result }} |
           | ruff check | ${{ steps.ruff-check.outputs.result }} |
-          "
+          EOF
+
+          cat quality_report.md >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            echo "summary<<EOF"
+            cat quality_report.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish quality check
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+        uses: actions/github-script@v7
+        continue-on-error: true
+        env:
+          SUMMARY: ${{ steps.quality-report.outputs.summary }}
+          PYTEST_RESULT: ${{ steps.pytest.outputs.result }}
+          MYPY_RESULT: ${{ steps.mypy.outputs.result }}
+          RUFF_FORMAT_RESULT: ${{ steps.ruff-format.outputs.result }}
+          RUFF_CHECK_RESULT: ${{ steps.ruff-check.outputs.result }}
+        with:
+          script: |
+            const results = [
+              process.env.PYTEST_RESULT,
+              process.env.MYPY_RESULT,
+              process.env.RUFF_FORMAT_RESULT,
+              process.env.RUFF_CHECK_RESULT,
+            ];
+            const allPassed = results.every((result) => result?.includes("成功"));
+
+            let checkConclusion = "neutral";
+            let checkTitle = "Quality checks need attention";
+            if (allPassed) {
+              checkConclusion = "success";
+              checkTitle = "All quality checks passed";
+            }
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: "Quality Checks Result",
+              head_sha: context.payload.pull_request.head.sha,
+              status: "completed",
+              conclusion: checkConclusion,
+              output: {
+                title: checkTitle,
+                summary: process.env.SUMMARY,
+              },
+            });

--- a/.github/workflows/pr-tag-check.yml
+++ b/.github/workflows/pr-tag-check.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  checks: write
 
 jobs:
   check-tag-conflict:
@@ -21,42 +21,104 @@ jobs:
 
       - name: Read version
         id: version
+        continue-on-error: true
         run: |
-          echo "version=$(awk -F'\"' '/^version *=/ {print $2}' pyproject.toml)" >> "$GITHUB_OUTPUT"
+          VERSION="$(awk -F'\"' '/^version *=/ {print $2}' pyproject.toml)"
+          if [ -z "$VERSION" ]; then
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if tag exists
         id: tag
+        if: steps.version.outcome == 'success'
+        continue-on-error: true
         run: |
           git fetch --tags
           if git rev-parse "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Comment on PR
-        if: github.event_name == 'pull_request'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build version tag check summary
+        id: tag-report
+        if: always()
         run: |
-          if [ "${{ steps.tag.outputs.exists }}" = "true" ]; then
-            MESSAGE="$(printf '%s\n' \
-              "## Version Tag Check ❌" \
-              "" \
-              "The version \`${{ steps.version.outputs.version }}\` already exists as a git tag." \
-              "" \
-              "Please update the version with a new version number before merging.")"
-            gh pr comment "${{ github.event.pull_request.number }}" --body "$MESSAGE"
+          TAG_CHECK_COMPLETED="false"
+          if [ "${{ steps.version.outcome }}" != "success" ]; then
+            cat > tag_report.md <<'EOF'
+          ## Version Tag Check ⚠️
+
+          The version could not be read, so tag availability was not checked.
+          EOF
+          elif [ "${{ steps.tag.outcome }}" != "success" ] || [ -z "${{ steps.tag.outputs.exists }}" ]; then
+            cat > tag_report.md <<'EOF'
+          ## Version Tag Check ⚠️
+
+          The version `${{ steps.version.outputs.version }}` could not be checked against git tags.
+          EOF
+          elif [ "${{ steps.tag.outputs.exists }}" = "true" ]; then
+            TAG_CHECK_COMPLETED="true"
+            cat > tag_report.md <<'EOF'
+          ## Version Tag Check ❌
+
+          The version `${{ steps.version.outputs.version }}` already exists as a git tag.
+
+          Please update the version with a new version number before merging.
+          EOF
           else
-            MESSAGE="$(printf '%s\n' \
-              "## Version Tag Check ✅" \
-              "" \
-              "The version \`${{ steps.version.outputs.version }}\` does not exist as a git tag." \
-              "" \
-              "This version is available for use.")"
-            gh pr comment "${{ github.event.pull_request.number }}" --body "$MESSAGE"
+            TAG_CHECK_COMPLETED="true"
+            cat > tag_report.md <<'EOF'
+          ## Version Tag Check ✅
+
+          The version `${{ steps.version.outputs.version }}` does not exist as a git tag.
+
+          This version is available for use.
+          EOF
           fi
 
-      - name: Fail if tag exists
-        if: steps.tag.outputs.exists == 'true'
-        run: exit 1
+          cat tag_report.md >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            echo "summary<<EOF"
+            cat tag_report.md
+            echo "EOF"
+            echo "tag_check_completed=$TAG_CHECK_COMPLETED"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish version tag check
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+        uses: actions/github-script@v7
+        continue-on-error: true
+        env:
+          SUMMARY: ${{ steps.tag-report.outputs.summary }}
+          TAG_EXISTS: ${{ steps.tag.outputs.exists }}
+          TAG_CHECK_COMPLETED: ${{ steps.tag-report.outputs.tag_check_completed }}
+        with:
+          script: |
+            const tagExists = process.env.TAG_EXISTS === "true";
+            const tagCheckCompleted = process.env.TAG_CHECK_COMPLETED === "true";
+
+            let checkConclusion = "neutral";
+            let checkTitle = "Version tag is available";
+            if (tagCheckCompleted && !tagExists) {
+              checkConclusion = "success";
+            } else if (!tagCheckCompleted) {
+              checkTitle = "Version tag check could not complete";
+            } else if (tagExists) {
+              checkTitle = "Version tag already exists";
+            }
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: "Version Tag Check",
+              head_sha: context.payload.pull_request.head.sha,
+              status: "completed",
+              conclusion: checkConclusion,
+              output: {
+                title: checkTitle,
+                summary: process.env.SUMMARY,
+              },
+            });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,12 @@ Follow single responsibility principle to minimize scope of changes.
 - **Scope**: Never test private methods directly. Cover them indirectly via public interfaces
 
 ### HOW
-- Structure with **AAA Pattern** (Arrange, Act, Assert) and explicit comments in Japanese
-- **Naming**: Describe business requirements (e.g., `sum_of_two_numbers_returns_total_value`)
+- Structure with **AAA Pattern** (Arrange, Act, Assert) with explicit sections in both docstrings and code comments, written in Japanese
+  - **Docstring**: Include `Arrange:`, `Act:`, `Assert:` lines describing each step
+  - **Code comments**: Insert `# Arrange`, `# Act`, `# Assert` as section dividers in the test function body
+- **Naming**: Use English for test function names, describing business requirements
 - **File placement**: Mirror source module structure in `tests/` directory
+- **Docstring**: Describe a summary of what is being tested (in Japanese)
 - **Docstring style**: Use passive voice ("〜こと" form) consistently
   - Title: "〜を検証" → "〜されること", "〜が〜されること"
   - When: "〜を選択", "〜を実行" → "〜が選択され", "〜が実行される"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,12 @@ Follow single responsibility principle to minimize scope of changes.
 - **Scope**: Never test private methods directly. Cover them indirectly via public interfaces
 
 ### HOW
-- Structure with **AAA Pattern** (Arrange, Act, Assert) and explicit comments in Japanese
-- **Naming**: Describe business requirements (e.g., `sum_of_two_numbers_returns_total_value`)
+- Structure with **AAA Pattern** (Arrange, Act, Assert) with explicit sections in both docstrings and code comments, written in Japanese
+  - **Docstring**: Include `Arrange:`, `Act:`, `Assert:` lines describing each step
+  - **Code comments**: Insert `# Arrange`, `# Act`, `# Assert` as section dividers in the test function body
+- **Naming**: Use English for test function names, describing business requirements
 - **File placement**: Mirror source module structure in `tests/` directory
+- **Docstring**: Describe a summary of what is being tested (in Japanese)
 - **Docstring style**: Use passive voice ("〜こと" form) consistently
   - Title: "〜を検証" → "〜されること", "〜が〜されること"
   - When: "〜を選択", "〜を実行" → "〜が選択され", "〜が実行される"


### PR DESCRIPTION
## 概要

- Copierテンプレートの参照コミットを `88e3afd` に更新
- PR品質チェックとバージョンタグチェックの結果を、PRコメントではなくGitHub Checksとして公開するように更新
- テスト記述ルールのAAAセクションと命名ルールを明確化

## 確認

- `uv run task test`（163 passed）

## 補足

- GitHub Actions workflowの権限と結果公開方法を変更しているため、PR上のCIで最終確認されます。
