### PR TITLE
fix: recurring gameplayのvariant group拡張を有効にする

### DIFF
--- a/src/services/dynamic_scene_selector.py
+++ b/src/services/dynamic_scene_selector.py
@@ -17,6 +17,8 @@ from .variant_group_assigner import VariantGroupAssigner
 class DynamicSceneSelector:
     """動的sceneを均等に扱いながら候補を選ぶ."""
 
+    RECURRING_GAMEPLAY_SIMILARITY_THRESHOLD = 0.98
+
     def __init__(
         self,
         similarity_threshold: float,
@@ -409,11 +411,4 @@ class DynamicSceneSelector:
 
     def _recurring_gameplay_similarity_threshold(self) -> float:
         """recurring gameplay向けの緩和済み類似度しきい値を返す."""
-        return min(
-            0.95,
-            max(
-                0.92,
-                self.similarity_threshold + 0.2,
-                max(self.threshold_steps, default=self.similarity_threshold),
-            ),
-        )
+        return self.RECURRING_GAMEPLAY_SIMILARITY_THRESHOLD

--- a/src/services/dynamic_scene_selector.py
+++ b/src/services/dynamic_scene_selector.py
@@ -362,7 +362,7 @@ class DynamicSceneSelector:
         selected_indices = list(seed_indices)
         selected_index_set = set(selected_indices)
         rejected_by_similarity_set: set[int] = set()
-        recurring_gameplay_threshold = self._recurring_gameplay_similarity_threshold()
+        recurring_gameplay_threshold = self.RECURRING_GAMEPLAY_SIMILARITY_THRESHOLD
         selected_count = 0
         for seed_index in selected_indices:
             selected_features_matrix[selected_count] = normalized_features[seed_index]
@@ -408,7 +408,3 @@ class DynamicSceneSelector:
         if candidate.scene_selection_role != SceneSelectionRole.RECURRING_GAMEPLAY:
             return threshold
         return max(threshold, recurring_gameplay_threshold)
-
-    def _recurring_gameplay_similarity_threshold(self) -> float:
-        """recurring gameplay向けの緩和済み類似度しきい値を返す."""
-        return self.RECURRING_GAMEPLAY_SIMILARITY_THRESHOLD

--- a/tests/services/test_dynamic_scene_selector.py
+++ b/tests/services/test_dynamic_scene_selector.py
@@ -363,6 +363,101 @@ def test_select_relaxes_similarity_for_recurring_gameplay_variants() -> None:
     ]
 
 
+def test_select_expands_default_recurring_gameplay_variant_group() -> None:
+    """recurring gameplayで既定variant group内の状態差画像が選ばれること.
+
+    Arrange:
+        - recurring gameplay sceneに類似度0.96の候補が2枚ある
+        - 既定のvariant groupしきい値で同じgroupに割り当てられる
+    Act:
+        - 2枚の選定が要求される
+    Assert:
+        - 同じvariant group内の状態差画像がどちらも選ばれること
+    """
+    # Arrange
+    first_feature = np.array([np.sqrt(0.96), np.sqrt(0.04), 0.0], dtype=np.float32)
+    second_feature = np.array([np.sqrt(0.96), 0.0, np.sqrt(0.04)], dtype=np.float32)
+    candidates = [
+        build_dynamic_candidate(
+            "/tmp/battle_phase_a.jpg",
+            "battle",
+            first_feature,
+            0.9,
+            SceneSelectionRole.RECURRING_GAMEPLAY,
+        ),
+        build_dynamic_candidate(
+            "/tmp/battle_phase_b.jpg",
+            "battle",
+            second_feature,
+            0.8,
+            SceneSelectionRole.RECURRING_GAMEPLAY,
+        ),
+    ]
+    selector = DynamicSceneSelector(
+        similarity_threshold=0.72,
+        threshold_steps=[0.72],
+    )
+
+    # Act
+    result = selector.select(candidates, num=2)
+
+    # Assert
+    assert [candidate.path for candidate in result.selected] == [
+        "/tmp/battle_phase_a.jpg",
+        "/tmp/battle_phase_b.jpg",
+    ]
+    assert result.annotations_by_path["/tmp/battle_phase_a.jpg"].variant_group == (
+        "battle_001"
+    )
+    assert result.annotations_by_path["/tmp/battle_phase_b.jpg"].variant_group == (
+        "battle_001"
+    )
+
+
+def test_select_rejects_near_identical_recurring_gameplay_frame() -> None:
+    """recurring gameplayでもほぼ同一の連番フレームが除外されること.
+
+    Arrange:
+        - recurring gameplay sceneに類似度0.99の候補が2枚ある
+        - 2枚とも同じvariant groupに割り当てられる
+    Act:
+        - 2枚の選定が要求される
+    Assert:
+        - ほぼ同一の2枚目は選ばれないこと
+    """
+    # Arrange
+    first_feature = np.array([np.sqrt(0.99), np.sqrt(0.01), 0.0], dtype=np.float32)
+    second_feature = np.array([np.sqrt(0.99), 0.0, np.sqrt(0.01)], dtype=np.float32)
+    candidates = [
+        build_dynamic_candidate(
+            "/tmp/battle_frame_a.jpg",
+            "battle",
+            first_feature,
+            0.9,
+            SceneSelectionRole.RECURRING_GAMEPLAY,
+        ),
+        build_dynamic_candidate(
+            "/tmp/battle_frame_b.jpg",
+            "battle",
+            second_feature,
+            0.8,
+            SceneSelectionRole.RECURRING_GAMEPLAY,
+        ),
+    ]
+    selector = DynamicSceneSelector(
+        similarity_threshold=0.72,
+        threshold_steps=[0.72],
+    )
+
+    # Act
+    result = selector.select(candidates, num=2)
+
+    # Assert
+    assert [candidate.path for candidate in result.selected] == [
+        "/tmp/battle_frame_a.jpg",
+    ]
+
+
 def build_dynamic_candidate(
     path: str,
     scene_slug: str,


### PR DESCRIPTION
## Summary
- recurring gameplayの類似度許容を0.98にして、既定variant group内の状態差画像が要求枚数に応じて選ばれるようにしました。
- 類似度0.96は選ばれ、0.99のほぼ同一フレームは除外される回帰テストを追加しました。
- 追加したしきい値参照を簡素化しました。

## Verification
- `uv run pytest tests/services/test_dynamic_scene_selector.py -q`
- `uv run task test` (165 passed)

Closes #156