### PR TITLE
fix: 既存タグ検出時にPRタグチェックを失敗させる

### DIFF
--- a/.github/workflows/pr-tag-check.yml
+++ b/.github/workflows/pr-tag-check.yml
@@ -107,6 +107,7 @@ jobs:
             } else if (!tagCheckCompleted) {
               checkTitle = "Version tag check could not complete";
             } else if (tagExists) {
+              checkConclusion = "failure";
               checkTitle = "Version tag already exists";
             }
 
@@ -122,3 +123,7 @@ jobs:
                 summary: process.env.SUMMARY,
               },
             });
+
+      - name: Fail if tag exists
+        if: steps.tag.outputs.exists == 'true'
+        run: exit 1

--- a/tests/test_pr_tag_check_workflow.py
+++ b/tests/test_pr_tag_check_workflow.py
@@ -1,0 +1,58 @@
+import re
+from pathlib import Path
+
+_WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[1] / ".github" / "workflows" / "pr-tag-check.yml"
+)
+
+
+def test_existing_version_tag_publishes_failure_check() -> None:
+    """既存のtagと同じversionが検出されると失敗checkが公開されること.
+
+    Arrange:
+        - PR tag check workflowが読み込まれる
+    Act:
+        - 既存tag分岐のgithub-scriptが取り出される
+    Assert:
+        - 既存tag分岐でcheck conclusionがfailureに設定されること
+    """
+    # Arrange
+    workflow = _WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    # Act
+    duplicate_tag_branch = re.search(
+        r"else if \(tagExists\) \{\n(?P<body>.*?)\n\s+\}",
+        workflow,
+        re.DOTALL,
+    )
+    assert duplicate_tag_branch is not None
+    branch_body = duplicate_tag_branch.group("body")
+
+    # Assert
+    assert 'checkConclusion = "failure";' in branch_body
+    assert 'checkTitle = "Version tag already exists";' in branch_body
+
+
+def test_existing_version_tag_fails_workflow_job() -> None:
+    """既存のtagと同じversionが検出されるとworkflow jobが失敗されること.
+
+    Arrange:
+        - PR tag check workflowが読み込まれる
+    Act:
+        - 既存tagを失敗扱いにするstepが検索される
+    Assert:
+        - 既存tagの場合にexit 1が実行されること
+    """
+    # Arrange
+    workflow = _WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    # Act
+    fail_step = re.search(
+        r"- name: Fail if tag exists\n"
+        r"\s+if: steps\.tag\.outputs\.exists == 'true'\n"
+        r"\s+run: exit 1",
+        workflow,
+    )
+
+    # Assert
+    assert fail_step is not None


### PR DESCRIPTION
## 概要

- PR tag check workflowで、既存のversion tagを検出したときにGitHub Checkのconclusionを`failure`にします。
- 既存tag検出時にworkflow job自体も`exit 1`で失敗させ、重複リリースversionのmergeを防ぎます。
- workflowの回帰テストを追加しました。

Closes #154

## 検証

- `actionlint .github/workflows/pr-tag-check.yml`
- `uv run task test`（176 passed）