### PR TITLE
fix: Copier更新でPR品質チェックの失敗伝播を修正

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,13 @@
-_commit: 88e3afd
+_commit: d5da11d
 _src_path: git@github.com:mizucopo/repo-template.git
 author_email: mizu.copo@gmail.com
 author_name: みず
 python_version: '3.13'
+use_chrome_extension: false
 use_docker: false
 use_gh_actions_pr_tag_check: true
 use_gh_actions_release: true
 use_mit_license: true
 use_python: true
+use_rust: false
+use_tauri: false

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,4 +1,4 @@
-_commit: d5da11d
+_commit: 25616bd
 _src_path: git@github.com:mizucopo/repo-template.git
 author_email: mizu.copo@gmail.com
 author_name: みず

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   quality-checks:
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -19,7 +20,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version-file: '.python-version'
+          python-version-file: ".python-version"
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -118,8 +119,8 @@ jobs:
             ];
             const allPassed = results.every((result) => result?.includes("成功"));
 
-            let checkConclusion = "neutral";
-            let checkTitle = "Quality checks need attention";
+            let checkConclusion = "failure";
+            let checkTitle = "❌ Quality checks failed";
             if (allPassed) {
               checkConclusion = "success";
               checkTitle = "All quality checks passed";

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -6,11 +6,9 @@ on:
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
   quality-checks:
-    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,108 +31,68 @@ jobs:
         id: pytest
         continue-on-error: true
         timeout-minutes: 10
-        run: |
-          uv run pytest --tb=short -v 2>&1 | tee pytest_output.txt
-          PYTEST_EXIT=${PIPESTATUS[0]}
-          if [ "$PYTEST_EXIT" -eq 0 ]; then
-            RESULT="✅ 成功"
-          else
-            RESULT="❌ 失敗 (終了コード: $PYTEST_EXIT)"
-          fi
-          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+        run: uv run pytest --tb=short -v
 
       - name: Run mypy
         id: mypy
         continue-on-error: true
-        run: |
-          if uv run mypy > mypy_output.txt 2>&1; then
-            RESULT="✅ 成功"
-          else
-            RESULT="❌ 失敗"
-          fi
-          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+        run: uv run mypy
 
       - name: Run ruff format check
         id: ruff-format
         continue-on-error: true
-        run: |
-          if uv run ruff format --check . > ruff_format_output.txt 2>&1; then
-            RESULT="✅ 成功"
-          else
-            RESULT="❌ 失敗"
-          fi
-          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+        run: uv run ruff format --check .
 
       - name: Run ruff check
         id: ruff-check
         continue-on-error: true
-        run: |
-          if uv run ruff check . > ruff_check_output.txt 2>&1; then
-            RESULT="✅ 成功"
-          else
-            RESULT="❌ 失敗"
-          fi
-          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+        run: uv run ruff check .
 
       - name: Build quality check summary
         id: quality-report
-        if: always()
+        if: ${{ !cancelled() }}
+        env:
+          PYTEST_OUTCOME: ${{ steps.pytest.outcome }}
+          MYPY_OUTCOME: ${{ steps.mypy.outcome }}
+          RUFF_FORMAT_OUTCOME: ${{ steps.ruff-format.outcome }}
+          RUFF_CHECK_OUTCOME: ${{ steps.ruff-check.outcome }}
         run: |
-          cat > quality_report.md <<'EOF'
+          format_result() {
+            case "$1" in
+              success) printf '✅ 成功' ;;
+              failure) printf '❌ 失敗' ;;
+              skipped) printf '⏭️ スキップ' ;;
+              *) printf '❓ %s' "${1:-unknown}" ;;
+            esac
+          }
+
+          cat > quality_report.md <<EOF
           ## Quality Checks Result
 
           | Item | Result |
           |-------------|------|
-          | pytest | ${{ steps.pytest.outputs.result }} |
-          | mypy | ${{ steps.mypy.outputs.result }} |
-          | ruff format | ${{ steps.ruff-format.outputs.result }} |
-          | ruff check | ${{ steps.ruff-check.outputs.result }} |
+          | pytest | $(format_result "$PYTEST_OUTCOME") |
+          | mypy | $(format_result "$MYPY_OUTCOME") |
+          | ruff format | $(format_result "$RUFF_FORMAT_OUTCOME") |
+          | ruff check | $(format_result "$RUFF_CHECK_OUTCOME") |
           EOF
 
           cat quality_report.md >> "$GITHUB_STEP_SUMMARY"
 
-          {
-            echo "summary<<EOF"
-            cat quality_report.md
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          HAS_FAILURE=false
+          for outcome in \
+            "$PYTEST_OUTCOME" \
+            "$MYPY_OUTCOME" \
+            "$RUFF_FORMAT_OUTCOME" \
+            "$RUFF_CHECK_OUTCOME"; do
+            if [ "$outcome" != "success" ]; then
+              HAS_FAILURE=true
+            fi
+          done
+          echo "has-failure=$HAS_FAILURE" >> "$GITHUB_OUTPUT"
 
-      - name: Publish quality check
-        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
-        uses: actions/github-script@v7
-        continue-on-error: true
-        env:
-          SUMMARY: ${{ steps.quality-report.outputs.summary }}
-          PYTEST_RESULT: ${{ steps.pytest.outputs.result }}
-          MYPY_RESULT: ${{ steps.mypy.outputs.result }}
-          RUFF_FORMAT_RESULT: ${{ steps.ruff-format.outputs.result }}
-          RUFF_CHECK_RESULT: ${{ steps.ruff-check.outputs.result }}
-        with:
-          script: |
-            const results = [
-              process.env.PYTEST_RESULT,
-              process.env.MYPY_RESULT,
-              process.env.RUFF_FORMAT_RESULT,
-              process.env.RUFF_CHECK_RESULT,
-            ];
-            const allPassed = results.every((result) => result?.includes("成功"));
-
-            let checkConclusion = "failure";
-            let checkTitle = "❌ Quality checks failed";
-            if (allPassed) {
-              checkConclusion = "success";
-              checkTitle = "All quality checks passed";
-            }
-
-            await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: "Quality Checks Result",
-              head_sha: context.payload.pull_request.head.sha,
-              status: "completed",
-              conclusion: checkConclusion,
-              output: {
-                title: checkTitle,
-                summary: process.env.SUMMARY,
-              },
-            });
+      - name: Enforce quality gate result
+        if: ${{ !cancelled() && steps.quality-report.outputs.has-failure == 'true' }}
+        run: |
+          echo "::error::One or more quality checks failed or were skipped."
+          exit 1

--- a/.github/workflows/pr-tag-check.yml
+++ b/.github/workflows/pr-tag-check.yml
@@ -46,11 +46,16 @@ jobs:
         if: always()
         run: |
           TAG_CHECK_COMPLETED="false"
+          VERSION_SOURCE_VALIDATION_FAILED="false"
           if [ "${{ steps.version.outcome }}" != "success" ]; then
-            cat > tag_report.md <<'EOF'
+            VERSION_ERROR="The version could not be read, so tag availability was not checked."
+            if [ -f version_check_error.txt ]; then
+              VERSION_ERROR="$(< version_check_error.txt)"
+            fi
+            cat > tag_report.md <<EOF
           ## Version Tag Check ⚠️
 
-          The version could not be read, so tag availability was not checked.
+          ${VERSION_ERROR}
           EOF
           elif [ "${{ steps.tag.outcome }}" != "success" ] || [ -z "${{ steps.tag.outputs.exists }}" ]; then
             cat > tag_report.md <<'EOF'
@@ -85,6 +90,7 @@ jobs:
             cat tag_report.md
             echo "EOF"
             echo "tag_check_completed=$TAG_CHECK_COMPLETED"
+            echo "version_source_validation_failed=$VERSION_SOURCE_VALIDATION_FAILED"
           } >> "$GITHUB_OUTPUT"
 
       - name: Publish version tag check
@@ -95,14 +101,20 @@ jobs:
           SUMMARY: ${{ steps.tag-report.outputs.summary }}
           TAG_EXISTS: ${{ steps.tag.outputs.exists }}
           TAG_CHECK_COMPLETED: ${{ steps.tag-report.outputs.tag_check_completed }}
+          VERSION_SOURCE_VALIDATION_FAILED: ${{ steps.tag-report.outputs.version_source_validation_failed }}
         with:
           script: |
             const tagExists = process.env.TAG_EXISTS === "true";
             const tagCheckCompleted = process.env.TAG_CHECK_COMPLETED === "true";
+            const versionSourceValidationFailed =
+              process.env.VERSION_SOURCE_VALIDATION_FAILED === "true";
 
             let checkConclusion = "neutral";
             let checkTitle = "Version tag is available";
-            if (tagCheckCompleted && !tagExists) {
+            if (versionSourceValidationFailed) {
+              checkConclusion = "failure";
+              checkTitle = "Chrome extension version source validation failed";
+            } else if (tagCheckCompleted && !tagExists) {
               checkConclusion = "success";
             } else if (!tagCheckCompleted) {
               checkTitle = "Version tag check could not complete";

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,20 @@ htmlcov/
 build/
 dist/
 
+# Rust
+target/
+src-tauri/gen/schemas/
+
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Coverage
+coverage/
+
 # macOS
 .DS_Store
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,15 @@
+## Issue-First Branch Workflow
+
+### WHAT
+
+- Never make changes directly on `main`.
+- Before starting work, create a GitHub Issue that describes the work.
+- Perform the work on a non-`main` branch associated with that Issue.
+
 ## Documentation
 
 ### HOW
+
 - Update related documentation when code changes affect users
 - Document usage for new features in README
 - Update relevant docs when interfaces change
@@ -10,6 +19,7 @@
 ## File Operations
 
 ### HOW
+
 ```bash
 # File operations
 git mv <old-path> <new-path>  # Move files
@@ -19,16 +29,19 @@ git rm <path>                  # Delete files
 ## Code Organization Rules
 
 ### WHY
+
 Maintain consistent structure to ensure readability, maintainability, and testability.
 Follow single responsibility principle to minimize scope of changes.
 
 ### WHAT
+
 - One class per file
 - One test file per class
 - Keep `__init__.py` files empty
 - Never modify pyproject.toml when fixing linting errors
 
 ### HOW
+
 - Create a new file when adding a new class
 - Name test files as `test_<filename>.py`
 - Fix lint errors in code, never relax configuration
@@ -37,6 +50,7 @@ Follow single responsibility principle to minimize scope of changes.
 ## Testing Guidelines
 
 ### WHAT
+
 - **Framework**: Use function-based tests (pytest), not class-based
 - **Language**: Write test comments (especially AAA steps) and docstrings in Japanese to clarify intent
 - **Strategy**: Test "What" (observable behavior/results), not "How" (implementation details)
@@ -45,6 +59,7 @@ Follow single responsibility principle to minimize scope of changes.
 - **Scope**: Never test private methods directly. Cover them indirectly via public interfaces
 
 ### HOW
+
 - Structure with **AAA Pattern** (Arrange, Act, Assert) with explicit sections in both docstrings and code comments, written in Japanese
   - **Docstring**: Include `Arrange:`, `Act:`, `Assert:` lines describing each step
   - **Code comments**: Insert `# Arrange`, `# Act`, `# Assert` as section dividers in the test function body
@@ -59,7 +74,7 @@ Follow single responsibility principle to minimize scope of changes.
 ## Quality Check
 
 ### HOW
+
 ```bash
 uv run task test
 ```
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,15 @@
+## Issue-First Branch Workflow
+
+### WHAT
+
+- Never make changes directly on `main`.
+- Before starting work, create a GitHub Issue that describes the work.
+- Perform the work on a non-`main` branch associated with that Issue.
+
 ## Documentation
 
 ### HOW
+
 - Update related documentation when code changes affect users
 - Document usage for new features in README
 - Update relevant docs when interfaces change
@@ -10,6 +19,7 @@
 ## File Operations
 
 ### HOW
+
 ```bash
 # File operations
 git mv <old-path> <new-path>  # Move files
@@ -19,16 +29,19 @@ git rm <path>                  # Delete files
 ## Code Organization Rules
 
 ### WHY
+
 Maintain consistent structure to ensure readability, maintainability, and testability.
 Follow single responsibility principle to minimize scope of changes.
 
 ### WHAT
+
 - One class per file
 - One test file per class
 - Keep `__init__.py` files empty
 - Never modify pyproject.toml when fixing linting errors
 
 ### HOW
+
 - Create a new file when adding a new class
 - Name test files as `test_<filename>.py`
 - Fix lint errors in code, never relax configuration
@@ -37,6 +50,7 @@ Follow single responsibility principle to minimize scope of changes.
 ## Testing Guidelines
 
 ### WHAT
+
 - **Framework**: Use function-based tests (pytest), not class-based
 - **Language**: Write test comments (especially AAA steps) and docstrings in Japanese to clarify intent
 - **Strategy**: Test "What" (observable behavior/results), not "How" (implementation details)
@@ -45,6 +59,7 @@ Follow single responsibility principle to minimize scope of changes.
 - **Scope**: Never test private methods directly. Cover them indirectly via public interfaces
 
 ### HOW
+
 - Structure with **AAA Pattern** (Arrange, Act, Assert) with explicit sections in both docstrings and code comments, written in Japanese
   - **Docstring**: Include `Arrange:`, `Act:`, `Assert:` lines describing each step
   - **Code comments**: Insert `# Arrange`, `# Act`, `# Assert` as section dividers in the test function body
@@ -59,7 +74,7 @@ Follow single responsibility principle to minimize scope of changes.
 ## Quality Check
 
 ### HOW
+
 ```bash
 uv run task test
 ```
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.5.1"
+version = "1.5.2"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/tests/test_pr_quality_checks_workflow.py
+++ b/tests/test_pr_quality_checks_workflow.py
@@ -1,0 +1,34 @@
+import re
+from pathlib import Path
+
+_WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "pr-quality-checks.yml"
+)
+
+
+def test_quality_check_job_fails_on_setup_errors() -> None:
+    """setupエラーがquality check jobの失敗として扱われること.
+
+    Arrange:
+        - PR quality check workflowが読み込まれる
+    Act:
+        - quality-checks jobのstep前設定が取り出される
+    Assert:
+        - job全体のcontinue-on-errorが設定されていないこと
+    """
+    # Arrange
+    workflow = _WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    # Act
+    job_settings = re.search(
+        r"jobs:\n  quality-checks:\n(?P<settings>.*?)\n    steps:",
+        workflow,
+        re.DOTALL,
+    )
+    assert job_settings is not None
+
+    # Assert
+    assert "continue-on-error:" not in job_settings.group("settings")

--- a/uv.lock
+++ b/uv.lock
@@ -176,7 +176,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

- Copier テンプレートを `25616bd` へ更新
- PR quality checks で tool 別の結果収集を維持しつつ、失敗・スキップ時に workflow job を確実に失敗させる quality gate を追加
- PR tag check、Issue-first ブランチ運用ガイド、Rust / Node.js / Coverage の ignore 設定を同期
- job-level `continue-on-error` の再混入を防ぐ回帰テストを追加
- プロジェクトバージョンを `1.5.1` から `1.5.2` へ更新

## Codex レビュー対応

- P1「job-level `continue-on-error` が setup / dependency installation 失敗を許容し得る」指摘に対応
- job-level の許容設定と独自 Check 公開処理を削除
- 各 quality check の outcome を集約し、1件でも非成功なら terminal step が `exit 1` する構成へ変更

## 検証

- `uv run task test`（177 tests passed、format・ruff・mypy 成功）
- `uv run pytest tests/test_pr_quality_checks_workflow.py tests/test_pr_tag_check_workflow.py`（3 tests passed）
- `actionlint .github/workflows/pr-quality-checks.yml`
- `uv lock --check`（バージョン更新前後とも成功）
- `git diff --check origin/main...HEAD`

## リスク・補足

- quality check の失敗またはスキップで workflow job が失敗するよう、CI の判定を意図的に厳格化
- 利用者向けの移行作業は不要