### PR TITLE
fix: recurring gameplayとPRタグチェックの修正を反映

### DIFF
--- a/.github/workflows/pr-tag-check.yml
+++ b/.github/workflows/pr-tag-check.yml
@@ -107,6 +107,7 @@ jobs:
             } else if (!tagCheckCompleted) {
               checkTitle = "Version tag check could not complete";
             } else if (tagExists) {
+              checkConclusion = "failure";
               checkTitle = "Version tag already exists";
             }
 
@@ -122,3 +123,7 @@ jobs:
                 summary: process.env.SUMMARY,
               },
             });
+
+      - name: Fail if tag exists
+        if: steps.tag.outputs.exists == 'true'
+        run: exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.5.0"
+version = "1.5.1"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/src/services/dynamic_scene_selector.py
+++ b/src/services/dynamic_scene_selector.py
@@ -17,6 +17,8 @@ from .variant_group_assigner import VariantGroupAssigner
 class DynamicSceneSelector:
     """動的sceneを均等に扱いながら候補を選ぶ."""
 
+    RECURRING_GAMEPLAY_SIMILARITY_THRESHOLD = 0.98
+
     def __init__(
         self,
         similarity_threshold: float,
@@ -360,7 +362,7 @@ class DynamicSceneSelector:
         selected_indices = list(seed_indices)
         selected_index_set = set(selected_indices)
         rejected_by_similarity_set: set[int] = set()
-        recurring_gameplay_threshold = self._recurring_gameplay_similarity_threshold()
+        recurring_gameplay_threshold = self.RECURRING_GAMEPLAY_SIMILARITY_THRESHOLD
         selected_count = 0
         for seed_index in selected_indices:
             selected_features_matrix[selected_count] = normalized_features[seed_index]
@@ -406,14 +408,3 @@ class DynamicSceneSelector:
         if candidate.scene_selection_role != SceneSelectionRole.RECURRING_GAMEPLAY:
             return threshold
         return max(threshold, recurring_gameplay_threshold)
-
-    def _recurring_gameplay_similarity_threshold(self) -> float:
-        """recurring gameplay向けの緩和済み類似度しきい値を返す."""
-        return min(
-            0.95,
-            max(
-                0.92,
-                self.similarity_threshold + 0.2,
-                max(self.threshold_steps, default=self.similarity_threshold),
-            ),
-        )

--- a/tests/models/test_scene_selection_role.py
+++ b/tests/models/test_scene_selection_role.py
@@ -1,0 +1,59 @@
+"""scene_selection_role.py の単体テスト."""
+
+import pytest
+
+from src.models.scene_selection_role import SceneSelectionRole
+
+
+@pytest.mark.parametrize(
+    "value,expected_role",
+    [
+        ("ordinary", SceneSelectionRole.ORDINARY),
+        ("cinematic", SceneSelectionRole.CINEMATIC),
+        ("recurring_gameplay", SceneSelectionRole.RECURRING_GAMEPLAY),
+        (" cinematic ", SceneSelectionRole.CINEMATIC),
+        (SceneSelectionRole.RECURRING_GAMEPLAY, SceneSelectionRole.RECURRING_GAMEPLAY),
+    ],
+)
+def test_from_value_returns_known_scene_selection_role(
+    value: object,
+    expected_role: SceneSelectionRole,
+) -> None:
+    """既知のrole値がSceneSelectionRoleとして返されること.
+
+    Arrange:
+        - 既知のroleを表す値がある
+    Act:
+        - SceneSelectionRoleへ正規化される
+    Assert:
+        - 対応するSceneSelectionRoleが返されること
+    """
+    # Arrange
+    # (パラメータ化されたvalueを使用)
+
+    # Act
+    role = SceneSelectionRole.from_value(value)
+
+    # Assert
+    assert role == expected_role
+
+
+@pytest.mark.parametrize("value", ["gameplay", "", None, 1])
+def test_from_value_normalizes_unknown_value_to_ordinary(value: object) -> None:
+    """未知のrole値がordinaryとして扱われること.
+
+    Arrange:
+        - 未知または文字列以外のrole値がある
+    Act:
+        - SceneSelectionRoleへ正規化される
+    Assert:
+        - ordinaryが返されること
+    """
+    # Arrange
+    # (パラメータ化されたvalueを使用)
+
+    # Act
+    role = SceneSelectionRole.from_value(value)
+
+    # Assert
+    assert role == SceneSelectionRole.ORDINARY

--- a/tests/services/test_dynamic_scene_selector.py
+++ b/tests/services/test_dynamic_scene_selector.py
@@ -363,6 +363,101 @@ def test_select_relaxes_similarity_for_recurring_gameplay_variants() -> None:
     ]
 
 
+def test_select_expands_default_recurring_gameplay_variant_group() -> None:
+    """recurring gameplayで既定variant group内の状態差画像が選ばれること.
+
+    Arrange:
+        - recurring gameplay sceneに類似度0.96の候補が2枚ある
+        - 既定のvariant groupしきい値で同じgroupに割り当てられる
+    Act:
+        - 2枚の選定が要求される
+    Assert:
+        - 同じvariant group内の状態差画像がどちらも選ばれること
+    """
+    # Arrange
+    first_feature = np.array([np.sqrt(0.96), np.sqrt(0.04), 0.0], dtype=np.float32)
+    second_feature = np.array([np.sqrt(0.96), 0.0, np.sqrt(0.04)], dtype=np.float32)
+    candidates = [
+        build_dynamic_candidate(
+            "/tmp/battle_phase_a.jpg",
+            "battle",
+            first_feature,
+            0.9,
+            SceneSelectionRole.RECURRING_GAMEPLAY,
+        ),
+        build_dynamic_candidate(
+            "/tmp/battle_phase_b.jpg",
+            "battle",
+            second_feature,
+            0.8,
+            SceneSelectionRole.RECURRING_GAMEPLAY,
+        ),
+    ]
+    selector = DynamicSceneSelector(
+        similarity_threshold=0.72,
+        threshold_steps=[0.72],
+    )
+
+    # Act
+    result = selector.select(candidates, num=2)
+
+    # Assert
+    assert [candidate.path for candidate in result.selected] == [
+        "/tmp/battle_phase_a.jpg",
+        "/tmp/battle_phase_b.jpg",
+    ]
+    assert result.annotations_by_path["/tmp/battle_phase_a.jpg"].variant_group == (
+        "battle_001"
+    )
+    assert result.annotations_by_path["/tmp/battle_phase_b.jpg"].variant_group == (
+        "battle_001"
+    )
+
+
+def test_select_rejects_near_identical_recurring_gameplay_frame() -> None:
+    """recurring gameplayでもほぼ同一の連番フレームが除外されること.
+
+    Arrange:
+        - recurring gameplay sceneに類似度0.99の候補が2枚ある
+        - 2枚とも同じvariant groupに割り当てられる
+    Act:
+        - 2枚の選定が要求される
+    Assert:
+        - ほぼ同一の2枚目は選ばれないこと
+    """
+    # Arrange
+    first_feature = np.array([np.sqrt(0.99), np.sqrt(0.01), 0.0], dtype=np.float32)
+    second_feature = np.array([np.sqrt(0.99), 0.0, np.sqrt(0.01)], dtype=np.float32)
+    candidates = [
+        build_dynamic_candidate(
+            "/tmp/battle_frame_a.jpg",
+            "battle",
+            first_feature,
+            0.9,
+            SceneSelectionRole.RECURRING_GAMEPLAY,
+        ),
+        build_dynamic_candidate(
+            "/tmp/battle_frame_b.jpg",
+            "battle",
+            second_feature,
+            0.8,
+            SceneSelectionRole.RECURRING_GAMEPLAY,
+        ),
+    ]
+    selector = DynamicSceneSelector(
+        similarity_threshold=0.72,
+        threshold_steps=[0.72],
+    )
+
+    # Act
+    result = selector.select(candidates, num=2)
+
+    # Assert
+    assert [candidate.path for candidate in result.selected] == [
+        "/tmp/battle_frame_a.jpg",
+    ]
+
+
 def build_dynamic_candidate(
     path: str,
     scene_slug: str,

--- a/tests/test_pr_tag_check_workflow.py
+++ b/tests/test_pr_tag_check_workflow.py
@@ -1,0 +1,58 @@
+import re
+from pathlib import Path
+
+_WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[1] / ".github" / "workflows" / "pr-tag-check.yml"
+)
+
+
+def test_existing_version_tag_publishes_failure_check() -> None:
+    """既存のtagと同じversionが検出されると失敗checkが公開されること.
+
+    Arrange:
+        - PR tag check workflowが読み込まれる
+    Act:
+        - 既存tag分岐のgithub-scriptが取り出される
+    Assert:
+        - 既存tag分岐でcheck conclusionがfailureに設定されること
+    """
+    # Arrange
+    workflow = _WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    # Act
+    duplicate_tag_branch = re.search(
+        r"else if \(tagExists\) \{\n(?P<body>.*?)\n\s+\}",
+        workflow,
+        re.DOTALL,
+    )
+    assert duplicate_tag_branch is not None
+    branch_body = duplicate_tag_branch.group("body")
+
+    # Assert
+    assert 'checkConclusion = "failure";' in branch_body
+    assert 'checkTitle = "Version tag already exists";' in branch_body
+
+
+def test_existing_version_tag_fails_workflow_job() -> None:
+    """既存のtagと同じversionが検出されるとworkflow jobが失敗されること.
+
+    Arrange:
+        - PR tag check workflowが読み込まれる
+    Act:
+        - 既存tagを失敗扱いにするstepが検索される
+    Assert:
+        - 既存tagの場合にexit 1が実行されること
+    """
+    # Arrange
+    workflow = _WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    # Act
+    fail_step = re.search(
+        r"- name: Fail if tag exists\n"
+        r"\s+if: steps\.tag\.outputs\.exists == 'true'\n"
+        r"\s+run: exit 1",
+        workflow,
+    )
+
+    # Assert
+    assert fail_step is not None

--- a/uv.lock
+++ b/uv.lock
@@ -176,7 +176,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- recurring gameplay の variant group 拡張を有効化
- PRタグチェックで既存タグ検出時に失敗するよう修正
- SceneSelectionRole の専用テストを追加し、バージョンを 1.5.1 に更新

## Verification
- uv run task test