### PR TITLE
feat: Video Set探索とキャッシュ基盤を実装

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,10 @@ _Avoid_: input folder, video folder, run, file list
 Video Setを発見し、そのcacheを保持するためにユーザーが指定するルートフォルダ。Video Setそのもののidentityではない。
 _Avoid_: Video Set, Output Folder, cache key
 
+**Input Lock**:
+一つのVideo Input Folderに対する同時実行を即時拒否し、非破壊validation完了後からprocessing cacheの変更とrun終了までを保護する非待機排他境界。異なるVideo Input Folderの実行は互いに妨げない。
+_Avoid_: Stage lock, waiting queue, global lock, cache artifact
+
 **Video Set Fingerprint**:
 Video Setの構成とVideo Orderをcacheやreportで参照するための、順序付きVideo Fingerprint列から導出される安定した識別子。
 _Avoid_: input path hash, unordered file set, global setting hash

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # game-screen-pick
 ゲームスクリーンショットから、ブログで使いやすい画像をOllamaの画像分類で選択するAIツールです。
 
-## 動画入力版の設計（未実装）
+## 動画入力版の設計と内部実装（公開前）
 
-複数のゲーム録画を一つのVideo Setとして扱う次期interfaceは、次の一つのcommandへ置き換える設計です。現時点では契約のみが確定しており、このcommandはまだ実行できません。
+複数のゲーム録画を一つのVideo Setとして扱う次期interfaceは、次の一つのcommandへ置き換える設計です。探索・content identity・Input Lock・Completed Stage cacheなどの内部基盤は実装済みですが、public CLIの切り替えはIssue #190で行うため、このcommandはまだ実行できません。
 
 ```bash
 game-screen-pick \
@@ -175,7 +175,7 @@ Ollama host の優先順位は `--ollama-host`、`OLLAMA_HOST`、`[ollama].host`
 ## 関連ドキュメント
 
 - [ADR index](docs/adr/README.md)
-- [ADR 0004: Select Video Set Blog Images Deterministically](docs/adr/0004-select-video-set-blog-images-deterministically.md)（動画入力向け設計、未実装）
-- [ADR 0005: Publish Video Selection Artifacts Atomically](docs/adr/0005-publish-video-selection-artifacts-atomically.md)（動画入力向け設計、未実装）
-- [ADR 0006: Expose Video Selection Through CLI and Versioned Config](docs/adr/0006-expose-video-selection-through-cli-and-versioned-config.md)（動画入力向け設計、未実装）
-- [ADR 0007: Migrate to the Video Set Selector Through a Gated Cutover](docs/adr/0007-migrate-to-video-set-selector-through-gated-cutover.md)（動画入力向け移行設計、未実装）
+- [ADR 0004: Select Video Set Blog Images Deterministically](docs/adr/0004-select-video-set-blog-images-deterministically.md)（動画入力向け設計、内部移行中）
+- [ADR 0005: Publish Video Selection Artifacts Atomically](docs/adr/0005-publish-video-selection-artifacts-atomically.md)（動画入力向け設計、内部移行中）
+- [ADR 0006: Expose Video Selection Through CLI and Versioned Config](docs/adr/0006-expose-video-selection-through-cli-and-versioned-config.md)（動画入力向け設計、内部移行中）
+- [ADR 0007: Migrate to the Video Set Selector Through a Gated Cutover](docs/adr/0007-migrate-to-video-set-selector-through-gated-cutover.md)（動画入力向け移行設計、内部移行中）

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,7 +1,7 @@
 # 動画入力の運用
 
 > [!IMPORTANT]
-> この文書は将来のVideo Set selectorの確定済み契約です。現在のscreenshot入力実装にはまだ適用されません。
+> Video Set探索・identity、Input Lock、Completed Stage cache、Legacy Cache削除の内部基盤は実装済みです。外部runtime、進捗表示、public CLIは後続Issueで接続し、installed CLIはIssue #190までscreenshot入力のままです。
 
 ## 最低runtime
 
@@ -20,6 +20,22 @@
 処理前に、CLI/TOML、入力・出力path、Video Set snapshot、cache書き込み、同一inputの非待機lock、外部tool、stream、model解決と能力を検査します。異常時はcache処理やOutput Folder公開を始めません。
 
 `--reset-cache`は上記の安全なpreflightとlock取得が成功した後に、`<VIDEO_INPUT_FOLDER>/.game-screen-pick/cache/`全体だけを削除します。Output Folder、Ollama model store、Hugging Face model cacheには触れません。Stage単位またはVideo単位の手動reset、自動削除、保持期限、容量上限はv1に含めません。
+
+## processing cache基盤
+
+Input Lockは`<VIDEO_INPUT_FOLDER>/.game-screen-pick/input.lock`でVideo Input Folder単位に取得します。待機queueは作らず、同じinputの別runが保持中なら即時に失敗します。lockはVideo Set snapshotの非破壊検査後から、cache準備、全Processing Stage、Output Folder公開の終了まで保持します。各Stageの前と公開直前にもsnapshotを再検査し、入力が変化したrunを確定しません。
+
+processing cacheはcontent-addressedな次のnamespaceを使います。
+
+```text
+<VIDEO_INPUT_FOLDER>/.game-screen-pick/cache/
+├── videos/<VIDEO_FINGERPRINT>/<STAGE>/<STAGE_FINGERPRINT>/
+└── video-sets/<VIDEO_SET_FINGERPRINT>/<STAGE>/<STAGE_FINGERPRINT>/
+```
+
+各Stage folderには`artifact.json`と`manifest.json`を置きます。manifestはschema、Stageとsubjectの完全fingerprint、上流fingerprint、Stage固有の正規化済み入力、artifactの相対path・byte数・SHA-256、timezone付き完了日時を保持し、absolute pathを含みません。artifactを書いた後にmanifestを作り、temporary directoryをrenameして一括公開します。manifestまたはartifactが欠ける、hashやmetadataが一致しない、symlinkであるなどのpartial・破損Stageはcache hitにせず再計算します。
+
+通常実行ではcacheの書込検査とInput Lock取得後に、認識済みLegacy Cacheの`neutral-analysis/`と`ollama-scenes.json`だけを自動削除します。削除件数と内容byte数をstructured diagnosticへ記録し、削除失敗はfatalです。新しい`videos/`、`video-sets/`、未知のentry、Output Folder、model storeは保持します。Legacy Cacheを変換または再利用する互換layerはありません。
 
 ## 自動再開
 

--- a/docs/video-input.md
+++ b/docs/video-input.md
@@ -1,7 +1,7 @@
 # 動画入力
 
 > [!IMPORTANT]
-> Effective Configurationと内部adapterは実装済みですが、installed public CLIはIssue #190までscreenshot入力のままです。現在のconsole commandではまだ動画入力を実行できません。
+> Effective Configuration、動画探索・identity、Input Lock、Completed Stage cacheの内部基盤は実装済みですが、installed public CLIはIssue #190までscreenshot入力のままです。現在のconsole commandではまだ動画入力を実行できません。
 
 ## 実行単位
 
@@ -38,7 +38,10 @@ game-screen-pick [OPTIONS] <VIDEO_INPUT_FOLDER> <OUTPUT_FOLDER>
 - 既定ではroot直下だけを探索し、recursive時だけ子directoryを探索します。
 - directory symlinkは辿りません。対応拡張子を持つfile symlinkは許可し、link先の内容を処理します。
 - Video Orderは入力rootからの正規化済み相対pathの自然順です。mtimeやfilesystem列挙順は使いません。
+- Video Identityはfile全体のSHA-256で決まります。renameやmtime変更では変わらず、内容変更時だけ変わります。
+- Video Set FingerprintはVideo OrderどおりのVideo Fingerprint列から決まり、input rootや設定値を含みません。
 - 対応動画0本、壊れた動画、同一内容の重複動画は、cacheやoutputを作る前に実行全体を失敗させます。
+- 発見後にpath、内容、size、mtime、inodeが変化した場合はsnapshot不一致としてrunを中止します。
 
 入力と出力は同一pathにも相互の親子にもできません。`OUTPUT_FOLDER`は存在しないか空である必要があり、途中処理や再開には使いません。
 

--- a/src/video_selection/application/video_selection_application.py
+++ b/src/video_selection/application/video_selection_application.py
@@ -6,6 +6,7 @@ from ..models.effective_configuration import EffectiveConfiguration
 from ..models.processing_stage import ProcessingStage
 from ..models.run_outcome import RunOutcome
 from ..models.run_status import RunStatus
+from ..models.video_set import VideoSet
 from ..protocols.media_runtime import MediaRuntime
 from ..protocols.model_runtime import ModelRuntime
 from ..protocols.run_observer import RunObserver
@@ -18,11 +19,14 @@ from ..services.candidate_annotation_artifact import (
     restore_candidate_annotations,
 )
 from ..services.discover_video_set import discover_video_set
+from ..services.input_folder_lock import InputFolderLock
+from ..services.prepare_processing_cache import prepare_processing_cache
 from ..services.processing_stage_runner import ProcessingStageRunner
 from ..services.select_images import select_images
 from ..services.snapshot_frame_candidates import snapshot_frame_candidates
 from ..services.snapshot_video_set import snapshot_video_set
 from ..services.validate_output_folder import validate_output_folder
+from ..services.validate_video_set_snapshot import validate_video_set_snapshot
 
 
 class VideoSelectionApplication:
@@ -49,18 +53,46 @@ class VideoSelectionApplication:
             configuration.output_folder,
         )
 
-        video_set = discover_video_set(configuration.video_input_folder)
+        video_set = discover_video_set(
+            configuration.video_input_folder,
+            recursive=configuration.recursive,
+        )
+        with InputFolderLock(configuration.video_input_folder) as input_lock:
+            validate_video_set_snapshot(video_set)
+            diagnostic = prepare_processing_cache(
+                configuration.processing_cache_folder,
+                input_lock=input_lock,
+                reset_cache=configuration.reset_cache,
+            )
+            self._observer.legacy_cache_cleaned(diagnostic)
+            return self._run_locked(configuration, video_set)
+
+    def _run_locked(
+        self,
+        configuration: EffectiveConfiguration,
+        video_set: VideoSet,
+    ) -> RunOutcome:
+        """Input Lockを保持したまま全Processing Stageを実行する。"""
         video_set_snapshot = snapshot_video_set(video_set)
         with suppress(FileNotFoundError):
             configuration.output_folder.rmdir()
         stage_runner = ProcessingStageRunner(
             configuration.processing_cache_folder,
             self._observer,
+            subject_namespace="video-sets",
+            subject_fingerprint=video_set.fingerprint,
+            before_stage=lambda: validate_video_set_snapshot(video_set),
         )
         stage_runner.complete(
             ProcessingStage.DISCOVER_VIDEO_SET,
-            {"videos": list(video_set_snapshot)},
-            {"videos": list(video_set_snapshot)},
+            {
+                "video_set_fingerprint": video_set.fingerprint,
+                "videos": list(video_set_snapshot),
+            },
+            {
+                "video_set_fingerprint": video_set.fingerprint,
+                "videos": list(video_set_snapshot),
+            },
         )
 
         frame_candidates = self._media_runtime.extract_candidates(video_set)
@@ -138,6 +170,7 @@ class VideoSelectionApplication:
             configuration.image_count,
             run_status,
         )
+        validate_video_set_snapshot(video_set)
         prepared_output.publish()
         return RunOutcome(
             output_folder=configuration.output_folder,

--- a/src/video_selection/application/video_selection_application.py
+++ b/src/video_selection/application/video_selection_application.py
@@ -170,7 +170,11 @@ class VideoSelectionApplication:
             configuration.image_count,
             run_status,
         )
-        validate_video_set_snapshot(video_set)
+        try:
+            validate_video_set_snapshot(video_set)
+        except BaseException:
+            prepared_output.discard()
+            raise
         prepared_output.publish()
         return RunOutcome(
             output_folder=configuration.output_folder,

--- a/src/video_selection/models/legacy_cache_cleanup_diagnostic.py
+++ b/src/video_selection/models/legacy_cache_cleanup_diagnostic.py
@@ -1,0 +1,17 @@
+"""Legacy Cache cleanupのstructured diagnostic。"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LegacyCacheCleanupDiagnostic:
+    """削除された認識済みlegacy entryの件数と内容byte。"""
+
+    removed_entry_count: int
+    removed_bytes: int
+
+    def __post_init__(self) -> None:
+        """diagnosticのcountを非負に保つ。"""
+        if self.removed_entry_count < 0 or self.removed_bytes < 0:
+            msg = "Legacy Cache cleanup diagnosticは非負である必要があります"
+            raise ValueError(msg)

--- a/src/video_selection/models/video_set.py
+++ b/src/video_selection/models/video_set.py
@@ -3,17 +3,35 @@
 from dataclasses import dataclass
 from pathlib import Path
 
+from .video_source import VideoSource
+
 
 @dataclass(frozen=True)
 class VideoSet:
-    """Video Input Folderから発見された順序付きvideo集合。"""
+    """Video Input Folderから発見された順序付き不変snapshot。"""
 
     input_folder: Path
-    videos: tuple[Path, ...]
+    sources: tuple[VideoSource, ...]
+    fingerprint: str
+    recursive: bool
+
+    def __post_init__(self) -> None:
+        """空集合と不正なVideo Set Fingerprintを拒否する。"""
+        if not self.sources:
+            msg = "Video Setには1本以上のVideo Sourceが必要です"
+            raise ValueError(msg)
+        if len(self.fingerprint) != 64 or any(
+            character not in "0123456789abcdef" for character in self.fingerprint
+        ):
+            msg = "Video Set Fingerprintには64桁のSHA-256が必要です"
+            raise ValueError(msg)
+
+    @property
+    def videos(self) -> tuple[Path, ...]:
+        """Video Orderを保った実filesystem pathを返す。"""
+        return tuple(source.path for source in self.sources)
 
     @property
     def relative_paths(self) -> tuple[str, ...]:
         """Video Orderを保った入力rootからの相対pathを返す。"""
-        return tuple(
-            video.relative_to(self.input_folder).as_posix() for video in self.videos
-        )
+        return tuple(source.relative_path for source in self.sources)

--- a/src/video_selection/models/video_source.py
+++ b/src/video_selection/models/video_source.py
@@ -1,0 +1,38 @@
+"""Video Set内の一つのVideo Source。"""
+
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+
+@dataclass(frozen=True)
+class VideoSource:
+    """content identityと発見時filesystem snapshotを持つvideo。"""
+
+    path: Path
+    relative_path: str
+    fingerprint: str
+    size_bytes: int
+    modified_at_ns: int
+    device: int
+    inode: int
+
+    def __post_init__(self) -> None:
+        """安全な相対pathとSHA-256 fingerprintを検証する。"""
+        relative_path = PurePosixPath(self.relative_path)
+        if (
+            relative_path.is_absolute()
+            or ".." in relative_path.parts
+            or self.relative_path != relative_path.as_posix()
+        ):
+            msg = "Video Sourceには正規化済み相対pathが必要です"
+            raise ValueError(msg)
+        if len(self.fingerprint) != 64 or any(
+            character not in "0123456789abcdef" for character in self.fingerprint
+        ):
+            msg = "Video Fingerprintには64桁のSHA-256が必要です"
+            raise ValueError(msg)
+
+    @property
+    def stat_signature(self) -> tuple[int, int, int, int]:
+        """実行中の内容変更検知に使う発見時statを返す。"""
+        return (self.device, self.inode, self.size_bytes, self.modified_at_ns)

--- a/src/video_selection/protocols/run_observer.py
+++ b/src/video_selection/protocols/run_observer.py
@@ -3,6 +3,7 @@
 from typing import Protocol
 
 from ..models.completed_stage import CompletedStage
+from ..models.legacy_cache_cleanup_diagnostic import LegacyCacheCleanupDiagnostic
 
 
 class RunObserver(Protocol):
@@ -10,3 +11,9 @@ class RunObserver(Protocol):
 
     def stage_completed(self, completed_stage: CompletedStage) -> None:
         """atomicに完了したStageを通知する。"""
+
+    def legacy_cache_cleaned(
+        self,
+        diagnostic: LegacyCacheCleanupDiagnostic,
+    ) -> None:
+        """認識済みLegacy Cache cleanupの結果を通知する。"""

--- a/src/video_selection/services/completed_stage_writer.py
+++ b/src/video_selection/services/completed_stage_writer.py
@@ -4,32 +4,60 @@ import fcntl
 import hashlib
 import json
 import shutil
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast
 from uuid import uuid4
 
 from ..models.completed_stage import CompletedStage
 from ..models.processing_stage import ProcessingStage
 from ..models.stage_fingerprint import StageFingerprint
 
+CacheNamespace = Literal["videos", "video-sets"]
+FaultInjector = Callable[[str], None]
+
 
 class CompletedStageWriter:
     """artifactの後にcompletion manifestをatomicに保存する。"""
 
-    def __init__(self, cache_folder: Path) -> None:
-        self._root = cache_folder / "walking-skeleton"
+    def __init__(
+        self,
+        cache_folder: Path,
+        *,
+        subject_namespace: CacheNamespace,
+        subject_fingerprint: str,
+        fault_injector: FaultInjector | None = None,
+    ) -> None:
+        self._cache_folder = cache_folder
+        self._subject_namespace = subject_namespace
+        self._subject_fingerprint = subject_fingerprint
+        self._root = cache_folder / subject_namespace / subject_fingerprint
+        self._fault_injector = fault_injector or _ignore_fault_checkpoint
+        if len(subject_fingerprint) != 64 or any(
+            character not in "0123456789abcdef" for character in subject_fingerprint
+        ):
+            msg = "cache subject fingerprintには64桁のSHA-256が必要です"
+            raise ValueError(msg)
 
     def write(
         self,
         stage: ProcessingStage,
         fingerprint: StageFingerprint,
         upstream_fingerprints: tuple[StageFingerprint, ...],
+        semantic_input: Mapping[str, object],
         artifact: dict[str, object],
     ) -> CompletedStage:
         """Stage artifactと完了manifestを保存する。"""
         stage_root = self._root / stage.value
         stage_root.mkdir(parents=True, exist_ok=True)
-        lock_root = self._root / ".locks" / stage.value
+        lock_root = (
+            self._cache_folder
+            / ".locks"
+            / self._subject_namespace
+            / self._subject_fingerprint
+            / stage.value
+        )
         lock_root.mkdir(parents=True, exist_ok=True)
         lock_path = lock_root / f"{fingerprint.value}.lock"
         with lock_path.open("a+b") as lock_file:
@@ -39,6 +67,7 @@ class CompletedStageWriter:
                     stage,
                     fingerprint,
                     upstream_fingerprints,
+                    semantic_input,
                     artifact,
                     stage_root,
                 )
@@ -50,6 +79,7 @@ class CompletedStageWriter:
         stage: ProcessingStage,
         fingerprint: StageFingerprint,
         upstream_fingerprints: tuple[StageFingerprint, ...],
+        semantic_input: Mapping[str, object],
         artifact: dict[str, object],
         stage_root: Path,
     ) -> CompletedStage:
@@ -60,6 +90,7 @@ class CompletedStageWriter:
                 stage,
                 fingerprint,
                 upstream_fingerprints,
+                semantic_input,
             )
             is not None
         ):
@@ -73,22 +104,40 @@ class CompletedStageWriter:
                 + "\n"
             ).encode()
             (temporary_folder / "artifact.json").write_bytes(artifact_bytes)
+            self._fault_injector("before-manifest")
             manifest = {
-                "schema": "game-screen-pick/completed-stage@0",
+                "schema": "game-screen-pick/completed-stage@1.0.0",
                 "status": "completed",
                 "stage": stage.value,
-                "fingerprint": fingerprint.value,
-                "upstream_fingerprints": [item.value for item in upstream_fingerprints],
-                "artifact": "artifact.json",
-                "artifact_sha256": hashlib.sha256(artifact_bytes).hexdigest(),
+                "stage_version": "walking-skeleton-0",
+                "stage_fingerprint": fingerprint.value,
+                "subject": {
+                    "namespace": self._subject_namespace,
+                    "fingerprint": self._subject_fingerprint,
+                },
+                "upstream_stage_fingerprints": [
+                    item.value for item in upstream_fingerprints
+                ],
+                "semantic_input": _normalize_json_mapping(semantic_input),
+                "artifacts": [
+                    {
+                        "path": "artifact.json",
+                        "size_bytes": len(artifact_bytes),
+                        "sha256": hashlib.sha256(artifact_bytes).hexdigest(),
+                    }
+                ],
+                "completed_at": datetime.now(timezone.utc).isoformat(),
             }
             manifest_bytes = (
                 json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True)
                 + "\n"
             ).encode()
             (temporary_folder / "manifest.json").write_bytes(manifest_bytes)
+            self._fault_injector("after-manifest")
+            self._fault_injector("before-rename")
             self._remove_partial_stage(stage_folder)
             temporary_folder.replace(stage_folder)
+            self._fault_injector("after-rename")
         finally:
             shutil.rmtree(temporary_folder, ignore_errors=True)
         return CompletedStage(stage=stage, fingerprint=fingerprint)
@@ -98,26 +147,58 @@ class CompletedStageWriter:
         stage: ProcessingStage,
         fingerprint: StageFingerprint,
         upstream_fingerprints: tuple[StageFingerprint, ...],
+        semantic_input: Mapping[str, object],
     ) -> dict[str, object] | None:
         """検証済みCompleted Stage artifactを返す。"""
         stage_folder = self._root / stage.value / fingerprint.value
+        artifact_path = stage_folder / "artifact.json"
+        manifest_path = stage_folder / "manifest.json"
+        if (
+            stage_folder.is_symlink()
+            or artifact_path.is_symlink()
+            or manifest_path.is_symlink()
+        ):
+            return None
         try:
-            artifact_bytes = (stage_folder / "artifact.json").read_bytes()
+            artifact_bytes = artifact_path.read_bytes()
             artifact_value: object = json.loads(artifact_bytes)
-            manifest: object = json.loads(
-                (stage_folder / "manifest.json").read_text(encoding="utf-8")
+            manifest_value: object = json.loads(
+                manifest_path.read_text(encoding="utf-8")
             )
         except (OSError, TypeError, ValueError):
             return None
-        if manifest != {
-            "schema": "game-screen-pick/completed-stage@0",
+        if not isinstance(manifest_value, dict) or not all(
+            isinstance(key, str) for key in manifest_value
+        ):
+            return None
+        manifest = cast(dict[str, object], manifest_value)
+        completed_at = manifest.get("completed_at")
+        if not _is_timezone_aware_iso_datetime(completed_at):
+            return None
+        expected_manifest = {
+            "schema": "game-screen-pick/completed-stage@1.0.0",
             "status": "completed",
             "stage": stage.value,
-            "fingerprint": fingerprint.value,
-            "upstream_fingerprints": [item.value for item in upstream_fingerprints],
-            "artifact": "artifact.json",
-            "artifact_sha256": hashlib.sha256(artifact_bytes).hexdigest(),
-        }:
+            "stage_version": "walking-skeleton-0",
+            "stage_fingerprint": fingerprint.value,
+            "subject": {
+                "namespace": self._subject_namespace,
+                "fingerprint": self._subject_fingerprint,
+            },
+            "upstream_stage_fingerprints": [
+                item.value for item in upstream_fingerprints
+            ],
+            "semantic_input": _normalize_json_mapping(semantic_input),
+            "artifacts": [
+                {
+                    "path": "artifact.json",
+                    "size_bytes": len(artifact_bytes),
+                    "sha256": hashlib.sha256(artifact_bytes).hexdigest(),
+                }
+            ],
+            "completed_at": completed_at,
+        }
+        if manifest != expected_manifest:
             return None
         if not isinstance(artifact_value, dict) or not all(
             isinstance(key, str) for key in artifact_value
@@ -132,3 +213,34 @@ class CompletedStageWriter:
             stage_folder.unlink()
         elif stage_folder.exists():
             shutil.rmtree(stage_folder)
+
+
+def _normalize_json_mapping(value: Mapping[str, object]) -> dict[str, object]:
+    normalized: object = json.loads(
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+    if not isinstance(normalized, dict) or not all(
+        isinstance(key, str) for key in normalized
+    ):
+        msg = "semantic inputにはJSON objectが必要です"
+        raise TypeError(msg)
+    return cast(dict[str, object], normalized)
+
+
+def _is_timezone_aware_iso_datetime(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return False
+    return parsed.tzinfo is not None
+
+
+def _ignore_fault_checkpoint(_checkpoint: str) -> None:
+    return

--- a/src/video_selection/services/discover_video_paths.py
+++ b/src/video_selection/services/discover_video_paths.py
@@ -1,0 +1,54 @@
+"""Video Input Folder内の対応video path探索。"""
+
+import re
+from collections.abc import Iterator
+from pathlib import Path
+
+SUPPORTED_VIDEO_SUFFIXES = frozenset({".mp4", ".mov", ".mkv", ".webm"})
+
+
+def discover_video_paths(input_folder: Path, recursive: bool) -> tuple[Path, ...]:
+    """symlink境界を守り対応videoを相対path自然順で返す。"""
+    candidates = tuple(_iter_video_paths(input_folder, recursive))
+    return tuple(
+        sorted(
+            candidates,
+            key=lambda path: _natural_relative_path_key(path, input_folder),
+        )
+    )
+
+
+def _iter_video_paths(input_folder: Path, recursive: bool) -> Iterator[Path]:
+    directories = [input_folder]
+    while directories:
+        directory = directories.pop()
+        for path in directory.iterdir():
+            if directory == input_folder and path.name == ".game-screen-pick":
+                continue
+            if path.is_symlink():
+                if _is_supported_video_file(path):
+                    yield path
+                continue
+            if path.is_dir():
+                if recursive:
+                    directories.append(path)
+                continue
+            if _is_supported_video_file(path):
+                yield path
+
+
+def _is_supported_video_file(path: Path) -> bool:
+    return path.is_file() and path.suffix.casefold() in SUPPORTED_VIDEO_SUFFIXES
+
+
+def _natural_relative_path_key(
+    path: Path,
+    input_folder: Path,
+) -> tuple[tuple[tuple[int, int | str], ...], str]:
+    relative_path = path.relative_to(input_folder).as_posix()
+    natural_parts = tuple(
+        (0, int(part)) if part.isdigit() else (1, part.casefold())
+        for part in re.split(r"(\d+)", relative_path)
+        if part
+    )
+    return natural_parts, relative_path

--- a/src/video_selection/services/discover_video_set.py
+++ b/src/video_selection/services/discover_video_set.py
@@ -1,40 +1,80 @@
-"""Video Input FolderからVideo Setを発見する。"""
+"""Video Input Folderからcontent-addressed Video Setを発見する。"""
 
-import re
+import hashlib
+import os
 from pathlib import Path
 
 from ..models.video_set import VideoSet
+from ..models.video_source import VideoSource
+from .discover_video_paths import discover_video_paths
 
-SUPPORTED_VIDEO_SUFFIXES = frozenset({".mp4", ".mov", ".mkv", ".webm"})
 
-
-def discover_video_set(input_folder: Path) -> VideoSet:
-    """root直下の対応videoを自然順で返す。"""
+def discover_video_set(input_folder: Path, recursive: bool = False) -> VideoSet:
+    """対応videoを自然順で発見し内容identityを確定する。"""
     if not input_folder.is_dir():
-        msg = f"Video Input Folderが存在しません: {input_folder}"
+        msg = "Video Input Folderが存在しません"
         raise ValueError(msg)
-    videos = tuple(
-        sorted(
-            (
-                path
-                for path in input_folder.iterdir()
-                if path.is_file() and path.suffix.casefold() in SUPPORTED_VIDEO_SUFFIXES
-            ),
-            key=_natural_path_key,
-        )
-    )
-    if not videos:
+    video_paths = discover_video_paths(input_folder, recursive)
+    if not video_paths:
         msg = "Video Input Folderに対応videoがありません"
         raise ValueError(msg)
-    return VideoSet(input_folder=input_folder, videos=videos)
+    sources = tuple(_build_video_source(input_folder, path) for path in video_paths)
+    _reject_duplicate_videos(sources)
+    return VideoSet(
+        input_folder=input_folder,
+        sources=sources,
+        fingerprint=_build_video_set_fingerprint(sources),
+        recursive=recursive,
+    )
 
 
-def _natural_path_key(path: Path) -> tuple[tuple[str | int, ...], str]:
-    """path名を数値部分込みの自然順keyへ変換する。"""
+def _build_video_source(input_folder: Path, video_path: Path) -> VideoSource:
+    """whole-file SHA-256と発見時statを一つのVideo Sourceにする。"""
+    before_stat = video_path.stat()
+    with video_path.open("rb") as video_file:
+        fingerprint = hashlib.file_digest(video_file, "sha256").hexdigest()
+    after_stat = video_path.stat()
+    before_signature = _stat_signature(before_stat)
+    after_signature = _stat_signature(after_stat)
+    if before_signature != after_signature:
+        msg = "Video Set snapshotがfingerprint計算中に変更されました"
+        raise ValueError(msg)
+    return VideoSource(
+        path=video_path,
+        relative_path=video_path.relative_to(input_folder).as_posix(),
+        fingerprint=fingerprint,
+        device=after_stat.st_dev,
+        inode=after_stat.st_ino,
+        size_bytes=after_stat.st_size,
+        modified_at_ns=after_stat.st_mtime_ns,
+    )
+
+
+def _reject_duplicate_videos(sources: tuple[VideoSource, ...]) -> None:
+    paths_by_fingerprint: dict[str, list[str]] = {}
+    for source in sources:
+        paths_by_fingerprint.setdefault(source.fingerprint, []).append(
+            source.relative_path
+        )
+    for relative_paths in paths_by_fingerprint.values():
+        if len(relative_paths) > 1:
+            displayed_paths = ", ".join(relative_paths)
+            msg = f"Duplicate Videoが見つかりました: {displayed_paths}"
+            raise ValueError(msg)
+
+
+def _build_video_set_fingerprint(sources: tuple[VideoSource, ...]) -> str:
+    fingerprint = hashlib.sha256()
+    fingerprint.update(b"game-screen-pick/video-set-fingerprint@1\0")
+    for source in sources:
+        fingerprint.update(bytes.fromhex(source.fingerprint))
+    return fingerprint.hexdigest()
+
+
+def _stat_signature(stat: os.stat_result) -> tuple[int, int, int, int]:
     return (
-        tuple(
-            int(part) if part.isdigit() else part.casefold()
-            for part in re.split(r"(\d+)", path.name)
-        ),
-        path.name,
+        stat.st_dev,
+        stat.st_ino,
+        stat.st_size,
+        stat.st_mtime_ns,
     )

--- a/src/video_selection/services/input_folder_lock.py
+++ b/src/video_selection/services/input_folder_lock.py
@@ -1,0 +1,66 @@
+"""Video Input Folder単位の非待機排他lock。"""
+
+import fcntl
+from pathlib import Path
+from types import TracebackType
+from typing import IO
+
+
+class InputFolderLock:
+    """同じVideo Input Folderの同時runを拒否するOS lock。"""
+
+    def __init__(self, input_folder: Path) -> None:
+        self._input_folder = input_folder
+        self._lock_file: IO[bytes] | None = None
+
+    @property
+    def is_held(self) -> bool:
+        """このinstanceがlockを保持しているか返す。"""
+        return self._lock_file is not None
+
+    @property
+    def processing_cache_folder(self) -> Path:
+        """このInput Lockが保護するprocessing cache rootを返す。"""
+        return self._input_folder / ".game-screen-pick" / "cache"
+
+    def __enter__(self) -> "InputFolderLock":
+        """lock fileを開き非待機exclusive lockを取得する。"""
+        metadata_folder = self._input_folder / ".game-screen-pick"
+        if metadata_folder.is_symlink() or (
+            metadata_folder.exists() and not metadata_folder.is_dir()
+        ):
+            msg = ".game-screen-pickには通常directoryが必要です"
+            raise RuntimeError(msg)
+        metadata_folder.mkdir(exist_ok=True)
+        lock_file = (metadata_folder / "input.lock").open("a+b")
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            lock_file.close()
+            msg = "このVideo Input Folderは既に実行中です"
+            raise RuntimeError(msg) from None
+        self._lock_file = lock_file
+        return self
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """保持中lockを必ず解放する。"""
+        del exception_type, exception, traceback
+        lock_file = self._lock_file
+        if lock_file is None:
+            return
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        finally:
+            lock_file.close()
+            self._lock_file = None
+
+    def assert_held_for(self, cache_folder: Path) -> None:
+        """指定cache rootに対応するlock保持を検証する。"""
+        if not self.is_held or cache_folder != self.processing_cache_folder:
+            msg = "processing cacheの変更には対応するInput Lockが必要です"
+            raise RuntimeError(msg)

--- a/src/video_selection/services/prepare_processing_cache.py
+++ b/src/video_selection/services/prepare_processing_cache.py
@@ -1,0 +1,72 @@
+"""Input Lock内で行うprocessing cache準備。"""
+
+import shutil
+from pathlib import Path
+from uuid import uuid4
+
+from ..models.legacy_cache_cleanup_diagnostic import LegacyCacheCleanupDiagnostic
+from .input_folder_lock import InputFolderLock
+
+
+def prepare_processing_cache(
+    cache_folder: Path,
+    *,
+    input_lock: InputFolderLock,
+    reset_cache: bool,
+) -> LegacyCacheCleanupDiagnostic:
+    """書込検査後にresetまたは認識済みlegacy削除を実行する。"""
+    input_lock.assert_held_for(cache_folder)
+    _require_safe_cache_folder(cache_folder)
+    cache_folder.mkdir(parents=True, exist_ok=True)
+    _verify_cache_writable(cache_folder)
+    if reset_cache:
+        shutil.rmtree(cache_folder)
+        cache_folder.mkdir()
+        return LegacyCacheCleanupDiagnostic(removed_entry_count=0, removed_bytes=0)
+    return _remove_recognized_legacy_cache(cache_folder)
+
+
+def _require_safe_cache_folder(cache_folder: Path) -> None:
+    if cache_folder.is_symlink() or (
+        cache_folder.exists() and not cache_folder.is_dir()
+    ):
+        msg = "processing cache rootには通常directoryが必要です"
+        raise RuntimeError(msg)
+
+
+def _verify_cache_writable(cache_folder: Path) -> None:
+    probe_path = cache_folder / f".write-probe-{uuid4().hex}"
+    try:
+        probe_path.write_bytes(b"")
+    finally:
+        probe_path.unlink(missing_ok=True)
+
+
+def _remove_recognized_legacy_cache(
+    cache_folder: Path,
+) -> LegacyCacheCleanupDiagnostic:
+    removed_entry_count = 0
+    removed_bytes = 0
+    neutral_analysis = cache_folder / "neutral-analysis"
+    if neutral_analysis.is_dir() and not neutral_analysis.is_symlink():
+        removed_bytes += _directory_content_bytes(neutral_analysis)
+        shutil.rmtree(neutral_analysis)
+        removed_entry_count += 1
+
+    ollama_scenes = cache_folder / "ollama-scenes.json"
+    if ollama_scenes.is_file() and not ollama_scenes.is_symlink():
+        removed_bytes += ollama_scenes.stat().st_size
+        ollama_scenes.unlink()
+        removed_entry_count += 1
+    return LegacyCacheCleanupDiagnostic(
+        removed_entry_count=removed_entry_count,
+        removed_bytes=removed_bytes,
+    )
+
+
+def _directory_content_bytes(directory: Path) -> int:
+    return sum(
+        path.stat().st_size
+        for path in directory.rglob("*")
+        if path.is_file() and not path.is_symlink()
+    )

--- a/src/video_selection/services/processing_stage_runner.py
+++ b/src/video_selection/services/processing_stage_runner.py
@@ -9,7 +9,11 @@ from ..models.processing_stage import ProcessingStage
 from ..models.stage_fingerprint import StageFingerprint
 from ..protocols.run_observer import RunObserver
 from .build_stage_fingerprint import build_stage_fingerprint
-from .completed_stage_writer import CompletedStageWriter
+from .completed_stage_writer import (
+    CacheNamespace,
+    CompletedStageWriter,
+    FaultInjector,
+)
 
 StageResult = TypeVar("StageResult")
 
@@ -17,9 +21,24 @@ StageResult = TypeVar("StageResult")
 class ProcessingStageRunner:
     """Stage順序、fingerprint、manifest確定、通知を一つに保つ。"""
 
-    def __init__(self, cache_folder: Path, observer: RunObserver) -> None:
-        self._writer = CompletedStageWriter(cache_folder)
+    def __init__(
+        self,
+        cache_folder: Path,
+        observer: RunObserver,
+        *,
+        subject_namespace: CacheNamespace,
+        subject_fingerprint: str,
+        before_stage: Callable[[], None] | None = None,
+        fault_injector: FaultInjector | None = None,
+    ) -> None:
+        self._writer = CompletedStageWriter(
+            cache_folder,
+            subject_namespace=subject_namespace,
+            subject_fingerprint=subject_fingerprint,
+            fault_injector=fault_injector,
+        )
         self._observer = observer
+        self._before_stage = before_stage or _skip_before_stage
         self._completed_stages: list[CompletedStage] = []
 
     @property
@@ -39,6 +58,7 @@ class ProcessingStageRunner:
             stage,
             fingerprint,
             upstream_fingerprints,
+            semantic_input,
             artifact,
         )
         self._record_completion(completed_stage)
@@ -52,7 +72,12 @@ class ProcessingStageRunner:
     ) -> StageResult | None:
         """検証済みCompleted Stageがあれば復元して完了扱いにする。"""
         upstream_fingerprints, fingerprint = self._prepare_stage(stage, semantic_input)
-        artifact = self._writer.read(stage, fingerprint, upstream_fingerprints)
+        artifact = self._writer.read(
+            stage,
+            fingerprint,
+            upstream_fingerprints,
+            semantic_input,
+        )
         if artifact is None:
             return None
         restored = restore(artifact)
@@ -74,6 +99,7 @@ class ProcessingStageRunner:
         if stage is not expected_stage:
             msg = f"expected={expected_stage.value}, actual={stage.value}"
             raise ValueError(msg)
+        self._before_stage()
         upstream_fingerprints = tuple(
             item.fingerprint for item in self._completed_stages
         )
@@ -87,3 +113,7 @@ class ProcessingStageRunner:
         """Stage完了をrun stateへ追加して通知する。"""
         self._completed_stages.append(completed_stage)
         self._observer.stage_completed(completed_stage)
+
+
+def _skip_before_stage() -> None:
+    return

--- a/src/video_selection/services/snapshot_video_set.py
+++ b/src/video_selection/services/snapshot_video_set.py
@@ -1,32 +1,14 @@
 """Video Setのcontent snapshotを構築する。"""
 
-import hashlib
-from pathlib import Path
-
 from ..models.video_set import VideoSet
 
 
 def snapshot_video_set(video_set: VideoSet) -> tuple[dict[str, str], ...]:
     """Video Orderを保ったrelative pathとcontent digestを返す。"""
-    snapshot = tuple(
+    return tuple(
         {
-            "path": relative_path,
-            "sha256": _file_sha256(video_path),
+            "path": source.relative_path,
+            "sha256": source.fingerprint,
         }
-        for video_path, relative_path in zip(
-            video_set.videos,
-            video_set.relative_paths,
-            strict=True,
-        )
+        for source in video_set.sources
     )
-    digests = tuple(item["sha256"] for item in snapshot)
-    if len(set(digests)) != len(digests):
-        msg = "Video Input Folderに同一内容の重複videoがあります"
-        raise ValueError(msg)
-    return snapshot
-
-
-def _file_sha256(video_path: Path) -> str:
-    """一つのvideo fileのSHA-256を返す。"""
-    with open(video_path, "rb") as video_file:
-        return hashlib.file_digest(video_file, "sha256").hexdigest()

--- a/src/video_selection/services/validate_video_set_snapshot.py
+++ b/src/video_selection/services/validate_video_set_snapshot.py
@@ -1,0 +1,29 @@
+"""実行中Video Set snapshotの不変性検証。"""
+
+from ..models.video_set import VideoSet
+from .discover_video_paths import discover_video_paths
+
+
+def validate_video_set_snapshot(video_set: VideoSet) -> None:
+    """相対path列と各videoのstatが発見時から不変か検証する。"""
+    current_paths = discover_video_paths(video_set.input_folder, video_set.recursive)
+    current_relative_paths = tuple(
+        path.relative_to(video_set.input_folder).as_posix() for path in current_paths
+    )
+    if current_relative_paths != video_set.relative_paths:
+        _raise_snapshot_changed()
+    for source, current_path in zip(video_set.sources, current_paths, strict=True):
+        stat = current_path.stat()
+        current_signature = (
+            stat.st_dev,
+            stat.st_ino,
+            stat.st_size,
+            stat.st_mtime_ns,
+        )
+        if current_signature != source.stat_signature:
+            _raise_snapshot_changed()
+
+
+def _raise_snapshot_changed() -> None:
+    msg = "Video Set snapshotが変更されました"
+    raise ValueError(msg)

--- a/src/video_selection/services/validate_video_set_snapshot.py
+++ b/src/video_selection/services/validate_video_set_snapshot.py
@@ -1,11 +1,14 @@
 """実行中Video Set snapshotの不変性検証。"""
 
+import hashlib
+import os
+
 from ..models.video_set import VideoSet
 from .discover_video_paths import discover_video_paths
 
 
 def validate_video_set_snapshot(video_set: VideoSet) -> None:
-    """相対path列と各videoのstatが発見時から不変か検証する。"""
+    """相対path列、stat、contentが発見時から不変か検証する。"""
     current_paths = discover_video_paths(video_set.input_folder, video_set.recursive)
     current_relative_paths = tuple(
         path.relative_to(video_set.input_folder).as_posix() for path in current_paths
@@ -13,15 +16,26 @@ def validate_video_set_snapshot(video_set: VideoSet) -> None:
     if current_relative_paths != video_set.relative_paths:
         _raise_snapshot_changed()
     for source, current_path in zip(video_set.sources, current_paths, strict=True):
-        stat = current_path.stat()
-        current_signature = (
-            stat.st_dev,
-            stat.st_ino,
-            stat.st_size,
-            stat.st_mtime_ns,
-        )
-        if current_signature != source.stat_signature:
+        before_stat = current_path.stat()
+        if _stat_signature(before_stat) != source.stat_signature:
             _raise_snapshot_changed()
+        with current_path.open("rb") as video_file:
+            current_fingerprint = hashlib.file_digest(video_file, "sha256").hexdigest()
+        after_stat = current_path.stat()
+        if (
+            _stat_signature(after_stat) != source.stat_signature
+            or current_fingerprint != source.fingerprint
+        ):
+            _raise_snapshot_changed()
+
+
+def _stat_signature(stat: os.stat_result) -> tuple[int, int, int, int]:
+    return (
+        stat.st_dev,
+        stat.st_ino,
+        stat.st_size,
+        stat.st_mtime_ns,
+    )
 
 
 def _raise_snapshot_changed() -> None:

--- a/tests/video_selection/application/test_video_selection_application.py
+++ b/tests/video_selection/application/test_video_selection_application.py
@@ -12,14 +12,46 @@ from src.video_selection.models.candidate_annotation import CandidateAnnotation
 from src.video_selection.models.context_cue import ContextCue
 from src.video_selection.models.effective_configuration import EffectiveConfiguration
 from src.video_selection.models.frame_candidate import FrameCandidate
+from src.video_selection.models.legacy_cache_cleanup_diagnostic import (
+    LegacyCacheCleanupDiagnostic,
+)
 from src.video_selection.models.processing_stage import ProcessingStage
 from src.video_selection.models.resolved_model_identity import ResolvedModelIdentity
+from src.video_selection.services.input_folder_lock import InputFolderLock
 from tests.video_selection.fakes.failing_vision_runtime import FailingVisionRuntime
 from tests.video_selection.fakes.fake_media_runtime import FakeMediaRuntime
 from tests.video_selection.fakes.fake_model_runtime import FakeModelRuntime
 from tests.video_selection.fakes.fake_speech_runtime import FakeSpeechRuntime
 from tests.video_selection.fakes.fake_vision_runtime import FakeVisionRuntime
 from tests.video_selection.fakes.recording_run_observer import RecordingRunObserver
+
+
+def _video_set_stage_manifests(
+    input_folder: Path,
+    stage: ProcessingStage,
+) -> tuple[Path, ...]:
+    return tuple(
+        (input_folder / ".game-screen-pick" / "cache" / "video-sets").glob(
+            f"*/{stage.value}/*/manifest.json"
+        )
+    )
+
+
+def _successful_application(
+    observer: RecordingRunObserver,
+) -> VideoSelectionApplication:
+    candidate = FrameCandidate(identifier="frame-001", image_bytes=b"image")
+    return VideoSelectionApplication(
+        media_runtime=FakeMediaRuntime((candidate,)),
+        speech_runtime=FakeSpeechRuntime(()),
+        model_runtime=FakeModelRuntime(
+            ResolvedModelIdentity(identifier="model-sha-001")
+        ),
+        vision_runtime=FakeVisionRuntime(
+            (CandidateAnnotation(candidate=candidate, summary="summary"),)
+        ),
+        observer=observer,
+    )
 
 
 def test_run_publishes_normalized_fake_result_atomically(tmp_path: Path) -> None:
@@ -107,11 +139,161 @@ def test_run_publishes_normalized_fake_result_atomically(tmp_path: Path) -> None
         ProcessingStage
     )
     manifests = tuple(
-        (input_folder / ".game-screen-pick" / "cache" / "walking-skeleton").glob(
-            "*/*/manifest.json"
+        (input_folder / ".game-screen-pick" / "cache" / "video-sets").glob(
+            "*/*/*/manifest.json"
         )
     )
     assert len(manifests) == len(ProcessingStage)
+
+
+def test_run_removes_recognized_legacy_cache_and_reports_diagnostic(
+    tmp_path: Path,
+) -> None:
+    """認識済みLegacy Cacheだけが削除され診断が通知されること。
+
+    Arrange:
+        - valid Video Setと二種類の認識済みLegacy Cacheが用意される
+        - 新cache namespaceに保護対象のmarkerが用意される
+    Act:
+        - Video Set選定applicationが実行される
+    Assert:
+        - Legacy Cacheだけが削除されること
+        - 削除entry数とbyte数がobserverへ通知されること
+        - 新cache namespaceが保持されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    output_folder = tmp_path / "output"
+    cache_folder = input_folder / ".game-screen-pick" / "cache"
+    neutral_analysis = cache_folder / "neutral-analysis"
+    protected_marker = cache_folder / "videos" / "keep.txt"
+    input_folder.mkdir()
+    (input_folder / "chapter-01.mp4").write_bytes(b"video-01")
+    neutral_analysis.mkdir(parents=True)
+    legacy_analysis_bytes = b"legacy-analysis"
+    legacy_scene_bytes = b'{"legacy": true}'
+    (neutral_analysis / "result.json").write_bytes(legacy_analysis_bytes)
+    (cache_folder / "ollama-scenes.json").write_bytes(legacy_scene_bytes)
+    protected_marker.parent.mkdir()
+    protected_marker.write_text("keep", encoding="utf-8")
+    observer = RecordingRunObserver()
+
+    # Act
+    _successful_application(observer).run(
+        EffectiveConfiguration(
+            video_input_folder=input_folder,
+            output_folder=output_folder,
+            image_count=1,
+        )
+    )
+
+    # Assert
+    assert not neutral_analysis.exists()
+    assert not (cache_folder / "ollama-scenes.json").exists()
+    assert protected_marker.read_text(encoding="utf-8") == "keep"
+    assert observer.legacy_cache_diagnostics == [
+        LegacyCacheCleanupDiagnostic(
+            removed_entry_count=2,
+            removed_bytes=len(legacy_analysis_bytes) + len(legacy_scene_bytes),
+        )
+    ]
+
+
+def test_input_lock_failure_preserves_cache_and_output(
+    tmp_path: Path,
+) -> None:
+    """Input Lock取得失敗時にcacheとOutput Folderが変更されないこと。
+
+    Arrange:
+        - valid Video Setと認識済みLegacy Cacheが用意される
+        - 同じVideo Input FolderのInput Lockが既に保持される
+    Act:
+        - Video Set選定applicationが実行される
+    Assert:
+        - 非待機の実行中errorが返されること
+        - Legacy CacheとOutput Folderが変更されないこと
+        - cleanup diagnosticが通知されないこと
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    output_folder = tmp_path / "output"
+    legacy_folder = input_folder / ".game-screen-pick" / "cache" / "neutral-analysis"
+    input_folder.mkdir()
+    (input_folder / "chapter-01.mp4").write_bytes(b"video-01")
+    legacy_folder.mkdir(parents=True)
+    legacy_marker = legacy_folder / "result.json"
+    legacy_marker.write_text("legacy", encoding="utf-8")
+    observer = RecordingRunObserver()
+
+    # Act
+    with (
+        InputFolderLock(input_folder),
+        pytest.raises(RuntimeError, match="既に実行中"),
+    ):
+        _successful_application(observer).run(
+            EffectiveConfiguration(
+                video_input_folder=input_folder,
+                output_folder=output_folder,
+                image_count=1,
+            )
+        )
+
+    # Assert
+    assert legacy_marker.read_text(encoding="utf-8") == "legacy"
+    assert not output_folder.exists()
+    assert observer.legacy_cache_diagnostics == []
+
+
+def test_reset_cache_removes_entire_processing_cache_before_run(
+    tmp_path: Path,
+) -> None:
+    """reset_cacheでprocessing cache全体が削除後に再構築されること。
+
+    Arrange:
+        - valid Video Setと未知のprocessing cache entryが用意される
+    Act:
+        - reset_cacheを有効にしてapplicationが実行される
+    Assert:
+        - 既存entryが削除されること
+        - 新しいVideo Set Stage cacheとOutput Folderが作成されること
+        - Legacy Cache削除件数はゼロとして通知されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    output_folder = tmp_path / "output"
+    cache_folder = input_folder / ".game-screen-pick" / "cache"
+    stale_marker = cache_folder / "unknown" / "keep-unless-reset.txt"
+    input_folder.mkdir()
+    (input_folder / "chapter-01.mp4").write_bytes(b"video-01")
+    stale_marker.parent.mkdir(parents=True)
+    stale_marker.write_text("stale", encoding="utf-8")
+    observer = RecordingRunObserver()
+
+    # Act
+    _successful_application(observer).run(
+        EffectiveConfiguration(
+            video_input_folder=input_folder,
+            output_folder=output_folder,
+            image_count=1,
+            reset_cache=True,
+        )
+    )
+
+    # Assert
+    assert not stale_marker.exists()
+    assert (
+        len(
+            _video_set_stage_manifests(
+                input_folder,
+                ProcessingStage.DISCOVER_VIDEO_SET,
+            )
+        )
+        == 1
+    )
+    assert (output_folder / "report.json").is_file()
+    assert observer.legacy_cache_diagnostics == [
+        LegacyCacheCleanupDiagnostic(removed_entry_count=0, removed_bytes=0)
+    ]
 
 
 def test_stage_failure_leaves_output_unpublished(tmp_path: Path) -> None:
@@ -304,14 +486,10 @@ def test_resolved_model_identity_changes_model_stage_fingerprint(
         )
 
     # Assert
-    model_stage_folder = (
-        input_folder
-        / ".game-screen-pick"
-        / "cache"
-        / "walking-skeleton"
-        / ProcessingStage.RESOLVE_MODELS.value
+    assert (
+        len(_video_set_stage_manifests(input_folder, ProcessingStage.RESOLVE_MODELS))
+        == 2
     )
-    assert len(tuple(model_stage_folder.iterdir())) == 2
 
 
 def test_video_content_change_changes_discovery_stage_fingerprint(
@@ -356,14 +534,15 @@ def test_video_content_change_changes_discovery_stage_fingerprint(
         )
 
     # Assert
-    discovery_stage_folder = (
-        input_folder
-        / ".game-screen-pick"
-        / "cache"
-        / "walking-skeleton"
-        / ProcessingStage.DISCOVER_VIDEO_SET.value
+    assert (
+        len(
+            _video_set_stage_manifests(
+                input_folder,
+                ProcessingStage.DISCOVER_VIDEO_SET,
+            )
+        )
+        == 2
     )
-    assert len(tuple(discovery_stage_folder.iterdir())) == 2
 
 
 def test_warm_run_reuses_cached_candidate_annotations(tmp_path: Path) -> None:
@@ -537,14 +716,15 @@ def test_candidate_identity_changes_extraction_stage_fingerprint(
         )
 
     # Assert
-    extraction_stage_folder = (
-        input_folder
-        / ".game-screen-pick"
-        / "cache"
-        / "walking-skeleton"
-        / ProcessingStage.EXTRACT_FRAME_CANDIDATES.value
+    assert (
+        len(
+            _video_set_stage_manifests(
+                input_folder,
+                ProcessingStage.EXTRACT_FRAME_CANDIDATES,
+            )
+        )
+        == 2
     )
-    assert len(tuple(extraction_stage_folder.iterdir())) == 2
 
 
 def test_context_identity_changes_context_stage_fingerprint(tmp_path: Path) -> None:
@@ -587,14 +767,10 @@ def test_context_identity_changes_context_stage_fingerprint(tmp_path: Path) -> N
         )
 
     # Assert
-    context_stage_folder = (
-        input_folder
-        / ".game-screen-pick"
-        / "cache"
-        / "walking-skeleton"
-        / ProcessingStage.COLLECT_CONTEXT.value
+    assert (
+        len(_video_set_stage_manifests(input_folder, ProcessingStage.COLLECT_CONTEXT))
+        == 2
     )
-    assert len(tuple(context_stage_folder.iterdir())) == 2
 
 
 def test_duplicate_video_content_is_rejected_before_cache_side_effects(
@@ -630,7 +806,7 @@ def test_duplicate_video_content_is_rejected_before_cache_side_effects(
     )
 
     # Act
-    with pytest.raises(ValueError, match="同一内容の重複video"):
+    with pytest.raises(ValueError, match="Duplicate Video"):
         application.run(
             EffectiveConfiguration(
                 video_input_folder=input_folder,
@@ -679,7 +855,7 @@ def test_existing_empty_output_folder_is_preserved_when_input_preflight_fails(
     )
 
     # Act
-    with pytest.raises(ValueError, match="同一内容の重複video"):
+    with pytest.raises(ValueError, match="Duplicate Video"):
         application.run(
             EffectiveConfiguration(
                 video_input_folder=input_folder,
@@ -829,14 +1005,15 @@ def test_changed_candidate_content_changes_extraction_stage_fingerprint(
         )
 
     # Assert
-    extraction_stage_folder = (
-        input_folder
-        / ".game-screen-pick"
-        / "cache"
-        / "walking-skeleton"
-        / ProcessingStage.EXTRACT_FRAME_CANDIDATES.value
+    assert (
+        len(
+            _video_set_stage_manifests(
+                input_folder,
+                ProcessingStage.EXTRACT_FRAME_CANDIDATES,
+            )
+        )
+        == 2
     )
-    assert len(tuple(extraction_stage_folder.iterdir())) == 2
 
 
 def test_duplicate_candidate_ids_are_rejected_before_candidate_cache(
@@ -885,14 +1062,10 @@ def test_duplicate_candidate_ids_are_rejected_before_candidate_cache(
         )
 
     # Assert
-    extraction_stage_folder = (
-        input_folder
-        / ".game-screen-pick"
-        / "cache"
-        / "walking-skeleton"
-        / ProcessingStage.EXTRACT_FRAME_CANDIDATES.value
+    assert not _video_set_stage_manifests(
+        input_folder,
+        ProcessingStage.EXTRACT_FRAME_CANDIDATES,
     )
-    assert not extraction_stage_folder.exists()
     assert not output_folder.exists()
 
 
@@ -938,14 +1111,10 @@ def test_unsafe_candidate_id_is_rejected_before_candidate_cache(
         )
 
     # Assert
-    extraction_stage_folder = (
-        input_folder
-        / ".game-screen-pick"
-        / "cache"
-        / "walking-skeleton"
-        / ProcessingStage.EXTRACT_FRAME_CANDIDATES.value
+    assert not _video_set_stage_manifests(
+        input_folder,
+        ProcessingStage.EXTRACT_FRAME_CANDIDATES,
     )
-    assert not extraction_stage_folder.exists()
     assert not output_folder.exists()
 
 
@@ -998,14 +1167,10 @@ def test_foreign_candidate_annotation_is_rejected_before_caching(
         )
 
     # Assert
-    annotation_stage_folder = (
-        input_folder
-        / ".game-screen-pick"
-        / "cache"
-        / "walking-skeleton"
-        / ProcessingStage.ANNOTATE_CANDIDATES.value
+    assert not _video_set_stage_manifests(
+        input_folder,
+        ProcessingStage.ANNOTATE_CANDIDATES,
     )
-    assert not annotation_stage_folder.exists()
     assert not output_folder.exists()
 
 
@@ -1159,12 +1324,8 @@ def test_incomplete_candidate_annotations_are_rejected_before_caching(
         )
 
     # Assert
-    annotation_stage_folder = (
-        input_folder
-        / ".game-screen-pick"
-        / "cache"
-        / "walking-skeleton"
-        / ProcessingStage.ANNOTATE_CANDIDATES.value
+    assert not _video_set_stage_manifests(
+        input_folder,
+        ProcessingStage.ANNOTATE_CANDIDATES,
     )
-    assert not annotation_stage_folder.exists()
     assert not output_folder.exists()

--- a/tests/video_selection/application/test_video_selection_application.py
+++ b/tests/video_selection/application/test_video_selection_application.py
@@ -17,7 +17,12 @@ from src.video_selection.models.legacy_cache_cleanup_diagnostic import (
 )
 from src.video_selection.models.processing_stage import ProcessingStage
 from src.video_selection.models.resolved_model_identity import ResolvedModelIdentity
+from src.video_selection.models.run_status import RunStatus
+from src.video_selection.models.selected_image import SelectedImage
+from src.video_selection.models.video_set import VideoSet
+from src.video_selection.services.atomic_output_publisher import AtomicOutputPublisher
 from src.video_selection.services.input_folder_lock import InputFolderLock
+from src.video_selection.services.prepared_output import PreparedOutput
 from tests.video_selection.fakes.failing_vision_runtime import FailingVisionRuntime
 from tests.video_selection.fakes.fake_media_runtime import FakeMediaRuntime
 from tests.video_selection.fakes.fake_model_runtime import FakeModelRuntime
@@ -144,6 +149,62 @@ def test_run_publishes_normalized_fake_result_atomically(tmp_path: Path) -> None
         )
     )
     assert len(manifests) == len(ProcessingStage)
+
+
+def test_final_snapshot_failure_discards_staged_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """最終snapshot検査失敗時にstaging outputが破棄されること。
+
+    Arrange:
+        - Output artifact準備直後に入力videoが変更される境界が用意される
+    Act:
+        - Video Set選定applicationが実行される
+    Assert:
+        - snapshot変更errorが返されること
+        - Output Folderとhidden staging directoryが残らないこと
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    output_folder = tmp_path / "output"
+    input_folder.mkdir()
+    video_path = input_folder / "chapter-01.mp4"
+    video_path.write_bytes(b"video-01")
+    original_prepare = AtomicOutputPublisher.prepare
+
+    def prepare_then_change_input(
+        publisher: AtomicOutputPublisher,
+        prepared_output_folder: Path,
+        video_set: VideoSet,
+        selected_images: tuple[SelectedImage, ...],
+        requested_count: int,
+        run_status: RunStatus,
+    ) -> PreparedOutput:
+        prepared_output = original_prepare(
+            publisher,
+            prepared_output_folder,
+            video_set,
+            selected_images,
+            requested_count,
+            run_status,
+        )
+        video_path.write_bytes(b"changed-video")
+        return prepared_output
+
+    monkeypatch.setattr(AtomicOutputPublisher, "prepare", prepare_then_change_input)
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="Video Set snapshotが変更されました"):
+        _successful_application(RecordingRunObserver()).run(
+            EffectiveConfiguration(
+                video_input_folder=input_folder,
+                output_folder=output_folder,
+                image_count=1,
+            )
+        )
+    assert not output_folder.exists()
+    assert tuple(tmp_path.glob(".output.*.staging")) == ()
 
 
 def test_run_removes_recognized_legacy_cache_and_reports_diagnostic(

--- a/tests/video_selection/fakes/recording_run_observer.py
+++ b/tests/video_selection/fakes/recording_run_observer.py
@@ -1,4 +1,7 @@
 from src.video_selection.models.completed_stage import CompletedStage
+from src.video_selection.models.legacy_cache_cleanup_diagnostic import (
+    LegacyCacheCleanupDiagnostic,
+)
 
 
 class RecordingRunObserver:
@@ -6,7 +9,15 @@ class RecordingRunObserver:
 
     def __init__(self) -> None:
         self.completed_stages: list[CompletedStage] = []
+        self.legacy_cache_diagnostics: list[LegacyCacheCleanupDiagnostic] = []
 
     def stage_completed(self, completed_stage: CompletedStage) -> None:
         """完了したStageを順番に記録する。"""
         self.completed_stages.append(completed_stage)
+
+    def legacy_cache_cleaned(
+        self,
+        diagnostic: LegacyCacheCleanupDiagnostic,
+    ) -> None:
+        """Legacy Cache cleanup diagnosticを記録する。"""
+        self.legacy_cache_diagnostics.append(diagnostic)

--- a/tests/video_selection/services/test_completed_stage_writer.py
+++ b/tests/video_selection/services/test_completed_stage_writer.py
@@ -1,7 +1,9 @@
 """Completed Stage writerのconcurrency test。"""
 
+import hashlib
 import json
 import threading
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -30,6 +32,7 @@ def test_same_fingerprint_writes_are_serialized(
     """
     # Arrange
     cache_folder = tmp_path / "cache"
+    subject_fingerprint = "a" * 64
     stage = ProcessingStage.DISCOVER_VIDEO_SET
     semantic_input = {"videos": ["video.mp4"]}
     fingerprint = build_stage_fingerprint(stage, (), semantic_input)
@@ -54,10 +57,15 @@ def test_same_fingerprint_writes_are_serialized(
 
     def write_artifact(value: str, finished: threading.Event | None = None) -> None:
         try:
-            CompletedStageWriter(cache_folder).write(
+            CompletedStageWriter(
+                cache_folder,
+                subject_namespace="video-sets",
+                subject_fingerprint=subject_fingerprint,
+            ).write(
                 stage,
                 fingerprint,
                 (),
+                semantic_input,
                 {"value": value},
             )
         except BaseException as error:
@@ -95,9 +103,265 @@ def test_same_fingerprint_writes_are_serialized(
     assert errors == []
     artifact_path = (
         cache_folder
-        / "walking-skeleton"
+        / "video-sets"
+        / subject_fingerprint
         / stage.value
         / fingerprint.value
         / "artifact.json"
     )
     assert json.loads(artifact_path.read_text(encoding="utf-8")) == {"value": "first"}
+
+
+def test_completed_manifest_describes_content_addressed_artifact(
+    tmp_path: Path,
+) -> None:
+    """Completed Stage manifestに再利用検証情報だけが記録されること。
+
+    Arrange:
+        - Video fingerprint、Stage fingerprint、semantic inputが用意される
+    Act:
+        - videos namespaceへStage artifactが確定される
+    Assert:
+        - subject、上流、version、相対path、size、hash、完了日時が記録されること
+        - absolute cache pathがmanifestへ含まれないこと
+    """
+    # Arrange
+    cache_folder = tmp_path / "private-cache"
+    subject_fingerprint = "b" * 64
+    stage = ProcessingStage.DISCOVER_VIDEO_SET
+    semantic_input = {"decode_backend": "cpu"}
+    fingerprint = build_stage_fingerprint(stage, (), semantic_input)
+    artifact: dict[str, object] = {"value": "artifact"}
+    writer = CompletedStageWriter(
+        cache_folder,
+        subject_namespace="videos",
+        subject_fingerprint=subject_fingerprint,
+    )
+
+    # Act
+    writer.write(stage, fingerprint, (), semantic_input, artifact)
+
+    # Assert
+    stage_folder = (
+        cache_folder / "videos" / subject_fingerprint / stage.value / fingerprint.value
+    )
+    artifact_bytes = (stage_folder / "artifact.json").read_bytes()
+    manifest_text = (stage_folder / "manifest.json").read_text(encoding="utf-8")
+    manifest = json.loads(manifest_text)
+    assert set(manifest) == {
+        "schema",
+        "status",
+        "stage",
+        "stage_version",
+        "stage_fingerprint",
+        "subject",
+        "upstream_stage_fingerprints",
+        "semantic_input",
+        "artifacts",
+        "completed_at",
+    }
+    assert manifest["schema"] == "game-screen-pick/completed-stage@1.0.0"
+    assert manifest["status"] == "completed"
+    assert manifest["stage"] == stage.value
+    assert manifest["stage_version"] == "walking-skeleton-0"
+    assert manifest["stage_fingerprint"] == fingerprint.value
+    assert manifest["subject"] == {
+        "namespace": "videos",
+        "fingerprint": subject_fingerprint,
+    }
+    assert manifest["upstream_stage_fingerprints"] == []
+    assert manifest["semantic_input"] == semantic_input
+    assert manifest["artifacts"] == [
+        {
+            "path": "artifact.json",
+            "size_bytes": len(artifact_bytes),
+            "sha256": hashlib.sha256(artifact_bytes).hexdigest(),
+        }
+    ]
+    assert datetime.fromisoformat(manifest["completed_at"]).tzinfo is not None
+    assert str(cache_folder) not in manifest_text
+
+
+@pytest.mark.parametrize(
+    "checkpoint",
+    ["before-manifest", "after-manifest", "before-rename"],
+)
+def test_fault_before_atomic_commit_leaves_no_completed_stage(
+    tmp_path: Path,
+    checkpoint: str,
+) -> None:
+    """atomic commit前のfaultでCompleted Stageが観測されないこと。
+
+    Arrange:
+        - manifestとrenameのcommit pointへfault injectorが設定される
+    Act:
+        - Stage artifactの確定が試行される
+    Assert:
+        - faultが返されfinal entryとtemporary entryが残らないこと
+    """
+    # Arrange
+    cache_folder = tmp_path / "cache"
+    subject_fingerprint = "c" * 64
+    stage = ProcessingStage.DISCOVER_VIDEO_SET
+    semantic_input = {"value": checkpoint}
+    fingerprint = build_stage_fingerprint(stage, (), semantic_input)
+
+    def inject_fault(actual_checkpoint: str) -> None:
+        if actual_checkpoint == checkpoint:
+            raise OSError(f"injected {checkpoint}")
+
+    writer = CompletedStageWriter(
+        cache_folder,
+        subject_namespace="video-sets",
+        subject_fingerprint=subject_fingerprint,
+        fault_injector=inject_fault,
+    )
+
+    # Act / Assert
+    with pytest.raises(OSError, match=f"injected {checkpoint}"):
+        writer.write(stage, fingerprint, (), semantic_input, {"value": "fresh"})
+    stage_root = cache_folder / "video-sets" / subject_fingerprint / stage.value
+    assert not (stage_root / fingerprint.value).exists()
+    assert tuple(stage_root.glob("*.tmp")) == ()
+
+
+def test_fault_after_rename_keeps_reusable_completed_stage(tmp_path: Path) -> None:
+    """rename後のfaultでもatomicに確定済みのStageが再利用されること。
+
+    Arrange:
+        - after-rename checkpointだけで失敗するwriterが用意される
+    Act:
+        - Stage writeがrename後に失敗し通常writerからreadされる
+    Assert:
+        - 完全なartifactがCompleted Stageとして再利用されること
+    """
+    # Arrange
+    cache_folder = tmp_path / "cache"
+    subject_fingerprint = "d" * 64
+    stage = ProcessingStage.DISCOVER_VIDEO_SET
+    semantic_input = {"value": "after-rename"}
+    fingerprint = build_stage_fingerprint(stage, (), semantic_input)
+
+    def inject_fault(checkpoint: str) -> None:
+        if checkpoint == "after-rename":
+            raise OSError("injected after-rename")
+
+    failing_writer = CompletedStageWriter(
+        cache_folder,
+        subject_namespace="video-sets",
+        subject_fingerprint=subject_fingerprint,
+        fault_injector=inject_fault,
+    )
+
+    # Act
+    with pytest.raises(OSError, match="injected after-rename"):
+        failing_writer.write(
+            stage,
+            fingerprint,
+            (),
+            semantic_input,
+            {"value": "committed"},
+        )
+    restored = CompletedStageWriter(
+        cache_folder,
+        subject_namespace="video-sets",
+        subject_fingerprint=subject_fingerprint,
+    ).read(stage, fingerprint, (), semantic_input)
+
+    # Assert
+    assert restored == {"value": "committed"}
+
+
+def test_rename_failure_leaves_no_partial_completed_stage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """filesystem rename失敗時にpartial Completed Stageが残らないこと。
+
+    Arrange:
+        - temporary Stage directoryのrenameがdisk errorになる
+    Act:
+        - Stage writeが実行される
+    Assert:
+        - errorが返されfinal entryとtemporary entryが残らないこと
+    """
+    # Arrange
+    cache_folder = tmp_path / "cache"
+    subject_fingerprint = "e" * 64
+    stage = ProcessingStage.DISCOVER_VIDEO_SET
+    semantic_input = {"value": "rename"}
+    fingerprint = build_stage_fingerprint(stage, (), semantic_input)
+    original_replace = Path.replace
+
+    def fail_temporary_replace(path: Path, target: Path) -> Path:
+        if path.name.endswith(".tmp"):
+            raise OSError("injected rename failure")
+        return original_replace(path, target)
+
+    monkeypatch.setattr(Path, "replace", fail_temporary_replace)
+    writer = CompletedStageWriter(
+        cache_folder,
+        subject_namespace="video-sets",
+        subject_fingerprint=subject_fingerprint,
+    )
+
+    # Act / Assert
+    with pytest.raises(OSError, match="injected rename failure"):
+        writer.write(stage, fingerprint, (), semantic_input, {"value": "fresh"})
+    stage_root = cache_folder / "video-sets" / subject_fingerprint / stage.value
+    assert not (stage_root / fingerprint.value).exists()
+    assert tuple(stage_root.glob("*.tmp")) == ()
+
+
+@pytest.mark.parametrize(
+    ("target_name", "failure"),
+    [
+        pytest.param("artifact.json", OSError("disk full"), id="disk-full"),
+        pytest.param(
+            "manifest.json",
+            PermissionError("permission denied"),
+            id="permission-denied",
+        ),
+    ],
+)
+def test_artifact_or_manifest_write_failure_is_not_reusable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    target_name: str,
+    failure: OSError,
+) -> None:
+    """artifactまたはmanifest書込失敗が再利用可能entryを残さないこと。
+
+    Arrange:
+        - artifactにdisk failureまたはmanifestにpermission failureが注入される
+    Act:
+        - Stage writeが実行される
+    Assert:
+        - filesystem errorが返されCompleted Stageが存在しないこと
+    """
+    # Arrange
+    cache_folder = tmp_path / "cache"
+    subject_fingerprint = "f" * 64
+    stage = ProcessingStage.DISCOVER_VIDEO_SET
+    semantic_input = {"target": target_name}
+    fingerprint = build_stage_fingerprint(stage, (), semantic_input)
+    original_write_bytes = Path.write_bytes
+
+    def fail_target_write(path: Path, data: bytes) -> int:
+        if path.name == target_name:
+            raise failure
+        return original_write_bytes(path, data)
+
+    monkeypatch.setattr(Path, "write_bytes", fail_target_write)
+    writer = CompletedStageWriter(
+        cache_folder,
+        subject_namespace="videos",
+        subject_fingerprint=subject_fingerprint,
+    )
+
+    # Act / Assert
+    with pytest.raises(type(failure), match=str(failure)):
+        writer.write(stage, fingerprint, (), semantic_input, {"value": "fresh"})
+    stage_root = cache_folder / "videos" / subject_fingerprint / stage.value
+    assert not (stage_root / fingerprint.value).exists()
+    assert tuple(stage_root.glob("*.tmp")) == ()

--- a/tests/video_selection/services/test_discover_video_set.py
+++ b/tests/video_selection/services/test_discover_video_set.py
@@ -242,3 +242,40 @@ def test_snapshot_validation_rejects_video_changes_before_cache_commit(
     # Act / Assert
     with pytest.raises(ValueError, match="Video Set snapshotが変更されました"):
         validate_video_set_snapshot(video_set)
+
+
+def test_snapshot_validation_rejects_same_stat_content_rewrite(
+    tmp_path: Path,
+) -> None:
+    """stat signatureが維持された内容変更もsnapshot不一致になること。
+
+    Arrange:
+        - 発見済みvideoと同じsize・inode・mtimeを保つ別内容が用意される
+    Act:
+        - Video Set snapshot validationが実行される
+    Assert:
+        - content fingerprint不一致として変更errorが返されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    video_path = input_folder / "chapter.mp4"
+    video_path.write_bytes(b"before")
+    video_set = discover_video_set(input_folder)
+    original_stat = video_path.stat()
+    video_path.write_bytes(b"after!")
+    os.utime(
+        video_path,
+        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+    )
+    rewritten_stat = video_path.stat()
+    assert (
+        rewritten_stat.st_dev,
+        rewritten_stat.st_ino,
+        rewritten_stat.st_size,
+        rewritten_stat.st_mtime_ns,
+    ) == video_set.sources[0].stat_signature
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="Video Set snapshotが変更されました"):
+        validate_video_set_snapshot(video_set)

--- a/tests/video_selection/services/test_discover_video_set.py
+++ b/tests/video_selection/services/test_discover_video_set.py
@@ -1,11 +1,15 @@
 """Video Set discoveryのtest。"""
 
+import os
 from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
 from src.video_selection.services.discover_video_set import discover_video_set
+from src.video_selection.services.validate_video_set_snapshot import (
+    validate_video_set_snapshot,
+)
 
 
 def test_natural_order_uses_normalized_path_as_tie_breaker(
@@ -40,3 +44,201 @@ def test_natural_order_uses_normalized_path_as_tie_breaker(
 
     # Assert
     assert video_set.relative_paths == ("clip01.mp4", "clip1.mp4")
+
+
+def test_recursive_discovery_uses_natural_relative_path_order(tmp_path: Path) -> None:
+    """recursive discoveryで相対path全体の自然順が使用されること。
+
+    Arrange:
+        - 数字を含む子directoryとvideoがfilesystem順と異なる順で作成される
+    Act:
+        - recursiveなVideo Set discoveryが実行される
+    Assert:
+        - root基準の相対path自然順でVideo Orderが確定されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    (input_folder / "chapter10").mkdir(parents=True)
+    (input_folder / "chapter2").mkdir()
+    (input_folder / "chapter10" / "clip1.mp4").write_bytes(b"chapter-10")
+    (input_folder / "chapter2" / "clip10.mp4").write_bytes(b"chapter-2-10")
+    (input_folder / "chapter2" / "clip2.mp4").write_bytes(b"chapter-2-2")
+
+    # Act
+    video_set = discover_video_set(input_folder, recursive=True)
+
+    # Assert
+    assert video_set.relative_paths == (
+        "chapter2/clip2.mp4",
+        "chapter2/clip10.mp4",
+        "chapter10/clip1.mp4",
+    )
+
+
+def test_non_recursive_discovery_ignores_child_videos(tmp_path: Path) -> None:
+    """recursive未指定時に子directoryのvideoが探索されないこと。
+
+    Arrange:
+        - root videoと子directory videoが用意される
+    Act:
+        - 既定のVideo Set discoveryが実行される
+    Assert:
+        - root videoだけがVideo Setへ含まれること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    child_folder = input_folder / "child"
+    child_folder.mkdir(parents=True)
+    (input_folder / "root.mp4").write_bytes(b"root")
+    (child_folder / "child.mp4").write_bytes(b"child")
+
+    # Act
+    video_set = discover_video_set(input_folder)
+
+    # Assert
+    assert video_set.relative_paths == ("root.mp4",)
+
+
+def test_directory_symlink_is_not_followed_but_file_symlink_is_accepted(
+    tmp_path: Path,
+) -> None:
+    """directory symlinkが無視されfile symlinkの内容が採用されること。
+
+    Arrange:
+        - input外のvideo fileとvideo directoryへのsymlinkが用意される
+    Act:
+        - recursiveなVideo Set discoveryが実行される
+    Assert:
+        - file symlinkだけがVideo Sourceとして含まれること
+    """
+    # Arrange
+    external_folder = tmp_path / "external"
+    external_folder.mkdir()
+    external_video = external_folder / "outside.mp4"
+    external_video.write_bytes(b"outside-video")
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    (input_folder / "linked-file.mp4").symlink_to(external_video)
+    (input_folder / "linked-directory").symlink_to(
+        external_folder,
+        target_is_directory=True,
+    )
+
+    # Act
+    video_set = discover_video_set(input_folder, recursive=True)
+
+    # Assert
+    assert video_set.relative_paths == ("linked-file.mp4",)
+    assert video_set.sources[0].fingerprint == (
+        discover_video_set(external_folder).sources[0].fingerprint
+    )
+
+
+def test_rename_and_mtime_change_preserve_content_identity(tmp_path: Path) -> None:
+    """renameとmtime変更後も同じVideo Fingerprintが維持されること。
+
+    Arrange:
+        - 内容が変わらない一つのvideoが用意される
+    Act:
+        - mtime変更とrenameの後にそれぞれdiscoveryが実行される
+    Assert:
+        - Video FingerprintとVideo Set Fingerprintが維持されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    video_path = input_folder / "chapter-01.mp4"
+    video_path.write_bytes(b"stable-video-content")
+    initial = discover_video_set(input_folder)
+
+    # Act
+    stat = video_path.stat()
+    os.utime(video_path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+    after_mtime = discover_video_set(input_folder)
+    renamed_path = input_folder / "renamed.mp4"
+    video_path.rename(renamed_path)
+    after_rename = discover_video_set(input_folder)
+
+    # Assert
+    assert after_mtime.sources[0].fingerprint == initial.sources[0].fingerprint
+    assert after_rename.sources[0].fingerprint == initial.sources[0].fingerprint
+    assert after_mtime.fingerprint == initial.fingerprint
+    assert after_rename.fingerprint == initial.fingerprint
+
+
+def test_content_change_changes_video_and_video_set_identity(tmp_path: Path) -> None:
+    """video内容変更時にVideoとVideo SetのFingerprintが変更されること。
+
+    Arrange:
+        - 一つのvideoから初期Video Setが発見される
+    Act:
+        - 同じpathの内容変更後に再度discoveryが実行される
+    Assert:
+        - Video FingerprintとVideo Set Fingerprintが変更されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    video_path = input_folder / "chapter.mp4"
+    video_path.write_bytes(b"before")
+    before = discover_video_set(input_folder)
+
+    # Act
+    video_path.write_bytes(b"after-content")
+    after = discover_video_set(input_folder)
+
+    # Assert
+    assert after.sources[0].fingerprint != before.sources[0].fingerprint
+    assert after.fingerprint != before.fingerprint
+
+
+def test_duplicate_video_content_is_rejected_with_relative_paths(
+    tmp_path: Path,
+) -> None:
+    """同じ内容の複数videoが相対path付きでfail-fastされること。
+
+    Arrange:
+        - 異なる相対pathに同一内容のvideoが用意される
+    Act:
+        - Video Set discoveryが実行される
+    Assert:
+        - 両方の安全な相対pathを示すDuplicate Video errorになること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    (input_folder / "chapter-01.mp4").write_bytes(b"duplicate")
+    (input_folder / "chapter-02.mp4").write_bytes(b"duplicate")
+
+    # Act / Assert
+    with pytest.raises(ValueError) as error:
+        discover_video_set(input_folder)
+    assert "Duplicate Video" in str(error.value)
+    assert "chapter-01.mp4" in str(error.value)
+    assert "chapter-02.mp4" in str(error.value)
+    assert str(input_folder) not in str(error.value)
+
+
+def test_snapshot_validation_rejects_video_changes_before_cache_commit(
+    tmp_path: Path,
+) -> None:
+    """発見後のVideo Set変更がsnapshot validationで拒否されること。
+
+    Arrange:
+        - 発見済みVideo Setの一つのvideoが変更される
+    Act:
+        - cache commit前のsnapshot validationが実行される
+    Assert:
+        - Video Set snapshot変更errorが返されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    video_path = input_folder / "chapter.mp4"
+    video_path.write_bytes(b"before")
+    video_set = discover_video_set(input_folder)
+    video_path.write_bytes(b"after-content")
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="Video Set snapshotが変更されました"):
+        validate_video_set_snapshot(video_set)

--- a/tests/video_selection/services/test_input_folder_lock.py
+++ b/tests/video_selection/services/test_input_folder_lock.py
@@ -1,0 +1,58 @@
+"""Input Lockのreal filesystem test。"""
+
+from pathlib import Path
+
+import pytest
+
+from src.video_selection.services.input_folder_lock import InputFolderLock
+
+
+def test_same_input_folder_lock_is_rejected_without_waiting(tmp_path: Path) -> None:
+    """同じVideo Input Folderの二つ目のlockが即時拒否されること。
+
+    Arrange:
+        - 一つ目のInput Lockが保持される
+    Act:
+        - 同じinput folderの二つ目のInput Lock取得が試行される
+    Assert:
+        - 待機せず同時実行errorが返されcache rootは作成されないこと
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+
+    # Act / Assert
+    with (
+        InputFolderLock(input_folder),
+        pytest.raises(RuntimeError, match="既に実行中"),
+        InputFolderLock(input_folder),
+    ):
+        pytest.fail("二つ目のInput Lockは取得されないこと")
+    assert not (input_folder / ".game-screen-pick" / "cache").exists()
+
+
+def test_different_input_folders_can_be_locked_concurrently(tmp_path: Path) -> None:
+    """異なるVideo Input FolderのInput Lockが同時に取得されること。
+
+    Arrange:
+        - 二つの異なるinput folderが用意される
+    Act:
+        - 両方のInput Lockが同時に取得される
+    Assert:
+        - 互いに妨げず保持状態になること
+    """
+    # Arrange
+    first_input = tmp_path / "first"
+    second_input = tmp_path / "second"
+    first_input.mkdir()
+    second_input.mkdir()
+
+    # Act
+    with (
+        InputFolderLock(first_input) as first_lock,
+        InputFolderLock(second_input) as second_lock,
+    ):
+        both_held = first_lock.is_held and second_lock.is_held
+
+    # Assert
+    assert both_held

--- a/tests/video_selection/services/test_prepare_processing_cache.py
+++ b/tests/video_selection/services/test_prepare_processing_cache.py
@@ -1,0 +1,207 @@
+"""Processing cache preparationのreal filesystem test。"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from src.video_selection.services.input_folder_lock import InputFolderLock
+from src.video_selection.services.prepare_processing_cache import (
+    prepare_processing_cache,
+)
+
+
+def test_recognized_legacy_cache_is_deleted_and_new_cache_is_preserved(
+    tmp_path: Path,
+) -> None:
+    """認識済みlegacyだけが削除され新cacheとunknown entryが保持されること。
+
+    Arrange:
+        - legacy二種、新cache二種、unknown entryがcache rootに用意される
+    Act:
+        - Input Lock内でprocessing cacheが準備される
+    Assert:
+        - legacyだけが削除され件数とbyteがstructuredに返されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    cache_folder = input_folder / ".game-screen-pick" / "cache"
+    neutral_cache = cache_folder / "neutral-analysis"
+    neutral_cache.mkdir(parents=True)
+    (neutral_cache / "one.json").write_bytes(b"1234")
+    legacy_scene = cache_folder / "ollama-scenes.json"
+    legacy_scene.write_bytes(b"123456")
+    (cache_folder / "videos" / "fingerprint").mkdir(parents=True)
+    (cache_folder / "video-sets" / "fingerprint").mkdir(parents=True)
+    (cache_folder / "unknown" / "keep").mkdir(parents=True)
+
+    # Act
+    with InputFolderLock(input_folder) as input_lock:
+        diagnostic = prepare_processing_cache(
+            cache_folder,
+            input_lock=input_lock,
+            reset_cache=False,
+        )
+
+    # Assert
+    assert diagnostic.removed_entry_count == 2
+    assert diagnostic.removed_bytes == 10
+    assert not neutral_cache.exists()
+    assert not legacy_scene.exists()
+    assert (cache_folder / "videos" / "fingerprint").is_dir()
+    assert (cache_folder / "video-sets" / "fingerprint").is_dir()
+    assert (cache_folder / "unknown" / "keep").is_dir()
+
+
+def test_legacy_cleanup_failure_is_fatal_and_new_cache_is_untouched(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """legacy削除失敗がfatalとなり新cacheへ変更が加えられないこと。
+
+    Arrange:
+        - legacy directoryと新しいvideos cacheが用意される
+        - legacy directory削除だけがpermission errorになる
+    Act:
+        - processing cache preparationが実行される
+    Assert:
+        - errorが返され新cache artifactが保持されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    cache_folder = input_folder / ".game-screen-pick" / "cache"
+    legacy_cache = cache_folder / "neutral-analysis"
+    legacy_cache.mkdir(parents=True)
+    new_artifact = cache_folder / "videos" / "fingerprint" / "artifact.json"
+    new_artifact.parent.mkdir(parents=True)
+    new_artifact.write_text("keep", encoding="utf-8")
+    original_rmtree = shutil.rmtree
+
+    def fail_legacy_delete(path: Path) -> None:
+        if Path(path) == legacy_cache:
+            raise PermissionError("injected legacy permission failure")
+        original_rmtree(path)
+
+    monkeypatch.setattr(shutil, "rmtree", fail_legacy_delete)
+
+    # Act / Assert
+    with (
+        InputFolderLock(input_folder) as input_lock,
+        pytest.raises(PermissionError, match="injected legacy"),
+    ):
+        prepare_processing_cache(
+            cache_folder,
+            input_lock=input_lock,
+            reset_cache=False,
+        )
+    assert new_artifact.read_text(encoding="utf-8") == "keep"
+
+
+def test_write_preflight_failure_does_not_delete_legacy_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cache書込preflight失敗時にlegacy削除が開始されないこと。
+
+    Arrange:
+        - legacy cacheとwrite probeのpermission failureが用意される
+    Act:
+        - Input Lock内でprocessing cache preparationが実行される
+    Assert:
+        - legacy cacheが削除されずfatal errorになること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    cache_folder = input_folder / ".game-screen-pick" / "cache"
+    legacy_cache = cache_folder / "neutral-analysis"
+    legacy_cache.mkdir(parents=True)
+    legacy_artifact = legacy_cache / "keep.json"
+    legacy_artifact.write_text("keep", encoding="utf-8")
+    original_write_bytes = Path.write_bytes
+
+    def fail_write_probe(path: Path, data: bytes) -> int:
+        if path.name.startswith(".write-probe-"):
+            raise PermissionError("injected cache write failure")
+        return original_write_bytes(path, data)
+
+    monkeypatch.setattr(Path, "write_bytes", fail_write_probe)
+
+    # Act / Assert
+    with (
+        InputFolderLock(input_folder) as input_lock,
+        pytest.raises(PermissionError, match="injected cache write"),
+    ):
+        prepare_processing_cache(
+            cache_folder,
+            input_lock=input_lock,
+            reset_cache=False,
+        )
+    assert legacy_artifact.read_text(encoding="utf-8") == "keep"
+
+
+def test_reset_cache_removes_only_processing_cache_root(tmp_path: Path) -> None:
+    """reset actionでprocessing cache rootだけが再作成されること。
+
+    Arrange:
+        - processing cache、model store、Output Folderが用意される
+    Act:
+        - reset指定でprocessing cacheが準備される
+    Assert:
+        - cache内容だけが消えmodel storeとoutputが保持されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    cache_folder = input_folder / ".game-screen-pick" / "cache"
+    cached_artifact = cache_folder / "videos" / "fingerprint" / "artifact.json"
+    cached_artifact.parent.mkdir(parents=True)
+    cached_artifact.write_text("cached", encoding="utf-8")
+    model_store = tmp_path / "model-store"
+    model_store.mkdir()
+    (model_store / "model.bin").write_text("model", encoding="utf-8")
+    output_folder = tmp_path / "output"
+    output_folder.mkdir()
+    (output_folder / "keep.webp").write_text("output", encoding="utf-8")
+
+    # Act
+    with InputFolderLock(input_folder) as input_lock:
+        diagnostic = prepare_processing_cache(
+            cache_folder,
+            input_lock=input_lock,
+            reset_cache=True,
+        )
+
+    # Assert
+    assert diagnostic.removed_entry_count == 0
+    assert diagnostic.removed_bytes == 0
+    assert cache_folder.is_dir()
+    assert tuple(cache_folder.iterdir()) == ()
+    assert (model_store / "model.bin").read_text(encoding="utf-8") == "model"
+    assert (output_folder / "keep.webp").read_text(encoding="utf-8") == "output"
+
+
+def test_cache_preparation_requires_the_matching_active_input_lock(
+    tmp_path: Path,
+) -> None:
+    """processing cache mutationに対応する保持中Input Lockが要求されること。
+
+    Arrange:
+        - lock未取得のVideo Input Folderが用意される
+    Act:
+        - processing cache preparationが直接実行される
+    Assert:
+        - mutation前にInput Lock errorとなること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    input_lock = InputFolderLock(input_folder)
+    cache_folder = input_folder / ".game-screen-pick" / "cache"
+
+    # Act / Assert
+    with pytest.raises(RuntimeError, match="Input Lock"):
+        prepare_processing_cache(
+            cache_folder,
+            input_lock=input_lock,
+            reset_cache=False,
+        )
+    assert not cache_folder.exists()

--- a/tests/video_selection/services/test_processing_stage_runner.py
+++ b/tests/video_selection/services/test_processing_stage_runner.py
@@ -28,7 +28,12 @@ def test_processing_stage_cannot_complete_out_of_order(tmp_path: Path) -> None:
     # Arrange
     cache_folder = tmp_path / "cache"
     observer = RecordingRunObserver()
-    runner = ProcessingStageRunner(cache_folder, observer)
+    runner = ProcessingStageRunner(
+        cache_folder,
+        observer,
+        subject_namespace="video-sets",
+        subject_fingerprint="a" * 64,
+    )
 
     # Act / Assert
     with pytest.raises(
@@ -57,6 +62,7 @@ def test_partial_stage_artifact_is_replaced_before_completion(tmp_path: Path) ->
     """
     # Arrange
     cache_folder = tmp_path / "cache"
+    subject_fingerprint = "b" * 64
     observer = RecordingRunObserver()
     semantic_input = {"videos": ["fresh.mp4"]}
     fingerprint = build_stage_fingerprint(
@@ -66,14 +72,20 @@ def test_partial_stage_artifact_is_replaced_before_completion(tmp_path: Path) ->
     )
     stage_folder = (
         cache_folder
-        / "walking-skeleton"
+        / "video-sets"
+        / subject_fingerprint
         / ProcessingStage.DISCOVER_VIDEO_SET.value
         / fingerprint.value
     )
     stage_folder.mkdir(parents=True)
     artifact_path = stage_folder / "artifact.json"
     artifact_path.write_text('{"videos": ["poison.mp4"]}\n', encoding="utf-8")
-    runner = ProcessingStageRunner(cache_folder, observer)
+    runner = ProcessingStageRunner(
+        cache_folder,
+        observer,
+        subject_namespace="video-sets",
+        subject_fingerprint=subject_fingerprint,
+    )
 
     # Act
     runner.complete(
@@ -88,7 +100,7 @@ def test_partial_stage_artifact_is_replaced_before_completion(tmp_path: Path) ->
     }
     manifest = json.loads((stage_folder / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["status"] == "completed"
-    assert manifest["fingerprint"] == fingerprint.value
+    assert manifest["stage_fingerprint"] == fingerprint.value
 
 
 def test_completed_stage_artifact_is_immutable_for_same_fingerprint(
@@ -105,8 +117,14 @@ def test_completed_stage_artifact_is_immutable_for_same_fingerprint(
     """
     # Arrange
     cache_folder = tmp_path / "cache"
+    subject_fingerprint = "c" * 64
     semantic_input = {"videos": [{"path": "video.mp4", "sha256": "digest"}]}
-    first_runner = ProcessingStageRunner(cache_folder, RecordingRunObserver())
+    first_runner = ProcessingStageRunner(
+        cache_folder,
+        RecordingRunObserver(),
+        subject_namespace="video-sets",
+        subject_fingerprint=subject_fingerprint,
+    )
     completed_stage = first_runner.complete(
         ProcessingStage.DISCOVER_VIDEO_SET,
         semantic_input=semantic_input,
@@ -114,7 +132,12 @@ def test_completed_stage_artifact_is_immutable_for_same_fingerprint(
     )
 
     # Act
-    ProcessingStageRunner(cache_folder, RecordingRunObserver()).complete(
+    ProcessingStageRunner(
+        cache_folder,
+        RecordingRunObserver(),
+        subject_namespace="video-sets",
+        subject_fingerprint=subject_fingerprint,
+    ).complete(
         ProcessingStage.DISCOVER_VIDEO_SET,
         semantic_input=semantic_input,
         artifact={"value": "second"},
@@ -123,9 +146,49 @@ def test_completed_stage_artifact_is_immutable_for_same_fingerprint(
     # Assert
     artifact_path = (
         cache_folder
-        / "walking-skeleton"
+        / "video-sets"
+        / subject_fingerprint
         / ProcessingStage.DISCOVER_VIDEO_SET.value
         / completed_stage.fingerprint.value
         / "artifact.json"
     )
     assert json.loads(artifact_path.read_text(encoding="utf-8")) == {"value": "first"}
+
+
+def test_snapshot_validation_failure_prevents_stage_cache_mutation(
+    tmp_path: Path,
+) -> None:
+    """Stage直前のsnapshot validation失敗でcacheが変更されないこと。
+
+    Arrange:
+        - snapshot変更errorを返すbefore-stage callbackが用意される
+    Act:
+        - 最初のProcessing Stage completionが試行される
+    Assert:
+        - errorが返されsubject cacheとobserverが未変更であること
+    """
+    # Arrange
+    cache_folder = tmp_path / "cache"
+    observer = RecordingRunObserver()
+
+    def reject_changed_snapshot() -> None:
+        msg = "Video Set snapshotが変更されました"
+        raise ValueError(msg)
+
+    runner = ProcessingStageRunner(
+        cache_folder,
+        observer,
+        subject_namespace="video-sets",
+        subject_fingerprint="d" * 64,
+        before_stage=reject_changed_snapshot,
+    )
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="Video Set snapshotが変更されました"):
+        runner.complete(
+            ProcessingStage.DISCOVER_VIDEO_SET,
+            semantic_input={"videos": []},
+            artifact={"videos": []},
+        )
+    assert observer.completed_stages == []
+    assert not (cache_folder / "video-sets").exists()


### PR DESCRIPTION
## 概要

- 対応動画を相対pathの自然順で探索し、whole-file SHA-256によるVideo Identityとordered Video Set Fingerprintを確定
- Video Input Folderのpath・stat・content snapshot検証と非待機Input Lockを追加
- `videos/` / `video-sets/` namespaceのcontent-addressed Completed Stage cache、atomic commit、partial・破損cache無視を実装
- lock取得後に認識済みLegacy Cacheだけを削除し、件数・byte数をstructured diagnosticへ通知
- `reset_cache`でprocessing cache rootだけを再作成し、model store・Output Folderを保護
- public CLIを切り替えず、内部実装状況とcache運用をREADME・docsへ反映

## Codex review対応

- device・inode・size・mtimeが同一でもcontent digestが変わった入力を拒否
- final snapshot validation失敗時に未公開のhidden staging outputを破棄

## 検証

- `uv run task test`
  - ruff: passed
  - format: passed
  - mypy: passed（181 source files）
  - pytest: 284 passed

## 移行上の注意

- public CLIとpackage versionは変更していません
- Video Set selectorのpublic cutoverはIssue #190で行います
- integration branchへのmerge後、Issue #180は手動でcloseします

Refs #180