### PR TITLE
feat: 動画単位のフレーム抽出Stageを実装

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,10 @@ _Avoid_: Video Set, Output Folder, cache key
 一つのVideo Input Folderに対する同時実行を即時拒否し、非破壊validation完了後からprocessing cacheの変更とrun終了までを保護する非待機排他境界。異なるVideo Input Folderの実行は互いに妨げない。
 _Avoid_: Stage lock, waiting queue, global lock, cache artifact
 
+**Video Set Snapshot Validation**:
+Input Lock取得直後とOutput Folder公開直前にはVideo Set全体のpath、stat、内容を、各Video Stage直前にはVideo Set全体のpath、statと対象Video Sourceの内容を発見時snapshotへ照合する不変性検査。Stageごとに全動画を再hashする検査とは区別する。
+_Avoid_: cache artifact validation, full-set hash per Video Stage, Input Lock
+
 **Video Set Fingerprint**:
 Video Setの構成とVideo Orderをcacheやreportで参照するための、順序付きVideo Fingerprint列から導出される安定した識別子。
 _Avoid_: input path hash, unordered file set, global setting hash
@@ -43,6 +47,10 @@ _Avoid_: path hash, file stat, stage setting hash
 **Processing Stage**:
 再開可能な画像選定を構成する、入力と再利用可能な成果物の境界が明示された処理単位。
 _Avoid_: arbitrary function, progress message, whole run
+
+**Stage Resource Metric**:
+Completed Stageを初回計算するときの処理開始からartifact構築までを対象にしたwall時間とCPU時間。CPU時間はcurrent processとchild processの合計で、cache再利用時は初回に保存された値を復元する。
+_Avoid_: FFmpeg-only metric, cache lookup duration, current-run reuse overhead
 
 **Migration Gate**:
 Video Set selectorのpublic cutoverに必要な実装PR、test、target性能、human quality、traceabilityの全証拠を一つの判定として扱う境界。不足時はscreenshot CLI、package version、legacy codeの公開状態を一切変えない。
@@ -75,6 +83,10 @@ _Avoid_: raw TOML, environment dump, global config hash, CLI defaults applied be
 **Resolved Model Identity**:
 configured model名から実行時に解決し、完全性とload能力を検証して1 run内でfreezeする、Ollamaの完全manifest digestまたはHugging Faceの完全commit SHA。model依存Stageのfingerprintとprovenanceへ保持し、TOMLへ手入力するhashとはしない。
 _Avoid_: model tag, configured model name, truncated report value, expected digest
+
+**Media Runtime Identity**:
+system FFmpegとffprobeのversion、および正規化したbuild情報と検証済みcapability一覧から実行時に導出する完全SHA-256の組。raw build文字列やTOMLへ手入力するhashではなく、同じversionでもbuildまたはcapabilityが変われば別identityになる。
+_Avoid_: version-only identity, raw version output, configured runtime hash
 
 **Model Upgrade Policy**:
 全model roleへ適用する`auto_upgrade`設定とbootstrap規則。既定では処理前に更新を試み、更新不能でも完全でload可能なlocal modelがあればwarning付きで使い、別modelへのfallbackやpartial downloadの利用は行わない。実際のcache互換性は設定値でなくResolved Model Identityが決める。
@@ -157,8 +169,12 @@ Candidate Annotationとcache再利用のためにFrame Candidateごとに永続�
 _Avoid_: Heartbeat Proxy, original-resolution frame, selected output
 
 **Frame Refinement**:
-Candidate Momentのanchor前後にあるnative frameを対象に、Content Reject Reason判定、Source-Local Frame Deduplication、最大Frame Candidate数への選抜を行うVideo Stage処理。最初に最もQuality Scoreが高いframeを選び、残りは選択済みframeとの最小視覚距離、Quality Score、anchorへの近さ、早いVideo Timeの順で最大件数まで選ぶ。Candidate Momentから参照する最終順序はVideo Time順とする。
+Candidate Momentのanchor前後にあるnative frameを対象に、Content Reject Reason判定、Source-Local Frame Deduplication、最大Frame Candidate数への選抜を行うVideo Stage処理。重なるrefinement windowは一つのRefinement Window Groupとして扱い、最初に最もQuality Scoreが高いframeを選び、残りは選択済みframeとの最小視覚距離、Quality Score、anchorへの近さ、早いVideo Timeの順で最大件数まで選ぶ。Candidate Momentから参照する最終順序はVideo Time順とする。
 _Avoid_: fixed-fps conversion, Candidate Annotation, Representative Frame selection
+
+**Refinement Window Group**:
+一つのVideo Source内で互いに重なるCandidate Momentのrefinement windowから作る最大の連続時間範囲。Neutral Image Analysisの相対分布と前後関係はこの範囲内だけで共有し、離れた範囲のsampleを隣接frameとして扱わない。
+_Avoid_: whole-video refinement, Timeline Segment, density window, arbitrary frame batch
 
 **Source-Local Frame Deduplication**:
 一つのCandidate Momentのrefinement内で、知覚的に同じnative frameを一つへまとめるVideo Stageの処理。Quality Score順に64×36 grayscale署名を比較し、すでに残したframeとの平均絶対画素差が2.0以下なら除外する。閾値は設定値でなくversioned algorithm contractとする。同一PTSのFrame CandidateはVideo Source内で一つだけ作って複数Momentから共有するが、離れたMoment間の似たframeは削除しない。動画全体・動画横断の視覚的重複抑制とは区別する。
@@ -353,7 +369,7 @@ _Avoid_: all Candidate Moments, annotated Blog Candidate, selected output
 _Avoid_: Candidate Annotation failure, silent omission, fabricated output, invalid-frame fallback
 
 **Neutral Image Analysis**:
-sceneやSelection Intent、modelに依存せず、Frame Candidateそのものから得られる画質metrics、Quality Score、正規化済みHSV・輝度・edge視覚特徴。画像の内容分類ではなく、blog candidate判定や動画横断のcosine similarity判定の土台になる。明確な無効frameには絶対条件、暗いgameなど入力特性とTransition Frameには動画内分布と前後関係を使う。CLIPやHugging Face model identityをVideo Stageへ持ち込まない。
+sceneやSelection Intent、modelに依存せず、Frame Candidateそのものから得られる画質metrics、Quality Score、正規化済みHSV・輝度・edge視覚特徴。画像の内容分類ではなく、blog candidate判定や動画横断のcosine similarity判定の土台になる。明確な無効frameには絶対条件、暗いgameなど入力特性にはRefinement Window Group内の分布、Transition Frameには同一streamとtime baseでdurationどおりに連続するnative frameだけの前後関係を使う。CLIPやHugging Face model identityをVideo Stageへ持ち込まない。
 _Avoid_: scene classification, selection intent, CLIP embedding, model-dependent feature
 
 **Content Reject Reason**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -85,8 +85,24 @@ _Avoid_: model fallback, cache reset, model identity, notification-only update c
 _Avoid_: partial cache, in-progress stage, progress checkpoint
 
 **Video Stage**:
-一つのVideo Identityだけを対象とし、Video Setの構成やVideo Orderから独立して再利用できる Processing Stage。同一動画内で完結する時間構造、候補密度、frame refinement、Neutral Image Analysisを所有する。
+一つのVideo Identityだけを対象とし、Video Setの構成やVideo Orderから独立して再利用できる Processing Stage。同一動画内で完結する時間構造、候補密度、frame refinement、Neutral Image Analysisを所有する。複数VideoはVideo Order順に各Videoのscanからcandidate extractionまでを直列実行し、Video Orderは実行順にだけ使ってfingerprintへ含めない。
 _Avoid_: Video Set Stage, cross-video selection, whole-run stage
+
+**Video Scan Stage**:
+一つのVideo Sourceを一度decodeして、heartbeat proxy、scene signal metadata、exact timeline、scan metricをCompleted Stageとして確定するVideo Stage。FingerprintにはVideo Fingerprint、選択video stream、Media Runtime Identity、decode backend、heartbeat/scene設定、proxy contract、scan/timeline algorithm versionだけを含める。metricにはexact duration、wall/CPU時間、処理速度、decode backend、heartbeat件数/bytes/gap、scene signal件数、Timeline Segment数を残すがfingerprintへ含めない。後続の密度、refinement、最大Frame Candidate数、Neutral Image Analysisだけが変わった場合も再利用できる。
+_Avoid_: Frame Refinement, Candidate Annotation, Video Set Stage
+
+**Primary Video Stream**:
+Video SourceからVideo Scan Stageが選ぶ一つの表示映像stream。`attached_pic`など静止coverを除外し、default dispositionを優先して、同順位は最小stream indexで決める。stream選択をpublic configにせず、選択結果のindex、codec、time base、寸法をscan fingerprintへ残す。
+_Avoid_: audio stream, cover art, user-selected stream index
+
+**Heartbeat Proxy**:
+Video Scan Stageがnative heartbeatごとに永続化する、長辺960px、FFmpeg MJPEG `q:v=3`、metadataなしのcache画像。scene signal用の一時320px画像、Frame Candidate Proxy、公開画像とは区別し、pathをidentityにしない。
+_Avoid_: scene signal image, Frame Candidate, selected output
+
+**Frame Candidate Extraction Stage**:
+Video Scan Stageを上流にして、Candidate Moment Density、Frame Refinement、Neutral Image AnalysisをCompleted Stageとして確定するVideo Stage。FingerprintにはVideo Fingerprint、上流Stage Fingerprint、density、refinement半径、最大Frame Candidate数、Neutral Analysis/reject/dedupe/ID/proxyのalgorithm versionだけを含める。metricにはwall/CPU時間、density上限/実Moment数、refinement frame数、reason別reject、dedupe、0-frame Moment、Frame Candidate件数/bytesを残すがfingerprintへ含めない。heartbeat/scene設定やdecode結果を独自に作り直さない。
+_Avoid_: full video scan, Context Cue extraction, final selection
 
 **Video Set Stage**:
 順序付きのVideo Setと各Video Stageの成果物を入力にして、Scene Catalog、Candidate Annotation、動画横断の比較と多様性、最終選定を所有する Processing Stage。各Video Sourceからの最低採用数は持たない。
@@ -97,16 +113,24 @@ _Avoid_: Video Stage, per-video processing, per-video selection quota
 _Avoid_: frame index, float timestamp, wall-clock time
 
 **Video Duration**:
-一つのVideo Sourceの有効なpresentation timelineが持つ、0から終端までの正確で正の時間長。
-_Avoid_: container duration, last frame index, wall-clock duration
+一つのVideo Sourceの有効なpresentation timelineが持つ、0から終端までの正確で正の時間長。終端は最終表示frameの`PTS + duration_ts`を優先し、取得できない場合だけvideo streamの`start_pts + duration_ts`を使って、最初の表示frame PTSからの有理数として導出する。frame間隔、平均fps、containerのfloat秒からは推測せず、正確な終端を得られなければfail-fastする。
+_Avoid_: container float duration, inferred frame duration, last frame index, wall-clock duration
 
 **Timeline Segment**:
-一つのVideo Sourceのtimeline全体をgapや重複なく覆う、順序付きの半開区間。各Candidate Momentはanchor時刻によって必ず一つのTimeline Segmentに属する。
+一つのVideo Sourceのtimeline全体をgapや重複なく覆う、順序付きの半開区間。境界は0、scene signalの正確なVideo Time、Video Durationから作り、scene signal時刻は後側segmentの開始点とする。heartbeatはsegmentを分割しない。各Candidate Momentはanchor時刻によって必ず一つのTimeline Segmentに属する。
 _Avoid_: overlapping window, scene, refinement window
+
+**Timeline Segment ID**:
+algorithm名、Video Fingerprint、開始・終了Video Timeの既約分数をcanonical JSONにしてSHA-256化した、`seg_`と64桁digestからなる安定識別子。pathやVideo Orderを含めず、表示時だけ短縮できる。
+_Avoid_: segment index, display ID, source path
 
 **Candidate Moment**:
 一つのVideo Source内で、ブログに有用なframeがanchor Video Timeの周辺に存在すると判断された時間上の候補。複数の検出根拠をまとめ、refinement後に有効なFrame Candidateがない状態も保持する。
 _Avoid_: extracted image, Frame Candidate, scene event
+
+**Candidate Moment ID**:
+algorithm名、Video Fingerprint、anchor Video Timeの既約分数をcanonical JSONにしてSHA-256化した、`mom_`と64桁digestからなる安定識別子。path、Video Order、検出根拠を含めず、表示時だけ短縮できる。
+_Avoid_: candidate index, evidence hash, display ID
 
 **Context Cue**:
 一つのVideo SourceのVideo Time区間に対応付けられた、内蔵text subtitleまたは音声の文字起こしから得る文脈テキスト。視覚的なCandidate Momentへの加点根拠に限り、単独ではCandidate Momentを生成せずframeの採否も決めない。
@@ -117,15 +141,31 @@ Context Cueが選定へどう関係したかを公開成果物で追跡する、
 _Avoid_: subtitle quotation, ASR transcript, raw Context Cue text, model reasoning trace
 
 **Candidate Moment Density**:
-Video Durationに比例して、一つのVideo Sourceが保持できるCandidate Moment数を定める上限率。既定値は毎分2件で、上限は採用ノルマではなく、適格なCandidate Momentがなければ0件になり得る。
+Video Durationに比例して、一つのVideo Sourceが保持できるCandidate Moment数を定める上限率。`60秒 / density_per_minute`幅の半開区間ごとに最大1件を残し、既定値は毎分2件、つまり30秒ごとに最大1件とする。この密度区間はTimeline Segmentや最終選定の時間quotaではない。heartbeat proxyとscene signalから得たanchorをScan Proxy Analysisによってrefinement前に絞り、同点はscene signalの有無、区間中央への近さ、早いVideo Timeの順で解消する。scene signal自体は画質への加点や予約枠にしない。適格なanchorがない区間は0件とし、refinement後に有効なFrame CandidateがなかったCandidate Momentも診断対象として保持する。
 _Avoid_: fixed per-video count, per-video selection quota, requested-output multiplier
+
+**Scan Proxy Analysis**:
+Candidate Momentの密度選抜だけに使う一時的な中立画質評価。heartbeat anchorは自身のproxy、scene signal anchorは一時320px画像とrefinement範囲内のheartbeat proxyにある有効画像のうち最高画質を使う。これにより短い画面と、白飛びなど無効なscene signal瞬間の前後を拾う。永続的なFrame Candidate評価であるNeutral Image Analysisとは区別する。
+_Avoid_: Neutral Image Analysis, Candidate Annotation, scene importance
 
 **Frame Candidate**:
 Candidate Moment周辺のrefinementで有効と判断された、一つのVideo Source上の正確なsource frame。同じframeを複数のCandidate Momentが参照でき、proxy画像や出力画像とは区別する。
 _Avoid_: Candidate Moment, cached proxy, output image
 
+**Frame Candidate Proxy**:
+Candidate Annotationとcache再利用のためにFrame Candidateごとに永続化する、長辺960px、FFmpeg MJPEG `q:v=3`、metadataなしの画像。公開時には#187が同じexact PTSから元解像度frameを再抽出してWebP quality 95を作る。
+_Avoid_: Heartbeat Proxy, original-resolution frame, selected output
+
+**Frame Refinement**:
+Candidate Momentのanchor前後にあるnative frameを対象に、Content Reject Reason判定、Source-Local Frame Deduplication、最大Frame Candidate数への選抜を行うVideo Stage処理。最初に最もQuality Scoreが高いframeを選び、残りは選択済みframeとの最小視覚距離、Quality Score、anchorへの近さ、早いVideo Timeの順で最大件数まで選ぶ。Candidate Momentから参照する最終順序はVideo Time順とする。
+_Avoid_: fixed-fps conversion, Candidate Annotation, Representative Frame selection
+
+**Source-Local Frame Deduplication**:
+一つのCandidate Momentのrefinement内で、知覚的に同じnative frameを一つへまとめるVideo Stageの処理。Quality Score順に64×36 grayscale署名を比較し、すでに残したframeとの平均絶対画素差が2.0以下なら除外する。閾値は設定値でなくversioned algorithm contractとする。同一PTSのFrame CandidateはVideo Source内で一つだけ作って複数Momentから共有するが、離れたMoment間の似たframeは削除しない。動画全体・動画横断の視覚的重複抑制とは区別する。
+_Avoid_: cross-video diversity, global near-duplicate removal, exact-frame duplication
+
 **Frame Candidate ID**:
-Video Fingerprintとframe自身の正確なVideo Timeからversion付きSHA-256 derivationで作る、`frm_`と64桁digestからなる安定識別子。出力先や選択順が変わっても同じFrame Candidateを指す。
+algorithm名、Video Fingerprint、frame自身のVideo Timeの既約分数をcanonical JSONにしてversion付きSHA-256 derivationで作る、`frm_`と64桁digestからなる安定識別子。出力先や選択順が変わっても同じFrame Candidateを指し、表示時だけ短縮できる。
 _Avoid_: output filename, selection index, source path
 
 **Representative Frame**:
@@ -313,8 +353,12 @@ _Avoid_: all Candidate Moments, annotated Blog Candidate, selected output
 _Avoid_: Candidate Annotation failure, silent omission, fabricated output, invalid-frame fallback
 
 **Neutral Image Analysis**:
-scene や selection intent に依存せず、Frame Candidateそのものから得られる特徴と品質評価。画像の内容分類ではなく、blog candidate 判定や動画横断の類似度判定の土台になる。
-_Avoid_: scene classification, selection intent
+sceneやSelection Intent、modelに依存せず、Frame Candidateそのものから得られる画質metrics、Quality Score、正規化済みHSV・輝度・edge視覚特徴。画像の内容分類ではなく、blog candidate判定や動画横断のcosine similarity判定の土台になる。明確な無効frameには絶対条件、暗いgameなど入力特性とTransition Frameには動画内分布と前後関係を使う。CLIPやHugging Face model identityをVideo Stageへ持ち込まない。
+_Avoid_: scene classification, selection intent, CLIP embedding, model-dependent feature
+
+**Content Reject Reason**:
+refinement frameを有効なFrame Candidateにしなかった理由を表す安定enum。`blackout`、`whiteout`、`single_tone`、`blur`、`fade_transition`、`temporal_transition`を持ち、free textだけの除外理由にはしない。
+_Avoid_: model classification, selection rejection, free-form reason
 
 **Transition Frame**:
 シーン移動や画面切り替えの途中に現れる、ブログ画像として説明価値が低い一時的な画面。

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,7 +17,7 @@ _Avoid_: Video Set, Output Folder, cache key
 _Avoid_: Stage lock, waiting queue, global lock, cache artifact
 
 **Video Set Snapshot Validation**:
-Input Lock取得直後とOutput Folder公開直前にはVideo Set全体のpath、stat、内容を、各Video Stage直前にはVideo Set全体のpath、statと対象Video Sourceの内容を発見時snapshotへ照合する不変性検査。Stageごとに全動画を再hashする検査とは区別する。
+Input Lock取得直後とOutput Folder公開直前にはVideo Set全体のpath、stat、内容を、各Video Sourceのmedia probe前と各Video Stage直前にはVideo Set全体のpath、statと対象Video Sourceの内容を発見時snapshotへ照合する不変性検査。変更済みsourceからstream metadataを取得せず、Stageごとに全動画を再hashする検査とは区別する。
 _Avoid_: cache artifact validation, full-set hash per Video Stage, Input Lock
 
 **Video Set Fingerprint**:
@@ -109,7 +109,7 @@ Video SourceからVideo Scan Stageが選ぶ一つの表示映像stream。`attach
 _Avoid_: audio stream, cover art, user-selected stream index
 
 **Heartbeat Proxy**:
-Video Scan Stageがnative heartbeatごとに永続化する、長辺960px、FFmpeg MJPEG `q:v=3`、metadataなしのcache画像。scene signal用の一時320px画像、Frame Candidate Proxy、公開画像とは区別し、pathをidentityにしない。
+Video Scan Stageがnative heartbeatごとに永続化する、長辺960px、FFmpeg MJPEG `q:v=3`、metadataなしのcache画像。Scan Proxy Analysisでは1件ずつRGB decode・測定して解放し、全proxyのdecoded RGBを同時保持しない。scene signal用の一時320px画像、Frame Candidate Proxy、公開画像とは区別し、pathをidentityにしない。
 _Avoid_: scene signal image, Frame Candidate, selected output
 
 **Frame Candidate Extraction Stage**:
@@ -157,7 +157,7 @@ Video Durationに比例して、一つのVideo Sourceが保持できるCandidate
 _Avoid_: fixed per-video count, per-video selection quota, requested-output multiplier
 
 **Scan Proxy Analysis**:
-Candidate Momentの密度選抜だけに使う一時的な中立画質評価。heartbeat anchorは自身のproxy、scene signal anchorは一時320px画像とrefinement範囲内のheartbeat proxyにある有効画像のうち最高画質を使う。これにより短い画面と、白飛びなど無効なscene signal瞬間の前後を拾う。永続的なFrame Candidate評価であるNeutral Image Analysisとは区別する。
+Candidate Momentの密度選抜だけに使う一時的な中立画質評価。heartbeat anchorは自身のproxy、scene signal anchorは一時320px画像とrefinement範囲内のheartbeat proxyにある有効画像のうち最高画質を使う。scene近傍のheartbeat品質はtimeline順の単調windowで参照し、sceneごとに全heartbeatを再走査しない。これにより短い画面と、白飛びなど無効なscene signal瞬間の前後を拾う。永続的なFrame Candidate評価であるNeutral Image Analysisとは区別する。
 _Avoid_: Neutral Image Analysis, Candidate Annotation, scene importance
 
 **Frame Candidate**:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## 動画入力版の設計と内部実装（公開前）
 
-複数のゲーム録画を一つのVideo Setとして扱う次期interfaceは、次の一つのcommandへ置き換える設計です。探索・content identity・Input Lock・Completed Stage cacheに加え、system FFmpeg/ffprobeを閉じ込めるMediaRuntimeと生成fixture CIまで実装済みです。frame抽出・timeline・Context CueなどのVideo Stage接続とpublic CLIの切り替えは後続Issueで行うため、このcommandはまだ実行できません。
+複数のゲーム録画を一つのVideo Setとして扱う次期interfaceは、次の一つのcommandへ置き換える設計です。探索・content identity・Input Lock・Completed Stage cache、system FFmpeg/ffprobeを閉じ込めるMediaRuntimeに加え、動画単位のscan、exact timeline、Candidate Moment、native frame refinement、model-free Neutral Image Analysisまで内部実装済みです。Context Cue、Video Set Stage、public CLIの接続と切り替えは後続Issueで行うため、このcommandはまだ実行できません。
 
 ```bash
 game-screen-pick \
@@ -16,6 +16,7 @@ game-screen-pick \
 最低runtimeはPython 3.13、FFmpeg/ffprobe 6.1.1、Ollama server 0.31.2、faster-whisper 1.2.1、CTranslate2 4.8.1です。Windows 11 + WSL2ではWindows native Ollamaへ明示URLで接続し、Windows/WSLのserverを自動切替しません。
 
 - [動画入力とCLI](docs/video-input.md)
+- [動画単位のscan、timeline、Frame Candidate cache](docs/video-stage.md)
 - [TOML、優先順位、model更新](docs/configuration.md)
 - [runtime、cache、進捗、エラー、WSL2運用](docs/operations.md)
 - [選択画像とreport](docs/report.md)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -43,7 +43,7 @@ PRでは通常quality checkと別のUbuntu 24.04 jobとして実行されます�
 
 ## processing cache基盤
 
-Input Lockは`<VIDEO_INPUT_FOLDER>/.game-screen-pick/input.lock`でVideo Input Folder単位に取得します。待機queueは作らず、同じinputの別runが保持中なら即時に失敗します。lockはVideo Set snapshotの非破壊検査後から、cache準備、全Processing Stage、Output Folder公開の終了まで保持します。lock取得直後と公開直前はVideo Set全体のpath・stat・内容を検査し、各Video Stage直前は全体のpath・statと対象Video Sourceの内容を検査します。これにより入力変更を拒否しつつ、Stageごとに全動画を再hashする二乗I/Oを避けます。
+Input Lockは`<VIDEO_INPUT_FOLDER>/.game-screen-pick/input.lock`でVideo Input Folder単位に取得します。待機queueは作らず、同じinputの別runが保持中なら即時に失敗します。lockはVideo Set snapshotの非破壊検査後から、cache準備、全Processing Stage、Output Folder公開の終了まで保持します。lock取得直後と公開直前はVideo Set全体のpath・stat・内容を検査し、各Video Sourceのmedia probe前と各Video Stage直前は全体のpath・statと対象Video Sourceの内容を検査します。これにより変更済み動画をprobeせず拒否しつつ、Stageごとに全動画を再hashする二乗I/Oを避けます。
 
 processing cacheはcontent-addressedな次のnamespaceを使います。
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -43,7 +43,7 @@ PRでは通常quality checkと別のUbuntu 24.04 jobとして実行されます�
 
 ## processing cache基盤
 
-Input Lockは`<VIDEO_INPUT_FOLDER>/.game-screen-pick/input.lock`でVideo Input Folder単位に取得します。待機queueは作らず、同じinputの別runが保持中なら即時に失敗します。lockはVideo Set snapshotの非破壊検査後から、cache準備、全Processing Stage、Output Folder公開の終了まで保持します。各Stageの前と公開直前にもsnapshotを再検査し、入力が変化したrunを確定しません。
+Input Lockは`<VIDEO_INPUT_FOLDER>/.game-screen-pick/input.lock`でVideo Input Folder単位に取得します。待機queueは作らず、同じinputの別runが保持中なら即時に失敗します。lockはVideo Set snapshotの非破壊検査後から、cache準備、全Processing Stage、Output Folder公開の終了まで保持します。lock取得直後と公開直前はVideo Set全体のpath・stat・内容を検査し、各Video Stage直前は全体のpath・statと対象Video Sourceの内容を検査します。これにより入力変更を拒否しつつ、Stageごとに全動画を再hashする二乗I/Oを避けます。
 
 processing cacheはcontent-addressedな次のnamespaceを使います。
 

--- a/docs/video-input.md
+++ b/docs/video-input.md
@@ -41,7 +41,7 @@ game-screen-pick [OPTIONS] <VIDEO_INPUT_FOLDER> <OUTPUT_FOLDER>
 - Video Identityはfile全体のSHA-256で決まります。renameやmtime変更では変わらず、内容変更時だけ変わります。
 - Video Set FingerprintはVideo OrderどおりのVideo Fingerprint列から決まり、input rootや設定値を含みません。
 - 対応動画0本、壊れた動画、同一内容の重複動画は、cacheやoutputを作る前に実行全体を失敗させます。
-- 発見後にpath、内容、size、mtime、inodeが変化した場合はsnapshot不一致としてrunを中止します。全体内容はInput Lock取得直後と公開直前、対象動画の内容は各Video Stage直前に検査します。
+- 発見後にpath、内容、size、mtime、inodeが変化した場合はsnapshot不一致としてrunを中止します。全体内容はInput Lock取得直後と公開直前、対象動画の内容はmedia probe前と各Video Stage直前に検査します。
 
 入力と出力は同一pathにも相互の親子にもできません。`OUTPUT_FOLDER`は存在しないか空である必要があり、途中処理や再開には使いません。
 

--- a/docs/video-input.md
+++ b/docs/video-input.md
@@ -41,7 +41,7 @@ game-screen-pick [OPTIONS] <VIDEO_INPUT_FOLDER> <OUTPUT_FOLDER>
 - Video Identityはfile全体のSHA-256で決まります。renameやmtime変更では変わらず、内容変更時だけ変わります。
 - Video Set FingerprintはVideo OrderどおりのVideo Fingerprint列から決まり、input rootや設定値を含みません。
 - 対応動画0本、壊れた動画、同一内容の重複動画は、cacheやoutputを作る前に実行全体を失敗させます。
-- 発見後にpath、内容、size、mtime、inodeが変化した場合はsnapshot不一致としてrunを中止します。
+- 発見後にpath、内容、size、mtime、inodeが変化した場合はsnapshot不一致としてrunを中止します。全体内容はInput Lock取得直後と公開直前、対象動画の内容は各Video Stage直前に検査します。
 
 入力と出力は同一pathにも相互の親子にもできません。`OUTPUT_FOLDER`は存在しないか空である必要があり、途中処理や再開には使いません。
 

--- a/docs/video-stage.md
+++ b/docs/video-stage.md
@@ -13,7 +13,8 @@ Video Set内の動画はVideo Order順に直列処理されます。各Video Ide
 2. `extract-frame-candidates`
    - density windowごとに最大1件のCandidate Momentを発見します。
    - Moment前後のnative frameだけを一回のrange scanで取り出します。
-   - model-free Neutral Image Analysis、無効frame除外、Moment内deduplication、多様性選抜を行います。
+   - 重なるMoment windowを一つのRefinement Window Groupとして順次処理し、選抜proxyを書いた時点でそのgroupのRGB frameを解放します。
+   - group内でmodel-free Neutral Image Analysis、無効frame除外、Moment内deduplication、多様性選抜を行います。
    - Frame Candidate Proxyと抽出metricをatomicに確定します。
 
 Video Stage cacheはVideo Fingerprintごとに`<VIDEO_INPUT_FOLDER>/.game-screen-pick/cache/videos/`へ保存されます。動画のrenameやVideo Order変更はfingerprintに含まれないため、同じ内容の動画では再利用されます。
@@ -40,11 +41,11 @@ Neutral Image AnalysisはOpenCV/NumPyの画質metricsとL2正規化済みHSV・�
 - `fade_transition`
 - `temporal_transition`
 
-絶対的に無効な露出・単色・ぼけを先に除外し、暗いゲーム画面と遷移frameの区別には動画内分布と前後関係を使います。
+絶対的に無効な露出・単色・ぼけを先に除外し、暗いゲーム画面にはRefinement Window Group内の相対分布を使います。`temporal_transition`は同一stream・time baseで、前frameの`PTS + duration_ts`が次frameのPTSと一致する3つのnative frameだけに適用します。離れたrangeのsampleを前後frameとして比較しません。
 
 ## Cache再利用
 
-`scan-video`はVideo Fingerprint、Primary Video Stream、Media Runtime Identity、decode backend、heartbeat/scene設定、proxy・scan・timeline algorithmだけで識別されます。density、refinement半径、最大Frame Candidate数、Neutral Image Analysisが変わっても再利用されます。
+`scan-video`はVideo Fingerprint、Primary Video Stream、Media Runtime Identity、decode backend、heartbeat/scene設定、proxy・scan・timeline algorithmだけで識別されます。Media Runtime IdentityはFFmpeg/ffprobe versionと、正規化済みbuild情報・検証済みcapability一覧から実行時に導出した完全SHA-256を持つため、同じversionの別buildでもcacheを再利用しません。raw build文字列や手入力hashは保存しません。density、refinement半径、最大Frame Candidate数、Neutral Image Analysisが変わっても再利用されます。
 
 `extract-frame-candidates`は上流scan fingerprint、density、refinement半径、最大Frame Candidate数、Neutral Analysis・reject・dedupe・ID・proxy algorithmで識別されます。
 
@@ -61,7 +62,7 @@ Completed Stage manifestは`artifact.json`を含む全artifactの相対path、by
 
 `scan-video`はexact duration、wall/CPU秒、処理速度、decode backend、decode pass数、heartbeat件数・容量・最大/p95 gap、scene signal件数、segment件数を記録します。
 
-`extract-frame-candidates`はwall/CPU秒、density上限と実Moment数、native frame件数、reason別reject件数、dedupe件数、0-frame Moment件数、Frame Candidate件数・容量を記録します。metric値はStage Fingerprintに含まれません。
+`extract-frame-candidates`はwall/CPU秒、density上限と実Moment数、native frame件数、reason別reject件数、dedupe件数、0-frame Moment件数、Frame Candidate件数・容量を記録します。両Stageのwall時間はartifact構築まで、CPU時間はcurrent processのPython/OpenCV/NumPyとFFmpeg child processの合計です。cache hitでは初回計算時のmetricを復元し、metric値はStage Fingerprintに含めません。
 
 ## 検証
 

--- a/docs/video-stage.md
+++ b/docs/video-stage.md
@@ -4,14 +4,15 @@
 
 ## Processing Stage
 
-Video Set内の動画はVideo Order順に直列処理されます。各Video Identityには、次の2つのCompleted Stageが作られます。
+Video Set内の動画はVideo Order順に直列処理されます。各sourceはmedia probeより前にsnapshotが検査され、各Video Identityには次の2つのCompleted Stageが作られます。
 
 1. `scan-video`
    - `attached_pic`を除外し、default disposition、stream indexの順でPrimary Video Streamを決めます。
    - 一回のnative decodeを、1秒heartbeat、320px scene signal、全frame timingへ分岐します。
+   - heartbeat/scene proxyは1件ずつRGB decode・測定して解放し、全proxyのRGBを同時保持しません。
    - Heartbeat Proxy、scene signalの時刻、exact timeline、scan metricをatomicに確定します。
 2. `extract-frame-candidates`
-   - density windowごとに最大1件のCandidate Momentを発見します。
+   - timeline順の単調windowでscene近傍のheartbeat品質を参照し、density windowごとに最大1件のCandidate Momentを発見します。
    - Moment前後のnative frameだけを一回のrange scanで取り出します。
    - 重なるMoment windowを一つのRefinement Window Groupとして順次処理し、選抜proxyを書いた時点でそのgroupのRGB frameを解放します。
    - group内でmodel-free Neutral Image Analysis、無効frame除外、Moment内deduplication、多様性選抜を行います。

--- a/docs/video-stage.md
+++ b/docs/video-stage.md
@@ -1,0 +1,73 @@
+# 動画単位のVideo Stage
+
+この文書は、公開前の動画入力selectorが一つのVideo Sourceから再利用可能なFrame Candidateを作る内部契約を説明します。現在のscreenshot入力CLIからはまだ呼び出されません。
+
+## Processing Stage
+
+Video Set内の動画はVideo Order順に直列処理されます。各Video Identityには、次の2つのCompleted Stageが作られます。
+
+1. `scan-video`
+   - `attached_pic`を除外し、default disposition、stream indexの順でPrimary Video Streamを決めます。
+   - 一回のnative decodeを、1秒heartbeat、320px scene signal、全frame timingへ分岐します。
+   - Heartbeat Proxy、scene signalの時刻、exact timeline、scan metricをatomicに確定します。
+2. `extract-frame-candidates`
+   - density windowごとに最大1件のCandidate Momentを発見します。
+   - Moment前後のnative frameだけを一回のrange scanで取り出します。
+   - model-free Neutral Image Analysis、無効frame除外、Moment内deduplication、多様性選抜を行います。
+   - Frame Candidate Proxyと抽出metricをatomicに確定します。
+
+Video Stage cacheはVideo Fingerprintごとに`<VIDEO_INPUT_FOLDER>/.game-screen-pick/cache/videos/`へ保存されます。動画のrenameやVideo Order変更はfingerprintに含まれないため、同じ内容の動画では再利用されます。
+
+## Exact timeline
+
+Video Timeは整数source PTSとstream time baseから導出し、最初の表示frameを0とします。Video Durationは最終表示frameの`PTS + duration_ts`を優先し、取得できない場合だけstreamのexactな`start_pts + duration_ts`を使います。float秒、平均fps、frame間隔からは推測しません。
+
+Timeline Segmentは0、scene signalのVideo Time、Video Durationを境界とする半開区間です。scene境界は後側のsegmentに属し、全segmentが`[0, Video Duration)`をgapやoverlapなく覆います。
+
+## ProxyとNeutral Image Analysis
+
+- Heartbeat Proxy: 長辺960px以下、FFmpeg MJPEG `q:v=3`、source metadataなし
+- scene signal画像: 長辺320px以下。Scan Proxy Analysis後に削除し、Completed Stageには時刻と解析結果だけを残す
+- Frame Candidate Proxy: 長辺960px以下、FFmpeg MJPEG `q:v=3`、source metadataなし
+- 元解像度frame: cacheしない。公開時にexact PTSから再抽出する
+
+Neutral Image AnalysisはOpenCV/NumPyの画質metricsとL2正規化済みHSV・輝度・edge特徴だけを使い、CLIPやHugging Face modelをloadしません。stable reject reasonは次の6種類です。
+
+- `blackout`
+- `whiteout`
+- `single_tone`
+- `blur`
+- `fade_transition`
+- `temporal_transition`
+
+絶対的に無効な露出・単色・ぼけを先に除外し、暗いゲーム画面と遷移frameの区別には動画内分布と前後関係を使います。
+
+## Cache再利用
+
+`scan-video`はVideo Fingerprint、Primary Video Stream、Media Runtime Identity、decode backend、heartbeat/scene設定、proxy・scan・timeline algorithmだけで識別されます。density、refinement半径、最大Frame Candidate数、Neutral Image Analysisが変わっても再利用されます。
+
+`extract-frame-candidates`は上流scan fingerprint、density、refinement半径、最大Frame Candidate数、Neutral Analysis・reject・dedupe・ID・proxy algorithmで識別されます。
+
+次のdownstream値はどちらのfingerprintにも入りません。
+
+- 選択画像枚数
+- Selection Intent、scene hint、spoiler sensitivity、similarity threshold
+- Ollama、STT、model lifecycle設定
+- source path、filename、Video Order
+
+Completed Stage manifestは`artifact.json`を含む全artifactの相対path、byte数、SHA-256を記録します。JPEGが1件でも欠損・破損した場合はStage全体を再利用せず、上流の健全なStageを残して再計算します。
+
+## Metric
+
+`scan-video`はexact duration、wall/CPU秒、処理速度、decode backend、decode pass数、heartbeat件数・容量・最大/p95 gap、scene signal件数、segment件数を記録します。
+
+`extract-frame-candidates`はwall/CPU秒、density上限と実Moment数、native frame件数、reason別reject件数、dedupe件数、0-frame Moment件数、Frame Candidate件数・容量を記録します。metric値はStage Fingerprintに含まれません。
+
+## 検証
+
+```bash
+uv run task test
+uv run task test-ffmpeg
+```
+
+生成FFmpeg fixtureでCFR/VFR、first/middle/last、scene境界、single decode、metadataなしMJPEG、exact range refinementを検証します。

--- a/src/video_selection/media/ffmpeg_media_runtime.py
+++ b/src/video_selection/media/ffmpeg_media_runtime.py
@@ -2,8 +2,12 @@
 
 import json
 import re
+import resource
 import subprocess
+import time
+from collections import deque
 from collections.abc import Iterator
+from fractions import Fraction
 from pathlib import Path
 
 from ..models.decoded_video_frame import DecodedVideoFrame
@@ -12,7 +16,10 @@ from ..models.media_probe import MediaProbe
 from ..models.media_runtime_error import MediaRuntimeError
 from ..models.media_runtime_failure_reason import MediaRuntimeFailureReason
 from ..models.media_runtime_identity import MediaRuntimeIdentity
+from ..models.media_stream import MediaStream
+from ..models.native_video_scan import NativeVideoScan
 from ..models.pcm_audio_chunk import PcmAudioChunk
+from ..models.scanned_video_frame import ScannedVideoFrame
 from .ffmpeg_pcm_reader import iter_pcm_audio_chunks
 from .ffmpeg_subtitle_reader import read_embedded_subtitle_events
 from .ffmpeg_video_reader import iter_decoded_video_frames
@@ -33,8 +40,8 @@ _BUILD_SIGNATURE_PREFIXES = (
 )
 _REQUIRED_DEMUXERS = frozenset({"matroska", "mov"})
 _REQUIRED_DECODERS = frozenset({"aac", "libdav1d", "subrip"})
-_REQUIRED_ENCODERS = frozenset({"pcm_s16le", "ppm", "srt"})
-_REQUIRED_MUXERS = frozenset({"image2pipe", "s16le", "srt"})
+_REQUIRED_ENCODERS = frozenset({"mjpeg", "pcm_s16le", "ppm", "srt"})
+_REQUIRED_MUXERS = frozenset({"image2", "image2pipe", "s16le", "srt"})
 _REQUIRED_FILTERS = frozenset(
     {
         "aformat",
@@ -42,9 +49,11 @@ _REQUIRED_FILTERS = frozenset(
         "asetnsamples",
         "ashowinfo",
         "format",
+        "nullsink",
         "scale",
         "select",
         "showinfo",
+        "split",
     }
 )
 _DECODE_ERRORS = (
@@ -53,6 +62,10 @@ _DECODE_ERRORS = (
     EOFError,
     ValueError,
 )
+_SHOWINFO_BRANCH_PATTERN = re.compile(r"showinfo@(?P<branch>timeline|heartbeat|scene)")
+_SHOWINFO_PTS_PATTERN = re.compile(r"\bpts:\s*(-?\d+)")
+_SHOWINFO_DURATION_PATTERN = re.compile(r"\bduration:\s*(-?\d+)")
+_SHOWINFO_SIZE_PATTERN = re.compile(r"\bs:(\d+)x(\d+)")
 
 
 class FfmpegMediaRuntime:
@@ -149,6 +162,172 @@ class FfmpegMediaRuntime:
                 "video streamをdecodeできませんでした",
             ) from error
 
+    def scan_video(
+        self,
+        media_path: Path,
+        stream: MediaStream,
+        artifact_folder: Path,
+        *,
+        heartbeat_interval_seconds: float,
+        scene_change_threshold: float,
+        scene_min_interval_seconds: float,
+        decode_backend: str,
+    ) -> NativeVideoScan:
+        """一回のdecodeをheartbeat、scene、timeline timingへ分岐する。"""
+        _validate_scan_configuration(
+            heartbeat_interval_seconds,
+            scene_change_threshold,
+            scene_min_interval_seconds,
+            decode_backend,
+        )
+        if stream.kind != "video" or stream.time_base is None:
+            msg = "Video Scanにはexact time baseを持つvideo streamが必要です"
+            raise ValueError(msg)
+        heartbeat_folder = artifact_folder / "heartbeats"
+        scene_folder = artifact_folder / ".scene-proxies"
+        heartbeat_folder.mkdir(parents=True)
+        scene_folder.mkdir()
+        command = self._composite_scan_command(
+            media_path,
+            stream,
+            heartbeat_folder,
+            scene_folder,
+            heartbeat_interval_seconds,
+            scene_change_threshold,
+            scene_min_interval_seconds,
+            decode_backend,
+        )
+        usage_before = resource.getrusage(resource.RUSAGE_CHILDREN)
+        started_at = time.monotonic()
+        timeline_first: tuple[int, int | None, int, int] | None = None
+        timeline_last: tuple[int, int | None, int, int] | None = None
+        heartbeat_metadata: list[tuple[int, int | None, int, int]] = []
+        scene_metadata: list[tuple[int, int | None, int, int]] = []
+        stderr_tail: deque[str] = deque(maxlen=80)
+        try:
+            process = subprocess.Popen(
+                command,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            if process.stderr is None:
+                msg = "FFmpeg scan stderrを開始できません"
+                raise RuntimeError(msg)
+            for line in process.stderr:
+                stderr_tail.append(line.rstrip())
+                parsed = _parse_named_showinfo(line)
+                if parsed is None:
+                    continue
+                branch, metadata = parsed
+                if branch == "timeline":
+                    if timeline_first is None:
+                        timeline_first = metadata
+                    timeline_last = metadata
+                elif branch == "heartbeat":
+                    heartbeat_metadata.append(metadata)
+                else:
+                    scene_metadata.append(metadata)
+            return_code = process.wait()
+        except OSError as error:
+            raise MediaRuntimeError(
+                MediaRuntimeFailureReason.DECODER_FAILURE,
+                "Video ScanのFFmpeg processを開始できませんでした",
+            ) from error
+        wall_seconds = time.monotonic() - started_at
+        usage_after = resource.getrusage(resource.RUSAGE_CHILDREN)
+        cpu_seconds = (
+            usage_after.ru_utime
+            - usage_before.ru_utime
+            + usage_after.ru_stime
+            - usage_before.ru_stime
+        )
+        if return_code != 0:
+            detail = "\n".join(stderr_tail)
+            raise MediaRuntimeError(
+                MediaRuntimeFailureReason.DECODER_FAILURE,
+                f"Video ScanのFFmpeg decodeに失敗しました\n{detail}",
+            )
+        if timeline_first is None or timeline_last is None:
+            raise MediaRuntimeError(
+                MediaRuntimeFailureReason.DECODER_FAILURE,
+                "Video Scanに表示可能frameがありません",
+            )
+        heartbeat_files = tuple(sorted(heartbeat_folder.glob("*.jpg")))
+        scene_files = tuple(sorted(scene_folder.glob("*.jpg")))
+        if len(heartbeat_files) != len(heartbeat_metadata) or len(scene_files) != len(
+            scene_metadata
+        ):
+            raise MediaRuntimeError(
+                MediaRuntimeFailureReason.DECODER_FAILURE,
+                "Video Scanのproxyとexact timingの件数が一致しません",
+            )
+        heartbeats = _scanned_frames(
+            heartbeat_metadata,
+            heartbeat_files,
+            stream.time_base,
+        )
+        scenes_with_dummy = _scanned_frames(
+            scene_metadata,
+            scene_files,
+            stream.time_base,
+        )
+        if not scenes_with_dummy:
+            raise MediaRuntimeError(
+                MediaRuntimeFailureReason.DECODER_FAILURE,
+                "Video Scanのscene分析枝を初期化できませんでした",
+            )
+        scenes_with_dummy[0].image_path.unlink()
+        scene_frames = tuple(scenes_with_dummy[1:])
+        origin_pts, _origin_duration, _origin_width, _origin_height = timeline_first
+        last_pts, last_duration, _last_width, _last_height = timeline_last
+        return NativeVideoScan(
+            stream_index=stream.index,
+            origin_pts=origin_pts,
+            last_frame_pts=last_pts,
+            last_frame_duration_ts=last_duration,
+            time_base=stream.time_base,
+            heartbeats=tuple(heartbeats),
+            scene_frames=scene_frames,
+            wall_seconds=wall_seconds,
+            cpu_seconds=cpu_seconds,
+            decode_pass_count=1,
+        )
+
+    def scan_video_frame_ranges(
+        self,
+        media_path: Path,
+        stream_index: int,
+        pts_ranges: tuple[tuple[int, int], ...],
+        max_dimension: int,
+    ) -> Iterator[DecodedVideoFrame]:
+        """半開PTS rangeの和集合にあるnative RGB24 frameだけを返す。"""
+        if (
+            max_dimension < 1
+            or not pts_ranges
+            or any(start >= end for start, end in pts_ranges)
+        ):
+            msg = "PTS rangeとmax_dimensionが不正です"
+            raise ValueError(msg)
+        expressions = [
+            f"gte(pts\\,{start})*lt(pts\\,{end})" for start, end in pts_ranges
+        ]
+        frame_filter = f"select='{'+'.join(expressions)}'," + _scale_filter(
+            max_dimension
+        )
+        command = self._video_decode_command(
+            media_path,
+            stream_index,
+            frame_filter,
+        )
+        try:
+            yield from iter_decoded_video_frames(command, stream_index)
+        except _DECODE_ERRORS as error:
+            raise MediaRuntimeError(
+                MediaRuntimeFailureReason.FRAME_EXTRACTION_FAILED,
+                "指定されたPTS rangeのnative frameを抽出できませんでした",
+            ) from error
+
     def extract_video_frame(
         self,
         media_path: Path,
@@ -180,6 +359,60 @@ class FfmpegMediaRuntime:
                 "指定されたsource PTSのvideo frameがありません",
             )
         return frames[0]
+
+    def write_mjpeg_proxy(
+        self,
+        frame: DecodedVideoFrame,
+        output_path: Path,
+        *,
+        quality: int,
+    ) -> None:
+        """RGB24 artifactをFFmpeg MJPEGへmetadataなしで保存する。"""
+        if not 1 <= quality <= 31:
+            msg = "FFmpeg MJPEG qualityは1以上31以下である必要があります"
+            raise ValueError(msg)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        command = [
+            self._ffmpeg_executable,
+            "-y",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "rawvideo",
+            "-pixel_format",
+            frame.pixel_format,
+            "-video_size",
+            f"{frame.width}x{frame.height}",
+            "-framerate",
+            "1",
+            "-i",
+            "pipe:0",
+            "-frames:v",
+            "1",
+            "-map_metadata",
+            "-1",
+            "-c:v",
+            "mjpeg",
+            "-q:v",
+            str(quality),
+            "-pix_fmt",
+            "yuvj420p",
+            str(output_path),
+        ]
+        try:
+            subprocess.run(
+                command,
+                input=frame.pixels,
+                check=True,
+                capture_output=True,
+            )
+        except (OSError, subprocess.CalledProcessError) as error:
+            raise MediaRuntimeError(
+                MediaRuntimeFailureReason.FRAME_EXTRACTION_FAILED,
+                "Frame Candidate ProxyをMJPEGへencodeできませんでした",
+            ) from error
 
     def scan_pcm_audio(
         self,
@@ -279,6 +512,87 @@ class FfmpegMediaRuntime:
                 "-c:v",
                 "ppm",
                 "pipe:1",
+            ]
+        )
+        return command
+
+    def _composite_scan_command(
+        self,
+        media_path: Path,
+        stream: MediaStream,
+        heartbeat_folder: Path,
+        scene_folder: Path,
+        heartbeat_interval_seconds: float,
+        scene_change_threshold: float,
+        scene_min_interval_seconds: float,
+        decode_backend: str,
+    ) -> list[str]:
+        command = [
+            self._ffmpeg_executable,
+            "-y",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "info",
+            "-nostats",
+            "-xerror",
+            "-err_detect",
+            "explode",
+            "-copyts",
+        ]
+        if decode_backend == "nvdec":
+            command.extend(["-hwaccel", "cuda"])
+        elif stream.codec_name == "av1":
+            command.extend(["-c:v", "libdav1d"])
+        command.extend(["-i", str(media_path)])
+        heartbeat_interval = _ffmpeg_number(heartbeat_interval_seconds)
+        scene_threshold = _ffmpeg_number(scene_change_threshold)
+        scene_interval = _ffmpeg_number(scene_min_interval_seconds)
+        graph = ";".join(
+            (
+                f"[0:{stream.index}]split=3[timeline_source]"
+                "[heartbeat_source][scene_source]",
+                "[timeline_source]showinfo@timeline,nullsink",
+                (
+                    "[heartbeat_source]"
+                    "select='isnan(prev_selected_t)+"
+                    f"gte(t-prev_selected_t,{heartbeat_interval})',"
+                    f"{_bounded_scale_filter(960)},"
+                    "format=yuvj420p,showinfo@heartbeat[heartbeat_output]"
+                ),
+                (
+                    "[scene_source]"
+                    f"{_bounded_scale_filter(320)},"
+                    "select='eq(n,0)+gte(n,1)*"
+                    f"gt(scene,{scene_threshold})*"
+                    "(isnan(prev_selected_t)+"
+                    f"gte(t-prev_selected_t,{scene_interval}))',"
+                    "format=yuvj420p,showinfo@scene[scene_output]"
+                ),
+            )
+        )
+        command.extend(
+            [
+                "-filter_complex",
+                graph,
+                "-map",
+                "[heartbeat_output]",
+                "-fps_mode",
+                "passthrough",
+                "-map_metadata",
+                "-1",
+                "-q:v",
+                "3",
+                str(heartbeat_folder / "%012d.jpg"),
+                "-map",
+                "[scene_output]",
+                "-fps_mode",
+                "passthrough",
+                "-map_metadata",
+                "-1",
+                "-q:v",
+                "3",
+                str(scene_folder / "%012d.jpg"),
             ]
         )
         return command
@@ -424,3 +738,82 @@ def _scale_filter(max_dimension: int) -> str:
         "force_original_aspect_ratio=decrease:force_divisible_by=2,"
         "format=rgb24,showinfo"
     )
+
+
+def _bounded_scale_filter(max_dimension: int) -> str:
+    return (
+        f"scale=w='min(iw,{max_dimension})':h='min(ih,{max_dimension})':"
+        "force_original_aspect_ratio=decrease:force_divisible_by=2"
+    )
+
+
+def _ffmpeg_number(value: float) -> str:
+    return format(value, ".15g")
+
+
+def _validate_scan_configuration(
+    heartbeat_interval_seconds: float,
+    scene_change_threshold: float,
+    scene_min_interval_seconds: float,
+    decode_backend: str,
+) -> None:
+    values = (
+        heartbeat_interval_seconds,
+        scene_change_threshold,
+        scene_min_interval_seconds,
+    )
+    if (
+        any(not isinstance(value, int | float) for value in values)
+        or any(not float("-inf") < value < float("inf") for value in values)
+        or heartbeat_interval_seconds <= 0
+        or not 0 <= scene_change_threshold <= 1
+        or scene_min_interval_seconds <= 0
+        or decode_backend not in {"cpu", "nvdec"}
+    ):
+        msg = "Video Scan設定が不正です"
+        raise ValueError(msg)
+
+
+def _parse_named_showinfo(
+    line: str,
+) -> tuple[str, tuple[int, int | None, int, int]] | None:
+    if " n:" not in line:
+        return None
+    branch_match = _SHOWINFO_BRANCH_PATTERN.search(line)
+    pts_match = _SHOWINFO_PTS_PATTERN.search(line)
+    size_match = _SHOWINFO_SIZE_PATTERN.search(line)
+    if branch_match is None or pts_match is None or size_match is None:
+        return None
+    duration_match = _SHOWINFO_DURATION_PATTERN.search(line)
+    duration = int(duration_match.group(1)) if duration_match is not None else None
+    return (
+        branch_match.group("branch"),
+        (
+            int(pts_match.group(1)),
+            duration,
+            int(size_match.group(1)),
+            int(size_match.group(2)),
+        ),
+    )
+
+
+def _scanned_frames(
+    metadata: list[tuple[int, int | None, int, int]],
+    paths: tuple[Path, ...],
+    time_base: Fraction,
+) -> list[ScannedVideoFrame]:
+    return [
+        ScannedVideoFrame(
+            source_pts=pts,
+            duration_ts=duration,
+            time_base=time_base,
+            width=width,
+            height=height,
+            image_path=path,
+        )
+        for (pts, duration, width, height), path in zip(
+            metadata,
+            paths,
+            strict=True,
+        )
+    ]

--- a/src/video_selection/media/ffmpeg_media_runtime.py
+++ b/src/video_selection/media/ffmpeg_media_runtime.py
@@ -1,5 +1,6 @@
 """system FFmpeg/ffprobeをsemantic media operationへ閉じ込めるruntime。"""
 
+import hashlib
 import json
 import re
 import resource
@@ -9,6 +10,7 @@ from collections import deque
 from collections.abc import Iterator
 from fractions import Fraction
 from pathlib import Path
+from typing import NoReturn
 
 from ..models.decoded_video_frame import DecodedVideoFrame
 from ..models.embedded_subtitle import EmbeddedSubtitle
@@ -102,10 +104,17 @@ class FfmpegMediaRuntime:
                 MediaRuntimeFailureReason.FFMPEG_FFPROBE_VERSION_MISMATCH,
                 "FFmpegとffprobeは同一buildである必要があります",
             )
-        self._verify_capabilities()
+        capabilities = self._verify_capabilities()
         return MediaRuntimeIdentity(
             ffmpeg_version=ffmpeg_version,
             ffprobe_version=ffprobe_version,
+            build_capability_sha256=self._build_capability_sha256(
+                ffmpeg_version,
+                ffprobe_version,
+                ffmpeg_build,
+                ffprobe_build,
+                capabilities,
+            ),
         )
 
     def probe(self, media_path: Path) -> MediaProbe:
@@ -669,7 +678,7 @@ class FfmpegMediaRuntime:
             int(patch) if patch is not None else 0,
         )
 
-    def _verify_capabilities(self) -> None:
+    def _verify_capabilities(self) -> dict[str, object]:
         try:
             demuxers = self._read_capability_names("-demuxers")
             decoders = self._read_capability_names("-decoders")
@@ -692,16 +701,49 @@ class FfmpegMediaRuntime:
             probe_document = json.loads(probe.stdout)
         except (OSError, subprocess.CalledProcessError, json.JSONDecodeError) as error:
             self._raise_missing_capability(error)
+        if not isinstance(probe_document, dict):
+            self._raise_missing_capability()
+        program_version = probe_document.get("program_version")
         if (
             not _REQUIRED_DEMUXERS.issubset(demuxers)
             or not _REQUIRED_DECODERS.issubset(decoders)
             or not _REQUIRED_ENCODERS.issubset(encoders)
             or not _REQUIRED_MUXERS.issubset(muxers)
             or not _REQUIRED_FILTERS.issubset(filters)
-            or not isinstance(probe_document, dict)
-            or not isinstance(probe_document.get("program_version"), dict)
+            or not isinstance(program_version, dict)
         ):
             self._raise_missing_capability()
+        return {
+            "demuxers": sorted(demuxers),
+            "decoders": sorted(decoders),
+            "encoders": sorted(encoders),
+            "muxers": sorted(muxers),
+            "filters": sorted(filters),
+            "ffprobe_program_version": program_version,
+        }
+
+    @staticmethod
+    def _build_capability_sha256(
+        ffmpeg_version: str,
+        ffprobe_version: str,
+        ffmpeg_build: tuple[str, ...],
+        ffprobe_build: tuple[str, ...],
+        capabilities: dict[str, object],
+    ) -> str:
+        """raw build文字列を残さずcanonical identity digestを導出する。"""
+        canonical = json.dumps(
+            {
+                "ffmpeg_version": ffmpeg_version,
+                "ffprobe_version": ffprobe_version,
+                "ffmpeg_build": list(ffmpeg_build),
+                "ffprobe_build": list(ffprobe_build),
+                "capabilities": capabilities,
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(canonical).hexdigest()
 
     def _read_capability_names(self, option: str) -> frozenset[str]:
         completed = subprocess.run(
@@ -722,7 +764,7 @@ class FfmpegMediaRuntime:
         return frozenset(names)
 
     @staticmethod
-    def _raise_missing_capability(error: BaseException | None = None) -> None:
+    def _raise_missing_capability(error: BaseException | None = None) -> NoReturn:
         failure = MediaRuntimeError(
             MediaRuntimeFailureReason.MISSING_REQUIRED_DEMUXER_OR_DECODER,
             "必要なFFmpeg/ffprobe media能力がありません",

--- a/src/video_selection/media/ffprobe_parser.py
+++ b/src/video_selection/media/ffprobe_parser.py
@@ -65,6 +65,7 @@ def _parse_stream(raw_stream: object) -> MediaStream:
         language=language,
         is_default=disposition.get("default") == 1,
         is_forced=disposition.get("forced") == 1,
+        is_attached_picture=disposition.get("attached_pic") == 1,
     )
 
 

--- a/src/video_selection/models/candidate_moment.py
+++ b/src/video_selection/models/candidate_moment.py
@@ -1,0 +1,42 @@
+"""Video Source内のCandidate Moment。"""
+
+import math
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import Literal
+
+MomentEvidence = Literal["heartbeat", "scene"]
+
+
+@dataclass(frozen=True)
+class CandidateMoment:
+    """exact anchor、検出根拠、refinement結果を保持する。"""
+
+    identifier: str
+    source_pts: int
+    anchor_time: Fraction
+    timeline_segment_id: str
+    evidence: tuple[MomentEvidence, ...]
+    proxy_quality_score: float
+    frame_candidate_ids: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        """ID、時刻、根拠、画質を検証する。"""
+        if (
+            not self.identifier.startswith("mom_")
+            or len(self.identifier) != 68
+            or any(
+                character not in "0123456789abcdef" for character in self.identifier[4:]
+            )
+        ):
+            msg = "Candidate Moment IDにはmom_と64桁SHA-256が必要です"
+            raise ValueError(msg)
+        if self.anchor_time < 0 or not self.evidence:
+            msg = "Candidate Momentには時刻と検出根拠が必要です"
+            raise ValueError(msg)
+        if tuple(sorted(set(self.evidence))) != self.evidence:
+            msg = "Candidate Moment evidenceは重複のない順序付き値が必要です"
+            raise ValueError(msg)
+        if not math.isfinite(self.proxy_quality_score):
+            msg = "Candidate Momentには有限のproxy画質値が必要です"
+            raise ValueError(msg)

--- a/src/video_selection/models/candidate_moment_discovery.py
+++ b/src/video_selection/models/candidate_moment_discovery.py
@@ -1,0 +1,19 @@
+"""density適用後のCandidate Moment discovery。"""
+
+from dataclasses import dataclass
+
+from .candidate_moment import CandidateMoment
+
+
+@dataclass(frozen=True)
+class CandidateMomentDiscovery:
+    """理論上限と実際に発見されたMomentを保持する。"""
+
+    density_cap: int
+    moments: tuple[CandidateMoment, ...]
+
+    def __post_init__(self) -> None:
+        """実Moment数がdensity上限を超えないことを検証する。"""
+        if self.density_cap < 1 or len(self.moments) > self.density_cap:
+            msg = "Candidate Moment数がdensity上限と一致しません"
+            raise ValueError(msg)

--- a/src/video_selection/models/completed_stage_bundle.py
+++ b/src/video_selection/models/completed_stage_bundle.py
@@ -1,0 +1,12 @@
+"""検証済みCompleted Stageの成果物bundle。"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class CompletedStageBundle:
+    """JSON artifactと検証済みartifact rootをまとめる。"""
+
+    artifact: dict[str, object]
+    root: Path

--- a/src/video_selection/models/content_reject_reason.py
+++ b/src/video_selection/models/content_reject_reason.py
@@ -1,0 +1,19 @@
+"""Video Stageのstable Content Reject Reason。"""
+
+from enum import StrEnum
+
+
+class ContentRejectReason(StrEnum):
+    """Neutral Image Analysisがframeを除外する理由。"""
+
+    BLACKOUT = "blackout"
+    WHITEOUT = "whiteout"
+    SINGLE_TONE = "single_tone"
+    BLUR = "blur"
+    FADE_TRANSITION = "fade_transition"
+    TEMPORAL_TRANSITION = "temporal_transition"
+
+    @classmethod
+    def empty_breakdown(cls) -> dict[str, int]:
+        """全stable reasonを0件で初期化する。"""
+        return {reason.value: 0 for reason in cls}

--- a/src/video_selection/models/frame_candidate.py
+++ b/src/video_selection/models/frame_candidate.py
@@ -1,11 +1,58 @@
-"""walking skeletonのFrame Candidate。"""
+"""Video Source内のFrame Candidate。"""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from fractions import Fraction
+from pathlib import Path
+
+from .decoded_video_frame import DecodedVideoFrame
+from .neutral_image_analysis import NeutralImageAnalysis
 
 
 @dataclass(frozen=True)
 class FrameCandidate:
-    """fake MediaRuntimeが返す最小Frame Candidate。"""
+    """安定ID、exact時刻、proxy、Neutral Image Analysisを持つframe。"""
 
     identifier: str
     image_bytes: bytes
+    video_fingerprint: str | None = None
+    stream_index: int | None = None
+    source_pts: int | None = None
+    origin_pts: int | None = None
+    time_base: Fraction | None = None
+    video_time: Fraction | None = None
+    analysis: NeutralImageAnalysis | None = None
+    proxy_path: Path | None = None
+    decoded_frame: DecodedVideoFrame | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Video Stage由来candidateのidentityとtimingを検証する。"""
+        if self.video_fingerprint is None:
+            return
+        if (
+            len(self.video_fingerprint) != 64
+            or any(
+                character not in "0123456789abcdef"
+                for character in self.video_fingerprint
+            )
+            or not self.identifier.startswith("frm_")
+            or len(self.identifier) != 68
+        ):
+            msg = "Frame CandidateにはVideo Fingerprintとfrm_ IDが必要です"
+            raise ValueError(msg)
+        if any(
+            item is None
+            for item in (
+                self.stream_index,
+                self.source_pts,
+                self.origin_pts,
+                self.time_base,
+                self.video_time,
+                self.analysis,
+            )
+        ):
+            msg = "Video Stage由来Frame Candidateにはexact timingとanalysisが必要です"
+            raise ValueError(msg)

--- a/src/video_selection/models/frame_candidate_extraction.py
+++ b/src/video_selection/models/frame_candidate_extraction.py
@@ -1,0 +1,38 @@
+"""一つのVideo SourceのFrame Candidate抽出結果。"""
+
+from dataclasses import dataclass
+
+from .candidate_moment import CandidateMoment
+from .content_reject_reason import ContentRejectReason
+from .frame_candidate import FrameCandidate
+
+
+@dataclass(frozen=True)
+class FrameCandidateExtraction:
+    """Moment、共有Frame Candidate、抽出診断を保持する。"""
+
+    moments: tuple[CandidateMoment, ...]
+    candidates: tuple[FrameCandidate, ...]
+    native_frame_count: int
+    reject_breakdown: dict[str, int]
+    deduplicated_frame_count: int
+    zero_frame_moment_count: int
+
+    def __post_init__(self) -> None:
+        """件数とstable reason breakdownを検証する。"""
+        if set(self.reject_breakdown) != {
+            reason.value for reason in ContentRejectReason
+        }:
+            msg = "Frame Candidate抽出には全stable reject reasonが必要です"
+            raise ValueError(msg)
+        if any(
+            value < 0
+            for value in (
+                self.native_frame_count,
+                self.deduplicated_frame_count,
+                self.zero_frame_moment_count,
+                *self.reject_breakdown.values(),
+            )
+        ):
+            msg = "Frame Candidate抽出の診断件数は0以上である必要があります"
+            raise ValueError(msg)

--- a/src/video_selection/models/frame_candidate_extraction_metrics.py
+++ b/src/video_selection/models/frame_candidate_extraction_metrics.py
@@ -1,0 +1,19 @@
+"""Frame Candidate Extraction Stageのmetric。"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FrameCandidateExtractionMetrics:
+    """抽出時間、Moment、reject、dedupe、proxy容量を保持する。"""
+
+    wall_seconds: float
+    cpu_seconds: float
+    density_cap: int
+    actual_moment_count: int
+    native_frame_count: int
+    reject_breakdown: dict[str, int]
+    deduplicated_frame_count: int
+    zero_frame_moment_count: int
+    frame_candidate_count: int
+    frame_candidate_bytes: int

--- a/src/video_selection/models/heartbeat_proxy.py
+++ b/src/video_selection/models/heartbeat_proxy.py
@@ -1,0 +1,23 @@
+"""Video Scan StageのHeartbeat Proxy。"""
+
+import math
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class HeartbeatProxy:
+    """exact時刻、cache path、model-free画質評価を持つproxy。"""
+
+    source_pts: int
+    video_time: Fraction
+    proxy_path: Path
+    quality_score: float
+    eligible: bool
+
+    def __post_init__(self) -> None:
+        """timeline位置と画質値を検証する。"""
+        if self.video_time < 0 or not math.isfinite(self.quality_score):
+            msg = "Heartbeat Proxyには有効な時刻と画質値が必要です"
+            raise ValueError(msg)

--- a/src/video_selection/models/media_runtime_identity.py
+++ b/src/video_selection/models/media_runtime_identity.py
@@ -5,7 +5,17 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class MediaRuntimeIdentity:
-    """同一buildとして検証されたFFmpegとffprobeのversion。"""
+    """同一buildとして検証されたFFmpeg/ffprobeの解決済みidentity。"""
 
     ffmpeg_version: str
     ffprobe_version: str
+    build_capability_sha256: str
+
+    def __post_init__(self) -> None:
+        """build/capability digestが完全SHA-256であることを検証する。"""
+        if len(self.build_capability_sha256) != 64 or any(
+            character not in "0123456789abcdef"
+            for character in self.build_capability_sha256
+        ):
+            msg = "Media Runtime Identityには完全SHA-256が必要です"
+            raise ValueError(msg)

--- a/src/video_selection/models/media_stream.py
+++ b/src/video_selection/models/media_stream.py
@@ -24,3 +24,4 @@ class MediaStream:
     language: str | None
     is_default: bool
     is_forced: bool
+    is_attached_picture: bool = False

--- a/src/video_selection/models/native_video_scan.py
+++ b/src/video_selection/models/native_video_scan.py
@@ -1,0 +1,37 @@
+"""MediaRuntimeの一回のnative Video Scan結果。"""
+
+import math
+from dataclasses import dataclass
+from fractions import Fraction
+
+from .scanned_video_frame import ScannedVideoFrame
+
+
+@dataclass(frozen=True)
+class NativeVideoScan:
+    """timeline端点、heartbeat、scene、一回のdecode metricを保持する。"""
+
+    stream_index: int
+    origin_pts: int
+    last_frame_pts: int
+    last_frame_duration_ts: int | None
+    time_base: Fraction
+    heartbeats: tuple[ScannedVideoFrame, ...]
+    scene_frames: tuple[ScannedVideoFrame, ...]
+    wall_seconds: float
+    cpu_seconds: float
+    decode_pass_count: int
+
+    def __post_init__(self) -> None:
+        """scanが一回のdecodeと1件以上のheartbeatを持つことを検証する。"""
+        if (
+            self.time_base <= 0
+            or not self.heartbeats
+            or self.decode_pass_count != 1
+            or not math.isfinite(self.wall_seconds)
+            or not math.isfinite(self.cpu_seconds)
+            or self.wall_seconds < 0
+            or self.cpu_seconds < 0
+        ):
+            msg = "Native Video Scanのtimingまたはmetricが不正です"
+            raise ValueError(msg)

--- a/src/video_selection/models/neutral_image_analysis.py
+++ b/src/video_selection/models/neutral_image_analysis.py
@@ -1,0 +1,23 @@
+"""一つのnative frameのNeutral Image Analysis。"""
+
+from dataclasses import dataclass
+
+from .content_reject_reason import ContentRejectReason
+from .neutral_image_metrics import NeutralImageMetrics
+
+
+@dataclass(frozen=True)
+class NeutralImageAnalysis:
+    """model非依存のmetrics、特徴、採否を保持する。"""
+
+    source_pts: int
+    metrics: NeutralImageMetrics
+    quality_score: float
+    visual_feature: tuple[float, ...]
+    grayscale_signature: bytes
+    reject_reason: ContentRejectReason | None
+
+    @property
+    def eligible(self) -> bool:
+        """Frame Candidateとして利用可能かを返す。"""
+        return self.reject_reason is None

--- a/src/video_selection/models/neutral_image_metrics.py
+++ b/src/video_selection/models/neutral_image_metrics.py
@@ -1,0 +1,25 @@
+"""model-free Neutral Image Analysisの画像metrics。"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NeutralImageMetrics:
+    """画質、露出、情報量を表す数値metric。"""
+
+    blur_score: float
+    brightness: float
+    contrast: float
+    edge_density: float
+    color_richness: float
+    ui_density: float
+    action_intensity: float
+    visual_balance: float
+    dramatic_score: float
+    luminance_entropy: float
+    luminance_range: float
+    near_black_ratio: float
+    near_white_ratio: float
+    dominant_tone_ratio: float
+    information_score: float
+    visibility_score: float

--- a/src/video_selection/models/processing_stage.py
+++ b/src/video_selection/models/processing_stage.py
@@ -7,8 +7,24 @@ class ProcessingStage(StrEnum):
     """walking skeletonを構成する順序付きProcessing Stage。"""
 
     DISCOVER_VIDEO_SET = "discover-video-set"
+    SCAN_VIDEO = "scan-video"
     EXTRACT_FRAME_CANDIDATES = "extract-frame-candidates"
     COLLECT_CONTEXT = "collect-context"
     RESOLVE_MODELS = "resolve-models"
     ANNOTATE_CANDIDATES = "annotate-candidates"
     SELECT_IMAGES = "select-images"
+
+
+VIDEO_SET_STAGE_ORDER = (
+    ProcessingStage.DISCOVER_VIDEO_SET,
+    ProcessingStage.EXTRACT_FRAME_CANDIDATES,
+    ProcessingStage.COLLECT_CONTEXT,
+    ProcessingStage.RESOLVE_MODELS,
+    ProcessingStage.ANNOTATE_CANDIDATES,
+    ProcessingStage.SELECT_IMAGES,
+)
+
+VIDEO_STAGE_ORDER = (
+    ProcessingStage.SCAN_VIDEO,
+    ProcessingStage.EXTRACT_FRAME_CANDIDATES,
+)

--- a/src/video_selection/models/scanned_video_frame.py
+++ b/src/video_selection/models/scanned_video_frame.py
@@ -1,0 +1,23 @@
+"""Composite Video Scanが生成した一つのproxy frame。"""
+
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ScannedVideoFrame:
+    """exact source timingと一時または永続JPEG pathを保持する。"""
+
+    source_pts: int
+    duration_ts: int | None
+    time_base: Fraction
+    width: int
+    height: int
+    image_path: Path
+
+    def __post_init__(self) -> None:
+        """time baseとproxy寸法を検証する。"""
+        if self.time_base <= 0 or self.width < 1 or self.height < 1:
+            msg = "Scanned Video Frameには正のtime baseと寸法が必要です"
+            raise ValueError(msg)

--- a/src/video_selection/models/scene_signal.py
+++ b/src/video_selection/models/scene_signal.py
@@ -1,0 +1,21 @@
+"""Video Scan Stageのscene signal metadata。"""
+
+import math
+from dataclasses import dataclass
+from fractions import Fraction
+
+
+@dataclass(frozen=True)
+class SceneSignal:
+    """永続画像を持たないexact scene signal。"""
+
+    source_pts: int
+    video_time: Fraction
+    quality_score: float
+    eligible: bool
+
+    def __post_init__(self) -> None:
+        """timeline位置と画質値を検証する。"""
+        if self.video_time < 0 or not math.isfinite(self.quality_score):
+            msg = "Scene Signalには有効な時刻と画質値が必要です"
+            raise ValueError(msg)

--- a/src/video_selection/models/timeline_segment.py
+++ b/src/video_selection/models/timeline_segment.py
@@ -1,0 +1,28 @@
+"""Video Source timelineの半開区間。"""
+
+from dataclasses import dataclass
+from fractions import Fraction
+
+
+@dataclass(frozen=True)
+class TimelineSegment:
+    """gapやoverlapなく並ぶ一つのexact時間区間。"""
+
+    identifier: str
+    start: Fraction
+    end: Fraction
+
+    def __post_init__(self) -> None:
+        """IDと正の半開区間を検証する。"""
+        if (
+            not self.identifier.startswith("seg_")
+            or len(self.identifier) != 68
+            or any(
+                character not in "0123456789abcdef" for character in self.identifier[4:]
+            )
+        ):
+            msg = "Timeline Segment IDにはseg_と64桁SHA-256が必要です"
+            raise ValueError(msg)
+        if self.start < 0 or self.end <= self.start:
+            msg = "Timeline Segmentには正しい半開区間が必要です"
+            raise ValueError(msg)

--- a/src/video_selection/models/video_duration.py
+++ b/src/video_selection/models/video_duration.py
@@ -1,0 +1,17 @@
+"""exactなVideo Duration。"""
+
+from dataclasses import dataclass
+from fractions import Fraction
+
+
+@dataclass(frozen=True)
+class VideoDuration:
+    """0から動画終端までの正の既約分数秒。"""
+
+    seconds: Fraction
+
+    def __post_init__(self) -> None:
+        """正のdurationだけを受理する。"""
+        if self.seconds <= 0:
+            msg = "Video Durationは正である必要があります"
+            raise ValueError(msg)

--- a/src/video_selection/models/video_scan_metrics.py
+++ b/src/video_selection/models/video_scan_metrics.py
@@ -1,0 +1,22 @@
+"""Video Scan Stageの比較可能metric。"""
+
+from dataclasses import dataclass
+from fractions import Fraction
+
+
+@dataclass(frozen=True)
+class VideoScanMetrics:
+    """exact duration、処理時間、proxy coverageと容量を保持する。"""
+
+    input_duration: Fraction
+    wall_seconds: float
+    cpu_seconds: float
+    input_seconds_per_wall_second: float
+    decode_backend: str
+    decode_pass_count: int
+    heartbeat_count: int
+    heartbeat_bytes: int
+    heartbeat_max_gap_seconds: float
+    heartbeat_p95_gap_seconds: float
+    scene_signal_count: int
+    timeline_segment_count: int

--- a/src/video_selection/models/video_scan_result.py
+++ b/src/video_selection/models/video_scan_result.py
@@ -1,0 +1,20 @@
+"""Completed Video Scan Stageのdomain result。"""
+
+from dataclasses import dataclass
+
+from .heartbeat_proxy import HeartbeatProxy
+from .media_stream import MediaStream
+from .scene_signal import SceneSignal
+from .video_scan_metrics import VideoScanMetrics
+from .video_timeline import VideoTimeline
+
+
+@dataclass(frozen=True)
+class VideoScanResult:
+    """Primary stream、exact timeline、scan signal、metricを保持する。"""
+
+    primary_stream: MediaStream
+    timeline: VideoTimeline
+    heartbeats: tuple[HeartbeatProxy, ...]
+    scene_signals: tuple[SceneSignal, ...]
+    metrics: VideoScanMetrics

--- a/src/video_selection/models/video_stage_result.py
+++ b/src/video_selection/models/video_stage_result.py
@@ -1,0 +1,20 @@
+"""一つのVideo SourceのVideo Stage結果。"""
+
+from dataclasses import dataclass
+
+from .completed_stage import CompletedStage
+from .frame_candidate_extraction import FrameCandidateExtraction
+from .frame_candidate_extraction_metrics import FrameCandidateExtractionMetrics
+from .video_scan_result import VideoScanResult
+from .video_source import VideoSource
+
+
+@dataclass(frozen=True)
+class VideoStageResult:
+    """scanとcandidate抽出のCompleted Stageをまとめる。"""
+
+    source: VideoSource
+    scan: VideoScanResult
+    extraction: FrameCandidateExtraction
+    extraction_metrics: FrameCandidateExtractionMetrics
+    completed_stages: tuple[CompletedStage, ...]

--- a/src/video_selection/models/video_timeline.py
+++ b/src/video_selection/models/video_timeline.py
@@ -1,0 +1,43 @@
+"""一つのVideo Sourceのexact timeline。"""
+
+from dataclasses import dataclass
+from fractions import Fraction
+
+from .timeline_segment import TimelineSegment
+from .video_duration import VideoDuration
+
+
+@dataclass(frozen=True)
+class VideoTimeline:
+    """origin、duration、gapless segment列を保持する。"""
+
+    origin_pts: int
+    time_base: Fraction
+    duration: VideoDuration
+    segments: tuple[TimelineSegment, ...]
+
+    def __post_init__(self) -> None:
+        """segment列がtimeline全体を一度だけ覆うことを検証する。"""
+        if self.time_base <= 0 or not self.segments:
+            msg = "Video Timelineにはtime baseとsegmentが必要です"
+            raise ValueError(msg)
+        expected_start = Fraction(0)
+        for segment in self.segments:
+            if segment.start != expected_start:
+                msg = "Timeline Segmentにgapまたはoverlapがあります"
+                raise ValueError(msg)
+            expected_start = segment.end
+        if expected_start != self.duration.seconds:
+            msg = "Timeline SegmentがVideo Durationを覆っていません"
+            raise ValueError(msg)
+
+    def segment_at(self, video_time: Fraction) -> TimelineSegment:
+        """Video Timeを所有する半開区間を返す。"""
+        if video_time < 0 or video_time >= self.duration.seconds:
+            msg = "Video TimeがVideo Durationの外側です"
+            raise ValueError(msg)
+        return next(
+            segment
+            for segment in self.segments
+            if segment.start <= video_time < segment.end
+        )

--- a/src/video_selection/protocols/media_runtime.py
+++ b/src/video_selection/protocols/media_runtime.py
@@ -8,6 +8,8 @@ from ..models.decoded_video_frame import DecodedVideoFrame
 from ..models.embedded_subtitle import EmbeddedSubtitle
 from ..models.media_probe import MediaProbe
 from ..models.media_runtime_identity import MediaRuntimeIdentity
+from ..models.media_stream import MediaStream
+from ..models.native_video_scan import NativeVideoScan
 from ..models.pcm_audio_chunk import PcmAudioChunk
 
 
@@ -29,6 +31,28 @@ class MediaRuntime(Protocol):
     ) -> Iterator[DecodedVideoFrame]:
         """一回のdecodeからnative PTS順にproxy frameを返す。"""
 
+    def scan_video_frame_ranges(
+        self,
+        media_path: Path,
+        stream_index: int,
+        pts_ranges: tuple[tuple[int, int], ...],
+        max_dimension: int,
+    ) -> Iterator[DecodedVideoFrame]:
+        """複数の半開PTS range内にあるnative frameを一回で返す。"""
+
+    def scan_video(
+        self,
+        media_path: Path,
+        stream: MediaStream,
+        artifact_folder: Path,
+        *,
+        heartbeat_interval_seconds: float,
+        scene_change_threshold: float,
+        scene_min_interval_seconds: float,
+        decode_backend: str,
+    ) -> NativeVideoScan:
+        """一回のdecodeからheartbeat、scene、timeline端点を返す。"""
+
     def extract_video_frame(
         self,
         media_path: Path,
@@ -37,6 +61,15 @@ class MediaRuntime(Protocol):
         max_dimension: int,
     ) -> DecodedVideoFrame:
         """指定source PTSの一つのframeを返す。"""
+
+    def write_mjpeg_proxy(
+        self,
+        frame: DecodedVideoFrame,
+        output_path: Path,
+        *,
+        quality: int,
+    ) -> None:
+        """RGB frameをmetadataなしMJPEG proxyへ保存する。"""
 
     def scan_pcm_audio(
         self,

--- a/src/video_selection/protocols/video_stage_media_runtime.py
+++ b/src/video_selection/protocols/video_stage_media_runtime.py
@@ -1,0 +1,52 @@
+"""Video Stageが必要とするMediaRuntime port。"""
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Protocol
+
+from ..models.decoded_video_frame import DecodedVideoFrame
+from ..models.media_probe import MediaProbe
+from ..models.media_runtime_identity import MediaRuntimeIdentity
+from ..models.media_stream import MediaStream
+from ..models.native_video_scan import NativeVideoScan
+
+
+class VideoStageMediaRuntime(Protocol):
+    """Video ScanとFrame Refinementに限定したexternal media境界。"""
+
+    def preflight(self) -> MediaRuntimeIdentity:
+        """system media runtime identityを解決する。"""
+
+    def probe(self, media_path: Path) -> MediaProbe:
+        """media stream metadataを返す。"""
+
+    def scan_video(
+        self,
+        media_path: Path,
+        stream: MediaStream,
+        artifact_folder: Path,
+        *,
+        heartbeat_interval_seconds: float,
+        scene_change_threshold: float,
+        scene_min_interval_seconds: float,
+        decode_backend: str,
+    ) -> NativeVideoScan:
+        """一回のdecodeからVideo Scan artifactを返す。"""
+
+    def scan_video_frame_ranges(
+        self,
+        media_path: Path,
+        stream_index: int,
+        pts_ranges: tuple[tuple[int, int], ...],
+        max_dimension: int,
+    ) -> Iterator[DecodedVideoFrame]:
+        """refinement range内のnative frameを返す。"""
+
+    def write_mjpeg_proxy(
+        self,
+        frame: DecodedVideoFrame,
+        output_path: Path,
+        *,
+        quality: int,
+    ) -> None:
+        """選抜済みframeをMJPEG proxyへ保存する。"""

--- a/src/video_selection/services/analyze_neutral_images.py
+++ b/src/video_selection/services/analyze_neutral_images.py
@@ -1,7 +1,9 @@
 """native RGB frameをmodel-freeに一括解析する。"""
 
 import math
+from collections.abc import Iterable
 from dataclasses import replace
+from fractions import Fraction
 
 import cv2
 import numpy as np
@@ -24,19 +26,32 @@ _QUALITY_WEIGHTS = {
     "dramatic_score": 0.05,
 }
 
+_FrameTiming = tuple[int, int, int | None, Fraction]
+
 
 def analyze_neutral_images(
-    frames: tuple[DecodedVideoFrame, ...],
+    frames: Iterable[DecodedVideoFrame],
 ) -> tuple[NeutralImageAnalysis, ...]:
     """動画内分布と前後関係を使いnative frameを解析する。"""
-    if not frames:
+    frame_timings: list[_FrameTiming] = []
+    raw_rows: list[tuple[dict[str, float], np.ndarray, bytes]] = []
+    for frame in frames:
+        frame_timings.append(
+            (
+                frame.stream_index,
+                frame.pts,
+                frame.duration_ts,
+                frame.time_base,
+            )
+        )
+        raw_rows.append(_measure_frame(frame))
+    if not raw_rows:
         return ()
-    raw_rows = [_measure_frame(frame) for frame in frames]
     information_scores = _information_scores(raw_rows)
     visibility_scores = [_visibility_score(row) for row in raw_rows]
     analyses = [
         NeutralImageAnalysis(
-            source_pts=frame.pts,
+            source_pts=frame_timings[index][1],
             metrics=_build_metrics(
                 raw,
                 information_scores[index],
@@ -47,11 +62,9 @@ def analyze_neutral_images(
             grayscale_signature=signature,
             reject_reason=_absolute_reject_reason(raw),
         )
-        for index, (frame, (raw, feature, signature)) in enumerate(
-            zip(frames, raw_rows, strict=True)
-        )
+        for index, (raw, feature, signature) in enumerate(raw_rows)
     ]
-    _apply_temporal_rejections(analyses, frames)
+    _apply_temporal_rejections(analyses, frame_timings)
     _apply_relative_fade_rejections(analyses)
     return tuple(analyses)
 
@@ -222,12 +235,12 @@ def _absolute_reject_reason(
 
 def _apply_temporal_rejections(
     analyses: list[NeutralImageAnalysis],
-    frames: tuple[DecodedVideoFrame, ...],
+    frame_timings: list[_FrameTiming],
 ) -> None:
     for index in range(1, len(analyses) - 1):
         if not (
-            _are_adjacent(frames[index - 1], frames[index])
-            and _are_adjacent(frames[index], frames[index + 1])
+            _are_adjacent(frame_timings[index - 1], frame_timings[index])
+            and _are_adjacent(frame_timings[index], frame_timings[index + 1])
         ):
             continue
         previous = analyses[index - 1]
@@ -255,15 +268,19 @@ def _apply_temporal_rejections(
 
 
 def _are_adjacent(
-    previous: DecodedVideoFrame,
-    following: DecodedVideoFrame,
+    previous: _FrameTiming,
+    following: _FrameTiming,
 ) -> bool:
+    previous_stream, previous_pts, previous_duration, previous_time_base = previous
+    following_stream, following_pts, _following_duration, following_time_base = (
+        following
+    )
     return (
-        previous.stream_index == following.stream_index
-        and previous.time_base == following.time_base
-        and previous.duration_ts is not None
-        and previous.duration_ts > 0
-        and previous.pts + previous.duration_ts == following.pts
+        previous_stream == following_stream
+        and previous_time_base == following_time_base
+        and previous_duration is not None
+        and previous_duration > 0
+        and previous_pts + previous_duration == following_pts
     )
 
 

--- a/src/video_selection/services/analyze_neutral_images.py
+++ b/src/video_selection/services/analyze_neutral_images.py
@@ -11,7 +11,7 @@ from ..models.decoded_video_frame import DecodedVideoFrame
 from ..models.neutral_image_analysis import NeutralImageAnalysis
 from ..models.neutral_image_metrics import NeutralImageMetrics
 
-NEUTRAL_ANALYSIS_ALGORITHM_VERSION = "neutral-image-analysis-v1"
+NEUTRAL_ANALYSIS_ALGORITHM_VERSION = "neutral-image-analysis-v2"
 BLUR_REJECT_VARIANCE_MIN = 12.0
 _QUALITY_WEIGHTS = {
     "blur_score": 0.165,
@@ -51,7 +51,7 @@ def analyze_neutral_images(
             zip(frames, raw_rows, strict=True)
         )
     ]
-    _apply_temporal_rejections(analyses)
+    _apply_temporal_rejections(analyses, frames)
     _apply_relative_fade_rejections(analyses)
     return tuple(analyses)
 
@@ -220,8 +220,16 @@ def _absolute_reject_reason(
     return None
 
 
-def _apply_temporal_rejections(analyses: list[NeutralImageAnalysis]) -> None:
+def _apply_temporal_rejections(
+    analyses: list[NeutralImageAnalysis],
+    frames: tuple[DecodedVideoFrame, ...],
+) -> None:
     for index in range(1, len(analyses) - 1):
+        if not (
+            _are_adjacent(frames[index - 1], frames[index])
+            and _are_adjacent(frames[index], frames[index + 1])
+        ):
+            continue
         previous = analyses[index - 1]
         current = analyses[index]
         following = analyses[index + 1]
@@ -244,6 +252,19 @@ def _apply_temporal_rejections(analyses: list[NeutralImageAnalysis]) -> None:
                 current,
                 reject_reason=ContentRejectReason.TEMPORAL_TRANSITION,
             )
+
+
+def _are_adjacent(
+    previous: DecodedVideoFrame,
+    following: DecodedVideoFrame,
+) -> bool:
+    return (
+        previous.stream_index == following.stream_index
+        and previous.time_base == following.time_base
+        and previous.duration_ts is not None
+        and previous.duration_ts > 0
+        and previous.pts + previous.duration_ts == following.pts
+    )
 
 
 def _apply_relative_fade_rejections(analyses: list[NeutralImageAnalysis]) -> None:

--- a/src/video_selection/services/analyze_neutral_images.py
+++ b/src/video_selection/services/analyze_neutral_images.py
@@ -1,0 +1,319 @@
+"""native RGB frameをmodel-freeに一括解析する。"""
+
+import math
+from dataclasses import replace
+
+import cv2
+import numpy as np
+
+from ..models.content_reject_reason import ContentRejectReason
+from ..models.decoded_video_frame import DecodedVideoFrame
+from ..models.neutral_image_analysis import NeutralImageAnalysis
+from ..models.neutral_image_metrics import NeutralImageMetrics
+
+NEUTRAL_ANALYSIS_ALGORITHM_VERSION = "neutral-image-analysis-v1"
+BLUR_REJECT_VARIANCE_MIN = 12.0
+_QUALITY_WEIGHTS = {
+    "blur_score": 0.165,
+    "contrast": 0.145,
+    "color_richness": 0.06,
+    "visual_balance": 0.10,
+    "edge_density": 0.13,
+    "action_intensity": 0.125,
+    "ui_density": 0.225,
+    "dramatic_score": 0.05,
+}
+
+
+def analyze_neutral_images(
+    frames: tuple[DecodedVideoFrame, ...],
+) -> tuple[NeutralImageAnalysis, ...]:
+    """動画内分布と前後関係を使いnative frameを解析する。"""
+    if not frames:
+        return ()
+    raw_rows = [_measure_frame(frame) for frame in frames]
+    information_scores = _information_scores(raw_rows)
+    visibility_scores = [_visibility_score(row) for row in raw_rows]
+    analyses = [
+        NeutralImageAnalysis(
+            source_pts=frame.pts,
+            metrics=_build_metrics(
+                raw,
+                information_scores[index],
+                visibility_scores[index],
+            ),
+            quality_score=_quality_score(raw),
+            visual_feature=tuple(float(value) for value in feature),
+            grayscale_signature=signature,
+            reject_reason=_absolute_reject_reason(raw),
+        )
+        for index, (frame, (raw, feature, signature)) in enumerate(
+            zip(frames, raw_rows, strict=True)
+        )
+    ]
+    _apply_temporal_rejections(analyses)
+    _apply_relative_fade_rejections(analyses)
+    return tuple(analyses)
+
+
+def _measure_frame(
+    frame: DecodedVideoFrame,
+) -> tuple[dict[str, float], np.ndarray, bytes]:
+    rgb = np.frombuffer(frame.pixels, dtype=np.uint8).reshape(
+        frame.height,
+        frame.width,
+        3,
+    )
+    gray = cv2.cvtColor(rgb, cv2.COLOR_RGB2GRAY)
+    hsv = cv2.cvtColor(rgb, cv2.COLOR_RGB2HSV)
+    gray_flat = gray.reshape(-1)
+    gray_size = gray.size
+    gray_hist = np.bincount(gray_flat, minlength=256).astype(np.float32)
+    gray_prob = gray_hist / gray_size
+    non_zero_prob = gray_prob[gray_prob > 0]
+    laplacian = cv2.Laplacian(gray, cv2.CV_32F)
+    _, contrast_std = cv2.meanStdDev(gray)
+    edges = cv2.Canny(gray, 50, 150)
+    sobel_x = cv2.Sobel(gray, cv2.CV_32F, 1, 0)
+    _, saturation_std = cv2.meanStdDev(hsv[:, :, 1])
+    sobel_y = cv2.Sobel(gray, cv2.CV_32F, 0, 1)
+    magnitude, angle = cv2.cartToPolar(sobel_x, sobel_y, angleInDegrees=True)
+    _, action_std = cv2.meanStdDev(
+        cv2.filter2D(
+            gray,
+            -1,
+            np.array([[-1, 0, 1], [-2, 0, 2], [-1, 0, 1]]),
+        )
+    )
+    high_saturation = hsv[:, :, 1] > 180
+    high_value = hsv[:, :, 2] > 180
+    luminance_p5, luminance_p95 = np.percentile(gray_flat, [5, 95])
+    dominant_tone_hist = np.bincount(gray_flat // 16, minlength=16)
+    brightness = float(cv2.mean(gray)[0])
+    raw = {
+        "blur_score": float(laplacian.var()),
+        "brightness": brightness,
+        "contrast": float(contrast_std[0][0]),
+        "edge_density": cv2.countNonZero(edges) / gray_size,
+        "color_richness": float(saturation_std[0][0]),
+        "ui_density": cv2.norm(sobel_x, cv2.NORM_L1) / gray_size,
+        "action_intensity": float(action_std[0][0]),
+        "visual_balance": float(max(0, 100 - abs(brightness - 128) * 0.5)),
+        "dramatic_score": float(
+            cv2.countNonZero((high_saturation & high_value).astype(np.uint8))
+            / gray_size
+            * 1000
+        ),
+        "luminance_entropy": float(-(non_zero_prob * np.log2(non_zero_prob)).sum()),
+        "luminance_range": float(luminance_p95 - luminance_p5),
+        "near_black_ratio": float(np.mean(gray_flat <= 12)),
+        "near_white_ratio": float(np.mean(gray_flat >= 243)),
+        "dominant_tone_ratio": float(dominant_tone_hist.max() / gray_size),
+    }
+    hsv_hist = cv2.calcHist([hsv], [0, 1], None, [8, 8], [0, 180, 0, 256])
+    luminance_hist = cv2.calcHist([gray], [0], None, [32], [0, 256])
+    edge_hist, _ = np.histogram(
+        angle,
+        bins=16,
+        range=(0, 360),
+        weights=magnitude,
+    )
+    feature = _safe_l2_normalize(
+        np.concatenate(
+            (
+                cv2.normalize(hsv_hist, hsv_hist).flatten(),
+                cv2.normalize(luminance_hist, luminance_hist).flatten(),
+                edge_hist.astype(np.float32),
+            )
+        ).astype(np.float32)
+    )
+    signature = cv2.resize(gray, (64, 36), interpolation=cv2.INTER_AREA).tobytes()
+    return raw, feature, signature
+
+
+def _information_scores(
+    rows: list[tuple[dict[str, float], np.ndarray, bytes]],
+) -> list[float]:
+    weights = {
+        "contrast": 0.20,
+        "edge_density": 0.25,
+        "action_intensity": 0.15,
+        "luminance_entropy": 0.20,
+        "luminance_range": 0.20,
+    }
+    sorted_values = {
+        name: np.sort(np.asarray([row[0][name] for row in rows], dtype=np.float32))
+        for name in weights
+    }
+    return [
+        float(
+            sum(
+                weight * _percentile_rank(raw[name], sorted_values[name])
+                for name, weight in weights.items()
+            )
+        )
+        for raw, _feature, _signature in rows
+    ]
+
+
+def _visibility_score(
+    row: tuple[dict[str, float], np.ndarray, bytes],
+) -> float:
+    raw = row[0]
+    return float(
+        0.30 * min(1.0, raw["luminance_range"] / 32.0)
+        + 0.25 * min(1.0, raw["luminance_entropy"] / 1.5)
+        + 0.20 * min(1.0, raw["edge_density"] / 0.08)
+        + 0.15 * min(1.0, raw["contrast"] / 12.0)
+        + 0.10 * (1.0 - max(raw["near_black_ratio"], raw["near_white_ratio"]))
+    )
+
+
+def _build_metrics(
+    raw: dict[str, float],
+    information_score: float,
+    visibility_score: float,
+) -> NeutralImageMetrics:
+    return NeutralImageMetrics(
+        blur_score=raw["blur_score"],
+        brightness=raw["brightness"],
+        contrast=raw["contrast"],
+        edge_density=raw["edge_density"],
+        color_richness=raw["color_richness"],
+        ui_density=raw["ui_density"],
+        action_intensity=raw["action_intensity"],
+        visual_balance=raw["visual_balance"],
+        dramatic_score=raw["dramatic_score"],
+        luminance_entropy=raw["luminance_entropy"],
+        luminance_range=raw["luminance_range"],
+        near_black_ratio=raw["near_black_ratio"],
+        near_white_ratio=raw["near_white_ratio"],
+        dominant_tone_ratio=raw["dominant_tone_ratio"],
+        information_score=information_score,
+        visibility_score=visibility_score,
+    )
+
+
+def _absolute_reject_reason(
+    raw: dict[str, float],
+) -> ContentRejectReason | None:
+    if (
+        raw["near_black_ratio"] >= 0.98
+        and raw["luminance_entropy"] <= 0.6
+        and raw["luminance_range"] <= 16
+    ):
+        return ContentRejectReason.BLACKOUT
+    if (
+        raw["near_white_ratio"] >= 0.98
+        and raw["luminance_entropy"] <= 0.6
+        and raw["luminance_range"] <= 16
+    ):
+        return ContentRejectReason.WHITEOUT
+    if (
+        raw["dominant_tone_ratio"] >= 0.97
+        and raw["luminance_range"] <= 20
+        and raw["contrast"] <= 10
+    ):
+        return ContentRejectReason.SINGLE_TONE
+    if raw["blur_score"] < BLUR_REJECT_VARIANCE_MIN and raw["edge_density"] < 0.03:
+        return ContentRejectReason.BLUR
+    return None
+
+
+def _apply_temporal_rejections(analyses: list[NeutralImageAnalysis]) -> None:
+    for index in range(1, len(analyses) - 1):
+        previous = analyses[index - 1]
+        current = analyses[index]
+        following = analyses[index + 1]
+        if any(
+            item.reject_reason is not None for item in (previous, current, following)
+        ):
+            continue
+        similarity = float(
+            np.clip(
+                np.dot(previous.visual_feature, following.visual_feature),
+                -1.0,
+                1.0,
+            )
+        )
+        if similarity >= 0.92 and current.metrics.visibility_score + 0.15 < min(
+            previous.metrics.visibility_score,
+            following.metrics.visibility_score,
+        ):
+            analyses[index] = replace(
+                current,
+                reject_reason=ContentRejectReason.TEMPORAL_TRANSITION,
+            )
+
+
+def _apply_relative_fade_rejections(analyses: list[NeutralImageAnalysis]) -> None:
+    eligible = [item for item in analyses if item.reject_reason is None]
+    if len(eligible) < 3:
+        return
+    brightness = np.asarray(
+        [item.metrics.brightness for item in eligible],
+        dtype=np.float32,
+    )
+    visibility = np.asarray(
+        [item.metrics.visibility_score for item in eligible],
+        dtype=np.float32,
+    )
+    luminance_range = np.asarray(
+        [item.metrics.luminance_range for item in eligible],
+        dtype=np.float32,
+    )
+    brightness_p10, brightness_p90 = np.percentile(brightness, [10, 90])
+    visibility_median = float(np.percentile(visibility, 50))
+    range_p25 = float(np.percentile(luminance_range, 25))
+    for index, analysis in enumerate(analyses):
+        metrics = analysis.metrics
+        if analysis.reject_reason is not None:
+            continue
+        is_exposure_extreme = (
+            metrics.brightness < brightness_p10 or metrics.brightness > brightness_p90
+        )
+        if (
+            is_exposure_extreme
+            and metrics.visibility_score + 0.20 < visibility_median
+            and metrics.luminance_range < max(24.0, range_p25 * 0.75)
+        ):
+            analyses[index] = replace(
+                analysis,
+                reject_reason=ContentRejectReason.FADE_TRANSITION,
+            )
+
+
+def _quality_score(raw: dict[str, float]) -> float:
+    normalized = {
+        "blur_score": _sigmoid(raw["blur_score"], 500, 0.005),
+        "contrast": _sigmoid(raw["contrast"], 50, 0.1),
+        "color_richness": _sigmoid(raw["color_richness"], 40, 0.1),
+        "edge_density": min(1.0, raw["edge_density"] * 5.0),
+        "dramatic_score": min(1.0, raw["dramatic_score"] / 100.0),
+        "visual_balance": raw["visual_balance"] / 100.0,
+        "action_intensity": _sigmoid(raw["action_intensity"], 30, 0.2),
+        "ui_density": _sigmoid(raw["ui_density"], 10, 0.3),
+    }
+    return float(
+        sum(normalized[name] * weight for name, weight in _QUALITY_WEIGHTS.items())
+    )
+
+
+def _sigmoid(value: float, center: float, steepness: float) -> float:
+    try:
+        return 1 / (1 + math.exp(-steepness * (value - center)))
+    except OverflowError:
+        return 1.0 if value > center else 0.0
+
+
+def _percentile_rank(value: float, sorted_values: np.ndarray) -> float:
+    left = np.searchsorted(sorted_values, value, side="left")
+    right = np.searchsorted(sorted_values, value, side="right")
+    return float((left + right) / 2.0 / sorted_values.size)
+
+
+def _safe_l2_normalize(values: np.ndarray) -> np.ndarray:
+    norm = float(np.linalg.norm(values))
+    if not math.isfinite(norm) or norm <= 0:
+        return np.zeros_like(values)
+    return values / norm

--- a/src/video_selection/services/build_exact_timeline.py
+++ b/src/video_selection/services/build_exact_timeline.py
@@ -1,0 +1,84 @@
+"""decoded frame timingからexact timelineを構築する。"""
+
+from fractions import Fraction
+from itertools import pairwise
+
+from ..models.media_stream import MediaStream
+from ..models.timeline_segment import TimelineSegment
+from ..models.video_duration import VideoDuration
+from ..models.video_timeline import VideoTimeline
+from .build_video_entity_id import build_video_entity_id
+
+_SEGMENT_ID_ALGORITHM = "timeline-segment-id-v1"
+
+
+def build_exact_timeline(
+    *,
+    video_fingerprint: str,
+    stream: MediaStream,
+    origin_pts: int,
+    last_frame_pts: int,
+    last_frame_duration_ts: int | None,
+    scene_pts: tuple[int, ...],
+) -> VideoTimeline:
+    """frame終端を優先しscene境界でgapless segmentを作る。"""
+    if stream.time_base is None:
+        msg = "Primary Video Streamにexact time baseが必要です"
+        raise ValueError(msg)
+    end_pts = _resolve_end_pts(
+        stream,
+        last_frame_pts,
+        last_frame_duration_ts,
+    )
+    duration_seconds = Fraction(end_pts - origin_pts) * stream.time_base
+    duration = VideoDuration(duration_seconds)
+    scene_times = {
+        Fraction(scene_pts_value - origin_pts) * stream.time_base
+        for scene_pts_value in scene_pts
+    }
+    boundaries = (
+        Fraction(0),
+        *sorted(
+            scene_time
+            for scene_time in scene_times
+            if 0 < scene_time < duration.seconds
+        ),
+        duration.seconds,
+    )
+    segments = tuple(
+        TimelineSegment(
+            identifier=build_video_entity_id(
+                "seg",
+                _SEGMENT_ID_ALGORITHM,
+                video_fingerprint,
+                start,
+                end,
+            ),
+            start=start,
+            end=end,
+        )
+        for start, end in pairwise(boundaries)
+    )
+    return VideoTimeline(
+        origin_pts=origin_pts,
+        time_base=stream.time_base,
+        duration=duration,
+        segments=segments,
+    )
+
+
+def _resolve_end_pts(
+    stream: MediaStream,
+    last_frame_pts: int,
+    last_frame_duration_ts: int | None,
+) -> int:
+    if last_frame_duration_ts is not None and last_frame_duration_ts > 0:
+        return last_frame_pts + last_frame_duration_ts
+    if (
+        stream.start_pts is not None
+        and stream.duration_ts is not None
+        and stream.duration_ts > 0
+    ):
+        return stream.start_pts + stream.duration_ts
+    msg = "exactな正のVideo Duration終端を得られません"
+    raise ValueError(msg)

--- a/src/video_selection/services/build_refinement_pts_ranges.py
+++ b/src/video_selection/services/build_refinement_pts_ranges.py
@@ -1,0 +1,44 @@
+"""Candidate Moment windowをsource PTS rangeへ変換する。"""
+
+import math
+from fractions import Fraction
+
+from ..models.candidate_moment import CandidateMoment
+from ..models.video_timeline import VideoTimeline
+
+
+def build_refinement_pts_ranges(
+    timeline: VideoTimeline,
+    moments: tuple[CandidateMoment, ...],
+    radius_seconds: float,
+) -> tuple[tuple[int, int], ...]:
+    """clamp済み半開Video Time windowをmerge済みPTS rangeで返す。"""
+    if not math.isfinite(radius_seconds) or radius_seconds < 0:
+        msg = "Frame Refinement半径は0以上の有限値である必要があります"
+        raise ValueError(msg)
+    radius = Fraction(str(radius_seconds))
+    ranges: list[tuple[int, int]] = []
+    for moment in moments:
+        if radius == 0:
+            ranges.append((moment.source_pts, moment.source_pts + 1))
+            continue
+        start_time = max(Fraction(0), moment.anchor_time - radius)
+        end_time = min(timeline.duration.seconds, moment.anchor_time + radius)
+        start_pts = timeline.origin_pts + _ceil_fraction(
+            start_time / timeline.time_base
+        )
+        end_pts = timeline.origin_pts + _ceil_fraction(end_time / timeline.time_base)
+        if start_pts < end_pts:
+            ranges.append((start_pts, end_pts))
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(ranges):
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+            continue
+        previous_start, previous_end = merged[-1]
+        merged[-1] = (previous_start, max(previous_end, end))
+    return tuple(merged)
+
+
+def _ceil_fraction(value: Fraction) -> int:
+    return -(-value.numerator // value.denominator)

--- a/src/video_selection/services/build_stage_fingerprint.py
+++ b/src/video_selection/services/build_stage_fingerprint.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping, Sequence
 
 from ..models.processing_stage import ProcessingStage
 from ..models.stage_fingerprint import StageFingerprint
+from .stage_version import stage_version
 
 
 def build_stage_fingerprint(
@@ -17,7 +18,7 @@ def build_stage_fingerprint(
     normalized = json.dumps(
         {
             "stage": stage.value,
-            "stage_version": "walking-skeleton-0",
+            "stage_version": stage_version(stage),
             "upstream": [item.value for item in upstream_fingerprints],
             "input": semantic_input,
         },

--- a/src/video_selection/services/build_video_entity_id.py
+++ b/src/video_selection/services/build_video_entity_id.py
@@ -1,0 +1,36 @@
+"""Video Stage entityの安定IDを導出する。"""
+
+import hashlib
+import json
+from fractions import Fraction
+from typing import Literal
+
+EntityPrefix = Literal["seg", "mom", "frm"]
+
+
+def build_video_entity_id(
+    prefix: EntityPrefix,
+    algorithm: str,
+    video_fingerprint: str,
+    *times: Fraction,
+) -> str:
+    """canonical JSONからprefix付きSHA-256 IDを返す。"""
+    if len(video_fingerprint) != 64 or any(
+        character not in "0123456789abcdef" for character in video_fingerprint
+    ):
+        msg = "Video Fingerprintには64桁のSHA-256が必要です"
+        raise ValueError(msg)
+    normalized = json.dumps(
+        {
+            "algorithm": algorithm,
+            "times": [
+                {"denominator": item.denominator, "numerator": item.numerator}
+                for item in times
+            ],
+            "video_fingerprint": video_fingerprint,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return f"{prefix}_{hashlib.sha256(normalized).hexdigest()}"

--- a/src/video_selection/services/build_video_scan_result.py
+++ b/src/video_selection/services/build_video_scan_result.py
@@ -34,15 +34,10 @@ def build_video_scan_result(
         scene_pts=tuple(item.source_pts for item in native_scan.scene_frames),
     )
     heartbeat_analyses = analyze_neutral_images(
-        tuple(
-            _decode_proxy(item, primary_stream.index) for item in native_scan.heartbeats
-        )
+        _decode_proxy(item, primary_stream.index) for item in native_scan.heartbeats
     )
     scene_analyses = analyze_neutral_images(
-        tuple(
-            _decode_proxy(item, primary_stream.index)
-            for item in native_scan.scene_frames
-        )
+        _decode_proxy(item, primary_stream.index) for item in native_scan.scene_frames
     )
     heartbeats = tuple(
         HeartbeatProxy(

--- a/src/video_selection/services/build_video_scan_result.py
+++ b/src/video_selection/services/build_video_scan_result.py
@@ -1,0 +1,137 @@
+"""Native Video ScanをCompleted Stage domain resultへ変換する。"""
+
+from fractions import Fraction
+
+import cv2
+import numpy as np
+
+from ..models.decoded_video_frame import DecodedVideoFrame
+from ..models.heartbeat_proxy import HeartbeatProxy
+from ..models.media_stream import MediaStream
+from ..models.native_video_scan import NativeVideoScan
+from ..models.scanned_video_frame import ScannedVideoFrame
+from ..models.scene_signal import SceneSignal
+from ..models.video_scan_metrics import VideoScanMetrics
+from ..models.video_scan_result import VideoScanResult
+from .analyze_neutral_images import analyze_neutral_images
+from .build_exact_timeline import build_exact_timeline
+
+
+def build_video_scan_result(
+    *,
+    native_scan: NativeVideoScan,
+    primary_stream: MediaStream,
+    video_fingerprint: str,
+    decode_backend: str,
+) -> VideoScanResult:
+    """proxyを解析してexact timelineと比較可能metricを構築する。"""
+    timeline = build_exact_timeline(
+        video_fingerprint=video_fingerprint,
+        stream=primary_stream,
+        origin_pts=native_scan.origin_pts,
+        last_frame_pts=native_scan.last_frame_pts,
+        last_frame_duration_ts=native_scan.last_frame_duration_ts,
+        scene_pts=tuple(item.source_pts for item in native_scan.scene_frames),
+    )
+    heartbeat_analyses = analyze_neutral_images(
+        tuple(
+            _decode_proxy(item, primary_stream.index) for item in native_scan.heartbeats
+        )
+    )
+    scene_analyses = analyze_neutral_images(
+        tuple(
+            _decode_proxy(item, primary_stream.index)
+            for item in native_scan.scene_frames
+        )
+    )
+    heartbeats = tuple(
+        HeartbeatProxy(
+            source_pts=frame.source_pts,
+            video_time=_video_time(frame.source_pts, native_scan),
+            proxy_path=frame.image_path,
+            quality_score=analysis.quality_score,
+            eligible=analysis.eligible,
+        )
+        for frame, analysis in zip(
+            native_scan.heartbeats,
+            heartbeat_analyses,
+            strict=True,
+        )
+    )
+    scene_signals = tuple(
+        SceneSignal(
+            source_pts=frame.source_pts,
+            video_time=_video_time(frame.source_pts, native_scan),
+            quality_score=analysis.quality_score,
+            eligible=analysis.eligible,
+        )
+        for frame, analysis in zip(
+            native_scan.scene_frames,
+            scene_analyses,
+            strict=True,
+        )
+        if 0 <= _video_time(frame.source_pts, native_scan) < timeline.duration.seconds
+    )
+    gaps = [
+        float(right.video_time - left.video_time)
+        for left, right in zip(heartbeats, heartbeats[1:], strict=False)
+    ]
+    input_seconds = float(timeline.duration.seconds)
+    metrics = VideoScanMetrics(
+        input_duration=timeline.duration.seconds,
+        wall_seconds=native_scan.wall_seconds,
+        cpu_seconds=native_scan.cpu_seconds,
+        input_seconds_per_wall_second=(
+            input_seconds / native_scan.wall_seconds
+            if native_scan.wall_seconds > 0
+            else 0.0
+        ),
+        decode_backend=decode_backend,
+        decode_pass_count=native_scan.decode_pass_count,
+        heartbeat_count=len(heartbeats),
+        heartbeat_bytes=sum(item.proxy_path.stat().st_size for item in heartbeats),
+        heartbeat_max_gap_seconds=max(gaps, default=0.0),
+        heartbeat_p95_gap_seconds=_percentile_95(gaps),
+        scene_signal_count=len(scene_signals),
+        timeline_segment_count=len(timeline.segments),
+    )
+    return VideoScanResult(
+        primary_stream=primary_stream,
+        timeline=timeline,
+        heartbeats=heartbeats,
+        scene_signals=scene_signals,
+        metrics=metrics,
+    )
+
+
+def _decode_proxy(
+    frame: ScannedVideoFrame,
+    stream_index: int,
+) -> DecodedVideoFrame:
+    encoded = np.frombuffer(frame.image_path.read_bytes(), dtype=np.uint8)
+    bgr = cv2.imdecode(encoded, cv2.IMREAD_COLOR)
+    if bgr is None:
+        msg = "Video Scan proxy画像をdecodeできません"
+        raise ValueError(msg)
+    rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+    height, width = rgb.shape[:2]
+    return DecodedVideoFrame(
+        stream_index=stream_index,
+        pts=frame.source_pts,
+        duration_ts=frame.duration_ts,
+        time_base=frame.time_base,
+        width=width,
+        height=height,
+        pixel_format="rgb24",
+        pixels=rgb.tobytes(),
+    )
+
+
+def _video_time(source_pts: int, scan: NativeVideoScan) -> Fraction:
+    return Fraction(source_pts - scan.origin_pts) * scan.time_base
+
+
+def _percentile_95(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    return float(np.percentile(np.asarray(values, dtype=np.float64), 95))

--- a/src/video_selection/services/completed_stage_writer.py
+++ b/src/video_selection/services/completed_stage_writer.py
@@ -11,11 +11,14 @@ from typing import Literal, cast
 from uuid import uuid4
 
 from ..models.completed_stage import CompletedStage
+from ..models.completed_stage_bundle import CompletedStageBundle
 from ..models.processing_stage import ProcessingStage
 from ..models.stage_fingerprint import StageFingerprint
+from .stage_version import stage_version
 
 CacheNamespace = Literal["videos", "video-sets"]
 FaultInjector = Callable[[str], None]
+ArtifactProducer = Callable[[Path], dict[str, object]]
 
 
 class CompletedStageWriter:
@@ -49,6 +52,23 @@ class CompletedStageWriter:
         artifact: dict[str, object],
     ) -> CompletedStage:
         """Stage artifactと完了manifestを保存する。"""
+        return self.write_artifacts(
+            stage,
+            fingerprint,
+            upstream_fingerprints,
+            semantic_input,
+            lambda _stage_folder: artifact,
+        )
+
+    def write_artifacts(
+        self,
+        stage: ProcessingStage,
+        fingerprint: StageFingerprint,
+        upstream_fingerprints: tuple[StageFingerprint, ...],
+        semantic_input: Mapping[str, object],
+        produce_artifacts: ArtifactProducer,
+    ) -> CompletedStage:
+        """複数artifactを生成して完了manifestとatomicに保存する。"""
         stage_root = self._root / stage.value
         stage_root.mkdir(parents=True, exist_ok=True)
         lock_root = (
@@ -68,7 +88,7 @@ class CompletedStageWriter:
                     fingerprint,
                     upstream_fingerprints,
                     semantic_input,
-                    artifact,
+                    produce_artifacts,
                     stage_root,
                 )
             finally:
@@ -80,13 +100,13 @@ class CompletedStageWriter:
         fingerprint: StageFingerprint,
         upstream_fingerprints: tuple[StageFingerprint, ...],
         semantic_input: Mapping[str, object],
-        artifact: dict[str, object],
+        produce_artifacts: ArtifactProducer,
         stage_root: Path,
     ) -> CompletedStage:
         """fingerprint lockの内側でStageを一度だけ確定する。"""
         stage_folder = stage_root / fingerprint.value
         if (
-            self.read(
+            self.read_bundle(
                 stage,
                 fingerprint,
                 upstream_fingerprints,
@@ -99,17 +119,29 @@ class CompletedStageWriter:
         temporary_folder = stage_root / f".{fingerprint.value}.{uuid4().hex}.tmp"
         temporary_folder.mkdir()
         try:
+            artifact = produce_artifacts(temporary_folder)
+            if not isinstance(artifact, dict) or not all(
+                isinstance(key, str) for key in artifact
+            ):
+                msg = "Completed Stage producerはJSON objectを返す必要があります"
+                raise TypeError(msg)
+            if (temporary_folder / "artifact.json").exists() or (
+                temporary_folder / "manifest.json"
+            ).exists():
+                msg = "producerは予約済みartifact名を作成できません"
+                raise ValueError(msg)
             artifact_bytes = (
                 json.dumps(artifact, ensure_ascii=False, indent=2, sort_keys=True)
                 + "\n"
             ).encode()
             (temporary_folder / "artifact.json").write_bytes(artifact_bytes)
             self._fault_injector("before-manifest")
+            artifact_records = _artifact_records(temporary_folder)
             manifest = {
                 "schema": "game-screen-pick/completed-stage@1.0.0",
                 "status": "completed",
                 "stage": stage.value,
-                "stage_version": "walking-skeleton-0",
+                "stage_version": stage_version(stage),
                 "stage_fingerprint": fingerprint.value,
                 "subject": {
                     "namespace": self._subject_namespace,
@@ -119,13 +151,7 @@ class CompletedStageWriter:
                     item.value for item in upstream_fingerprints
                 ],
                 "semantic_input": _normalize_json_mapping(semantic_input),
-                "artifacts": [
-                    {
-                        "path": "artifact.json",
-                        "size_bytes": len(artifact_bytes),
-                        "sha256": hashlib.sha256(artifact_bytes).hexdigest(),
-                    }
-                ],
+                "artifacts": artifact_records,
                 "completed_at": datetime.now(timezone.utc).isoformat(),
             }
             manifest_bytes = (
@@ -150,6 +176,22 @@ class CompletedStageWriter:
         semantic_input: Mapping[str, object],
     ) -> dict[str, object] | None:
         """検証済みCompleted Stage artifactを返す。"""
+        bundle = self.read_bundle(
+            stage,
+            fingerprint,
+            upstream_fingerprints,
+            semantic_input,
+        )
+        return None if bundle is None else bundle.artifact
+
+    def read_bundle(
+        self,
+        stage: ProcessingStage,
+        fingerprint: StageFingerprint,
+        upstream_fingerprints: tuple[StageFingerprint, ...],
+        semantic_input: Mapping[str, object],
+    ) -> CompletedStageBundle | None:
+        """検証済みJSON artifactとStage rootを返す。"""
         stage_folder = self._root / stage.value / fingerprint.value
         artifact_path = stage_folder / "artifact.json"
         manifest_path = stage_folder / "manifest.json"
@@ -175,11 +217,15 @@ class CompletedStageWriter:
         completed_at = manifest.get("completed_at")
         if not _is_timezone_aware_iso_datetime(completed_at):
             return None
+        try:
+            artifact_records = _artifact_records(stage_folder)
+        except OSError:
+            return None
         expected_manifest = {
             "schema": "game-screen-pick/completed-stage@1.0.0",
             "status": "completed",
             "stage": stage.value,
-            "stage_version": "walking-skeleton-0",
+            "stage_version": stage_version(stage),
             "stage_fingerprint": fingerprint.value,
             "subject": {
                 "namespace": self._subject_namespace,
@@ -189,13 +235,7 @@ class CompletedStageWriter:
                 item.value for item in upstream_fingerprints
             ],
             "semantic_input": _normalize_json_mapping(semantic_input),
-            "artifacts": [
-                {
-                    "path": "artifact.json",
-                    "size_bytes": len(artifact_bytes),
-                    "sha256": hashlib.sha256(artifact_bytes).hexdigest(),
-                }
-            ],
+            "artifacts": artifact_records,
             "completed_at": completed_at,
         }
         if manifest != expected_manifest:
@@ -204,7 +244,10 @@ class CompletedStageWriter:
             isinstance(key, str) for key in artifact_value
         ):
             return None
-        return cast(dict[str, object], artifact_value)
+        return CompletedStageBundle(
+            artifact=cast(dict[str, object], artifact_value),
+            root=stage_folder,
+        )
 
     @staticmethod
     def _remove_partial_stage(stage_folder: Path) -> None:
@@ -244,3 +287,29 @@ def _is_timezone_aware_iso_datetime(value: object) -> bool:
 
 def _ignore_fault_checkpoint(_checkpoint: str) -> None:
     return
+
+
+def _artifact_records(stage_folder: Path) -> list[dict[str, object]]:
+    """manifest以外の通常fileを相対path順でhash化する。"""
+    records: list[dict[str, object]] = []
+    for path in sorted(stage_folder.rglob("*")):
+        if path.name == "manifest.json" and path.parent == stage_folder:
+            continue
+        if path.is_symlink():
+            msg = "Completed Stage artifactにsymbolic linkは使えません"
+            raise OSError(msg)
+        if path.is_dir():
+            continue
+        if not path.is_file():
+            msg = "Completed Stage artifactは通常fileである必要があります"
+            raise OSError(msg)
+        relative_path = path.relative_to(stage_folder).as_posix()
+        content = path.read_bytes()
+        records.append(
+            {
+                "path": relative_path,
+                "size_bytes": len(content),
+                "sha256": hashlib.sha256(content).hexdigest(),
+            }
+        )
+    return records

--- a/src/video_selection/services/discover_candidate_moments.py
+++ b/src/video_selection/services/discover_candidate_moments.py
@@ -1,6 +1,7 @@
 """scan signalからdensity制限済みCandidate Momentを発見する。"""
 
 import math
+from collections import deque
 from fractions import Fraction
 from typing import cast
 
@@ -34,10 +35,12 @@ def discover_candidate_moments(
     radius = Fraction(str(refinement_radius_seconds))
     density_cap = math.ceil(timeline.duration.seconds / window_width)
     anchors: dict[Fraction, tuple[int, set[MomentEvidence], float]] = {}
+    eligible_heartbeats: list[HeartbeatProxy] = []
 
     for heartbeat in heartbeats:
         if not heartbeat.eligible or heartbeat.video_time >= timeline.duration.seconds:
             continue
+        eligible_heartbeats.append(heartbeat)
         _merge_anchor(
             anchors,
             heartbeat.video_time,
@@ -46,25 +49,57 @@ def discover_candidate_moments(
             heartbeat.quality_score,
         )
 
-    for scene in scene_signals:
-        if scene.video_time >= timeline.duration.seconds:
-            continue
-        quality_candidates = [
-            heartbeat.quality_score
-            for heartbeat in heartbeats
-            if heartbeat.eligible
-            and abs(heartbeat.video_time - scene.video_time) <= radius
-        ]
-        if scene.eligible:
-            quality_candidates.append(scene.quality_score)
-        if not quality_candidates:
+    eligible_heartbeats.sort(key=lambda item: (item.video_time, item.source_pts))
+    ordered_scenes = sorted(
+        (
+            scene
+            for scene in scene_signals
+            if scene.video_time < timeline.duration.seconds
+        ),
+        key=lambda item: (item.video_time, item.source_pts),
+    )
+    quality_window: deque[int] = deque()
+    left_index = 0
+    right_index = 0
+    for scene in ordered_scenes:
+        lower_bound = scene.video_time - radius
+        upper_bound = scene.video_time + radius
+        while (
+            right_index < len(eligible_heartbeats)
+            and eligible_heartbeats[right_index].video_time <= upper_bound
+        ):
+            while quality_window and (
+                eligible_heartbeats[quality_window[-1]].quality_score
+                <= eligible_heartbeats[right_index].quality_score
+            ):
+                quality_window.pop()
+            quality_window.append(right_index)
+            right_index += 1
+        while (
+            left_index < right_index
+            and eligible_heartbeats[left_index].video_time < lower_bound
+        ):
+            if quality_window and quality_window[0] == left_index:
+                quality_window.popleft()
+            left_index += 1
+        heartbeat_quality = (
+            eligible_heartbeats[quality_window[0]].quality_score
+            if quality_window
+            else None
+        )
+        quality_score = heartbeat_quality
+        if scene.eligible and (
+            quality_score is None or scene.quality_score > quality_score
+        ):
+            quality_score = scene.quality_score
+        if quality_score is None:
             continue
         _merge_anchor(
             anchors,
             scene.video_time,
             scene.source_pts,
             "scene",
-            max(quality_candidates),
+            quality_score,
         )
 
     windows: dict[int, list[tuple[Fraction, int, set[MomentEvidence], float]]] = {}

--- a/src/video_selection/services/discover_candidate_moments.py
+++ b/src/video_selection/services/discover_candidate_moments.py
@@ -1,0 +1,130 @@
+"""scan signalからdensity制限済みCandidate Momentを発見する。"""
+
+import math
+from fractions import Fraction
+from typing import cast
+
+from ..models.candidate_moment import CandidateMoment, MomentEvidence
+from ..models.candidate_moment_discovery import CandidateMomentDiscovery
+from ..models.heartbeat_proxy import HeartbeatProxy
+from ..models.scene_signal import SceneSignal
+from ..models.video_timeline import VideoTimeline
+from .build_video_entity_id import build_video_entity_id
+
+_MOMENT_ID_ALGORITHM = "candidate-moment-id-v1"
+
+
+def discover_candidate_moments(
+    *,
+    video_fingerprint: str,
+    timeline: VideoTimeline,
+    heartbeats: tuple[HeartbeatProxy, ...],
+    scene_signals: tuple[SceneSignal, ...],
+    density_per_minute: float,
+    refinement_radius_seconds: float,
+) -> CandidateMomentDiscovery:
+    """各density windowからproxy画質が最も高いanchorを最大1件返す。"""
+    if not math.isfinite(density_per_minute) or density_per_minute <= 0:
+        msg = "Candidate Moment Densityは正の有限値である必要があります"
+        raise ValueError(msg)
+    if not math.isfinite(refinement_radius_seconds) or refinement_radius_seconds < 0:
+        msg = "Frame Refinement半径は0以上の有限値である必要があります"
+        raise ValueError(msg)
+    window_width = Fraction(60) / Fraction(str(density_per_minute))
+    radius = Fraction(str(refinement_radius_seconds))
+    density_cap = math.ceil(timeline.duration.seconds / window_width)
+    anchors: dict[Fraction, tuple[int, set[MomentEvidence], float]] = {}
+
+    for heartbeat in heartbeats:
+        if not heartbeat.eligible or heartbeat.video_time >= timeline.duration.seconds:
+            continue
+        _merge_anchor(
+            anchors,
+            heartbeat.video_time,
+            heartbeat.source_pts,
+            "heartbeat",
+            heartbeat.quality_score,
+        )
+
+    for scene in scene_signals:
+        if scene.video_time >= timeline.duration.seconds:
+            continue
+        quality_candidates = [
+            heartbeat.quality_score
+            for heartbeat in heartbeats
+            if heartbeat.eligible
+            and abs(heartbeat.video_time - scene.video_time) <= radius
+        ]
+        if scene.eligible:
+            quality_candidates.append(scene.quality_score)
+        if not quality_candidates:
+            continue
+        _merge_anchor(
+            anchors,
+            scene.video_time,
+            scene.source_pts,
+            "scene",
+            max(quality_candidates),
+        )
+
+    windows: dict[int, list[tuple[Fraction, int, set[MomentEvidence], float]]] = {}
+    for video_time, (source_pts, evidence, quality_score) in anchors.items():
+        window_index = int(video_time // window_width)
+        windows.setdefault(window_index, []).append(
+            (video_time, source_pts, evidence, quality_score)
+        )
+
+    moments: list[CandidateMoment] = []
+    for window_index in sorted(windows):
+        center = window_width * window_index + window_width / 2
+        video_time, source_pts, evidence, quality_score = min(
+            windows[window_index],
+            key=lambda item: (
+                -item[3],
+                -int("scene" in item[2]),
+                abs(item[0] - center),
+                item[0],
+            ),
+        )
+        moments.append(
+            CandidateMoment(
+                identifier=build_video_entity_id(
+                    "mom",
+                    _MOMENT_ID_ALGORITHM,
+                    video_fingerprint,
+                    video_time,
+                ),
+                source_pts=source_pts,
+                anchor_time=video_time,
+                timeline_segment_id=timeline.segment_at(video_time).identifier,
+                evidence=cast(
+                    tuple[MomentEvidence, ...],
+                    tuple(sorted(evidence)),
+                ),
+                proxy_quality_score=quality_score,
+            )
+        )
+    return CandidateMomentDiscovery(
+        density_cap=density_cap,
+        moments=tuple(moments),
+    )
+
+
+def _merge_anchor(
+    anchors: dict[Fraction, tuple[int, set[MomentEvidence], float]],
+    video_time: Fraction,
+    source_pts: int,
+    evidence: MomentEvidence,
+    quality_score: float,
+) -> None:
+    current = anchors.get(video_time)
+    if current is None:
+        anchors[video_time] = (source_pts, {evidence}, quality_score)
+        return
+    current_source_pts, current_evidence, current_quality = current
+    current_evidence.add(evidence)
+    anchors[video_time] = (
+        min(current_source_pts, source_pts),
+        current_evidence,
+        max(current_quality, quality_score),
+    )

--- a/src/video_selection/services/processing_stage_runner.py
+++ b/src/video_selection/services/processing_stage_runner.py
@@ -5,11 +5,13 @@ from pathlib import Path
 from typing import TypeVar
 
 from ..models.completed_stage import CompletedStage
-from ..models.processing_stage import ProcessingStage
+from ..models.completed_stage_bundle import CompletedStageBundle
+from ..models.processing_stage import VIDEO_SET_STAGE_ORDER, ProcessingStage
 from ..models.stage_fingerprint import StageFingerprint
 from ..protocols.run_observer import RunObserver
 from .build_stage_fingerprint import build_stage_fingerprint
 from .completed_stage_writer import (
+    ArtifactProducer,
     CacheNamespace,
     CompletedStageWriter,
     FaultInjector,
@@ -30,6 +32,7 @@ class ProcessingStageRunner:
         subject_fingerprint: str,
         before_stage: Callable[[], None] | None = None,
         fault_injector: FaultInjector | None = None,
+        stage_order: tuple[ProcessingStage, ...] = VIDEO_SET_STAGE_ORDER,
     ) -> None:
         self._writer = CompletedStageWriter(
             cache_folder,
@@ -39,7 +42,11 @@ class ProcessingStageRunner:
         )
         self._observer = observer
         self._before_stage = before_stage or _skip_before_stage
+        self._stage_order = stage_order
         self._completed_stages: list[CompletedStage] = []
+        if not stage_order or len(stage_order) != len(set(stage_order)):
+            msg = "stage_orderには重複のない1件以上のStageが必要です"
+            raise ValueError(msg)
 
     @property
     def completed_stages(self) -> tuple[CompletedStage, ...]:
@@ -84,13 +91,58 @@ class ProcessingStageRunner:
         self._record_completion(CompletedStage(stage=stage, fingerprint=fingerprint))
         return restored
 
+    def complete_artifacts(
+        self,
+        stage: ProcessingStage,
+        semantic_input: Mapping[str, object],
+        produce_artifacts: ArtifactProducer,
+    ) -> CompletedStageBundle:
+        """複数artifactを生成して次のStageを確定する。"""
+        upstream_fingerprints, fingerprint = self._prepare_stage(stage, semantic_input)
+        completed_stage = self._writer.write_artifacts(
+            stage,
+            fingerprint,
+            upstream_fingerprints,
+            semantic_input,
+            produce_artifacts,
+        )
+        bundle = self._writer.read_bundle(
+            stage,
+            fingerprint,
+            upstream_fingerprints,
+            semantic_input,
+        )
+        if bundle is None:
+            msg = "確定直後のCompleted Stage artifactを検証できませんでした"
+            raise RuntimeError(msg)
+        self._record_completion(completed_stage)
+        return bundle
+
+    def reuse_bundle(
+        self,
+        stage: ProcessingStage,
+        semantic_input: Mapping[str, object],
+    ) -> CompletedStageBundle | None:
+        """検証済みCompleted Stage bundleがあれば完了扱いにする。"""
+        upstream_fingerprints, fingerprint = self._prepare_stage(stage, semantic_input)
+        bundle = self._writer.read_bundle(
+            stage,
+            fingerprint,
+            upstream_fingerprints,
+            semantic_input,
+        )
+        if bundle is None:
+            return None
+        self._record_completion(CompletedStage(stage=stage, fingerprint=fingerprint))
+        return bundle
+
     def _prepare_stage(
         self,
         stage: ProcessingStage,
         semantic_input: Mapping[str, object],
     ) -> tuple[tuple[StageFingerprint, ...], StageFingerprint]:
         """次Stageを検証して上流とfingerprintを返す。"""
-        stages = tuple(ProcessingStage)
+        stages = self._stage_order
         completed_count = len(self._completed_stages)
         if completed_count >= len(stages):
             msg = f"all Processing Stages are completed: actual={stage.value}"

--- a/src/video_selection/services/refine_candidate_moments.py
+++ b/src/video_selection/services/refine_candidate_moments.py
@@ -1,0 +1,239 @@
+"""Candidate Moment周辺のnative frameを選抜する。"""
+
+import math
+from dataclasses import replace
+from fractions import Fraction
+
+import numpy as np
+
+from ..models.candidate_moment import CandidateMoment
+from ..models.content_reject_reason import ContentRejectReason
+from ..models.decoded_video_frame import DecodedVideoFrame
+from ..models.frame_candidate import FrameCandidate
+from ..models.frame_candidate_extraction import FrameCandidateExtraction
+from ..models.neutral_image_analysis import NeutralImageAnalysis
+from ..models.video_timeline import VideoTimeline
+from .analyze_neutral_images import analyze_neutral_images
+from .build_video_entity_id import build_video_entity_id
+
+_FRAME_ID_ALGORITHM = "frame-candidate-id-v1"
+_PERCEPTUAL_MAD_THRESHOLD = 2.0
+
+
+def refine_candidate_moments(
+    *,
+    video_fingerprint: str,
+    timeline: VideoTimeline,
+    moments: tuple[CandidateMoment, ...],
+    frames: tuple[DecodedVideoFrame, ...],
+    refinement_radius_seconds: float,
+    max_frame_candidates: int,
+) -> FrameCandidateExtraction:
+    """無効frame除外、Moment内dedupe、多様性選抜を適用する。"""
+    if not math.isfinite(refinement_radius_seconds) or refinement_radius_seconds < 0:
+        msg = "Frame Refinement半径は0以上の有限値である必要があります"
+        raise ValueError(msg)
+    if not 1 <= max_frame_candidates <= 3:
+        msg = "最大Frame Candidate数は1以上3以下である必要があります"
+        raise ValueError(msg)
+    radius = Fraction(str(refinement_radius_seconds))
+    unique_frames = {
+        frame.pts: frame
+        for frame in frames
+        if _is_in_any_refinement_window(frame, timeline, moments, radius)
+    }
+    ordered_frames = tuple(unique_frames[pts] for pts in sorted(unique_frames))
+    analyses = analyze_neutral_images(ordered_frames)
+    analysis_by_pts = {item.source_pts: item for item in analyses}
+    frame_by_pts = {item.pts: item for item in ordered_frames}
+    reject_breakdown = ContentRejectReason.empty_breakdown()
+    for analysis in analyses:
+        if analysis.reject_reason is not None:
+            reject_breakdown[analysis.reject_reason.value] += 1
+
+    candidate_by_pts: dict[int, FrameCandidate] = {}
+    refined_moments: list[CandidateMoment] = []
+    deduplicated_frame_count = 0
+    for moment in moments:
+        eligible = [
+            (frame_by_pts[pts], analysis)
+            for pts, analysis in analysis_by_pts.items()
+            if analysis.eligible
+            and _is_in_moment_window(
+                _video_time(frame_by_pts[pts], timeline),
+                moment.anchor_time,
+                timeline.duration.seconds,
+                radius,
+            )
+        ]
+        deduplicated, removed_count = _deduplicate_for_moment(
+            eligible,
+            moment,
+            timeline,
+        )
+        deduplicated_frame_count += removed_count
+        selected = _select_diverse_frames(
+            deduplicated,
+            moment,
+            timeline,
+            max_frame_candidates,
+        )
+        candidate_ids: list[str] = []
+        for frame, analysis in selected:
+            candidate = candidate_by_pts.get(frame.pts)
+            if candidate is None:
+                video_time = _video_time(frame, timeline)
+                candidate = FrameCandidate(
+                    identifier=build_video_entity_id(
+                        "frm",
+                        _FRAME_ID_ALGORITHM,
+                        video_fingerprint,
+                        video_time,
+                    ),
+                    image_bytes=b"",
+                    video_fingerprint=video_fingerprint,
+                    stream_index=frame.stream_index,
+                    source_pts=frame.pts,
+                    origin_pts=timeline.origin_pts,
+                    time_base=frame.time_base,
+                    video_time=video_time,
+                    analysis=analysis,
+                    decoded_frame=frame,
+                )
+                candidate_by_pts[frame.pts] = candidate
+            candidate_ids.append(candidate.identifier)
+        refined_moments.append(
+            replace(moment, frame_candidate_ids=tuple(candidate_ids))
+        )
+
+    candidates = tuple(
+        sorted(
+            candidate_by_pts.values(),
+            key=lambda candidate: (
+                Fraction(0) if candidate.video_time is None else candidate.video_time
+            ),
+        )
+    )
+    return FrameCandidateExtraction(
+        moments=tuple(refined_moments),
+        candidates=candidates,
+        native_frame_count=len(ordered_frames),
+        reject_breakdown=reject_breakdown,
+        deduplicated_frame_count=deduplicated_frame_count,
+        zero_frame_moment_count=sum(
+            not moment.frame_candidate_ids for moment in refined_moments
+        ),
+    )
+
+
+def _is_in_any_refinement_window(
+    frame: DecodedVideoFrame,
+    timeline: VideoTimeline,
+    moments: tuple[CandidateMoment, ...],
+    radius: Fraction,
+) -> bool:
+    video_time = _video_time(frame, timeline)
+    return 0 <= video_time < timeline.duration.seconds and any(
+        _is_in_moment_window(
+            video_time,
+            moment.anchor_time,
+            timeline.duration.seconds,
+            radius,
+        )
+        for moment in moments
+    )
+
+
+def _is_in_moment_window(
+    video_time: Fraction,
+    anchor_time: Fraction,
+    duration: Fraction,
+    radius: Fraction,
+) -> bool:
+    if radius == 0:
+        return video_time == anchor_time
+    start = max(Fraction(0), anchor_time - radius)
+    end = min(duration, anchor_time + radius)
+    return start <= video_time < end
+
+
+def _video_time(
+    frame: DecodedVideoFrame,
+    timeline: VideoTimeline,
+) -> Fraction:
+    return Fraction(frame.pts - timeline.origin_pts) * frame.time_base
+
+
+def _deduplicate_for_moment(
+    eligible: list[tuple[DecodedVideoFrame, NeutralImageAnalysis]],
+    moment: CandidateMoment,
+    timeline: VideoTimeline,
+) -> tuple[list[tuple[DecodedVideoFrame, NeutralImageAnalysis]], int]:
+    ordered = sorted(
+        eligible,
+        key=lambda item: (
+            -item[1].quality_score,
+            abs(_video_time(item[0], timeline) - moment.anchor_time),
+            _video_time(item[0], timeline),
+        ),
+    )
+    kept: list[tuple[DecodedVideoFrame, NeutralImageAnalysis]] = []
+    removed_count = 0
+    for item in ordered:
+        if any(
+            _signature_mad(item[1], existing[1]) <= _PERCEPTUAL_MAD_THRESHOLD
+            for existing in kept
+        ):
+            removed_count += 1
+            continue
+        kept.append(item)
+    return kept, removed_count
+
+
+def _select_diverse_frames(
+    frames: list[tuple[DecodedVideoFrame, NeutralImageAnalysis]],
+    moment: CandidateMoment,
+    timeline: VideoTimeline,
+    maximum: int,
+) -> list[tuple[DecodedVideoFrame, NeutralImageAnalysis]]:
+    if not frames:
+        return []
+    remaining = list(frames)
+    selected = [remaining.pop(0)]
+    while remaining and len(selected) < maximum:
+        chosen = max(
+            remaining,
+            key=lambda item: (
+                min(_visual_distance(item[1], existing[1]) for existing in selected),
+                item[1].quality_score,
+                -abs(_video_time(item[0], timeline) - moment.anchor_time),
+                -_video_time(item[0], timeline),
+            ),
+        )
+        selected.append(chosen)
+        remaining.remove(chosen)
+    return sorted(selected, key=lambda item: _video_time(item[0], timeline))
+
+
+def _signature_mad(
+    left: NeutralImageAnalysis,
+    right: NeutralImageAnalysis,
+) -> float:
+    left_values = np.frombuffer(left.grayscale_signature, dtype=np.uint8).astype(
+        np.int16
+    )
+    right_values = np.frombuffer(right.grayscale_signature, dtype=np.uint8).astype(
+        np.int16
+    )
+    return float(np.mean(np.abs(left_values - right_values)))
+
+
+def _visual_distance(
+    left: NeutralImageAnalysis,
+    right: NeutralImageAnalysis,
+) -> float:
+    return float(
+        np.linalg.norm(
+            np.asarray(left.visual_feature) - np.asarray(right.visual_feature)
+        )
+    )

--- a/src/video_selection/services/refine_candidate_moments.py
+++ b/src/video_selection/services/refine_candidate_moments.py
@@ -1,6 +1,7 @@
 """Candidate Moment周辺のnative frameを選抜する。"""
 
 import math
+from collections.abc import Iterable, Iterator
 from dataclasses import replace
 from fractions import Fraction
 
@@ -14,6 +15,7 @@ from ..models.frame_candidate_extraction import FrameCandidateExtraction
 from ..models.neutral_image_analysis import NeutralImageAnalysis
 from ..models.video_timeline import VideoTimeline
 from .analyze_neutral_images import analyze_neutral_images
+from .build_refinement_pts_ranges import build_refinement_pts_ranges
 from .build_video_entity_id import build_video_entity_id
 
 _FRAME_ID_ALGORITHM = "frame-candidate-id-v1"
@@ -30,13 +32,146 @@ def refine_candidate_moments(
     max_frame_candidates: int,
 ) -> FrameCandidateExtraction:
     """無効frame除外、Moment内dedupe、多様性選抜を適用する。"""
+    groups = tuple(
+        iter_refined_candidate_groups(
+            video_fingerprint=video_fingerprint,
+            timeline=timeline,
+            moments=moments,
+            frames=frames,
+            refinement_radius_seconds=refinement_radius_seconds,
+            max_frame_candidates=max_frame_candidates,
+        )
+    )
+    return combine_refined_candidate_groups(moments, groups)
+
+
+def iter_refined_candidate_groups(
+    *,
+    video_fingerprint: str,
+    timeline: VideoTimeline,
+    moments: tuple[CandidateMoment, ...],
+    frames: Iterable[DecodedVideoFrame],
+    refinement_radius_seconds: float,
+    max_frame_candidates: int,
+) -> Iterator[FrameCandidateExtraction]:
+    """一回のframe streamを連続Refinement Window Groupごとに解析する。"""
+    _validate_refinement_arguments(
+        refinement_radius_seconds,
+        max_frame_candidates,
+    )
+    pts_ranges = build_refinement_pts_ranges(
+        timeline,
+        moments,
+        refinement_radius_seconds,
+    )
+    frame_iterator = iter(frames)
+    pending: DecodedVideoFrame | None = None
+    radius = Fraction(str(refinement_radius_seconds))
+    for start_pts, end_pts in pts_ranges:
+        group_frames: list[DecodedVideoFrame] = []
+        while True:
+            if pending is None:
+                try:
+                    frame = next(frame_iterator)
+                except StopIteration:
+                    break
+            else:
+                frame = pending
+                pending = None
+            if frame.pts < start_pts:
+                msg = "refinement frameが要求PTS range外です"
+                raise ValueError(msg)
+            if frame.pts >= end_pts:
+                pending = frame
+                break
+            group_frames.append(frame)
+        group_moments = tuple(
+            moment for moment in moments if start_pts <= moment.source_pts < end_pts
+        )
+        yield _refine_candidate_group(
+            video_fingerprint=video_fingerprint,
+            timeline=timeline,
+            moments=group_moments,
+            frames=tuple(group_frames),
+            radius=radius,
+            max_frame_candidates=max_frame_candidates,
+        )
+    if pending is not None:
+        msg = "refinement frameが要求PTS range外です"
+        raise ValueError(msg)
+    try:
+        next(frame_iterator)
+    except StopIteration:
+        return
+    msg = "refinement frameが要求PTS range外です"
+    raise ValueError(msg)
+
+
+def combine_refined_candidate_groups(
+    moments: tuple[CandidateMoment, ...],
+    groups: tuple[FrameCandidateExtraction, ...],
+) -> FrameCandidateExtraction:
+    """順次確定したgroupを一つのVideo Source抽出結果へ統合する。"""
+    refined_by_id = {
+        moment.identifier: moment for group in groups for moment in group.moments
+    }
+    refined_moments = tuple(
+        refined_by_id.get(moment.identifier, replace(moment, frame_candidate_ids=()))
+        for moment in moments
+    )
+    candidate_by_id = {
+        candidate.identifier: candidate
+        for group in groups
+        for candidate in group.candidates
+    }
+    candidates = tuple(
+        sorted(
+            candidate_by_id.values(),
+            key=lambda candidate: (
+                Fraction(0) if candidate.video_time is None else candidate.video_time
+            ),
+        )
+    )
+    reject_breakdown = ContentRejectReason.empty_breakdown()
+    for group in groups:
+        for reason, count in group.reject_breakdown.items():
+            reject_breakdown[reason] += count
+    return FrameCandidateExtraction(
+        moments=refined_moments,
+        candidates=candidates,
+        native_frame_count=sum(group.native_frame_count for group in groups),
+        reject_breakdown=reject_breakdown,
+        deduplicated_frame_count=sum(
+            group.deduplicated_frame_count for group in groups
+        ),
+        zero_frame_moment_count=sum(
+            not moment.frame_candidate_ids for moment in refined_moments
+        ),
+    )
+
+
+def _validate_refinement_arguments(
+    refinement_radius_seconds: float,
+    max_frame_candidates: int,
+) -> None:
     if not math.isfinite(refinement_radius_seconds) or refinement_radius_seconds < 0:
         msg = "Frame Refinement半径は0以上の有限値である必要があります"
         raise ValueError(msg)
     if not 1 <= max_frame_candidates <= 3:
         msg = "最大Frame Candidate数は1以上3以下である必要があります"
         raise ValueError(msg)
-    radius = Fraction(str(refinement_radius_seconds))
+
+
+def _refine_candidate_group(
+    *,
+    video_fingerprint: str,
+    timeline: VideoTimeline,
+    moments: tuple[CandidateMoment, ...],
+    frames: tuple[DecodedVideoFrame, ...],
+    radius: Fraction,
+    max_frame_candidates: int,
+) -> FrameCandidateExtraction:
+    """一つの連続Refinement Window Groupを解析して選抜する。"""
     unique_frames = {
         frame.pts: frame
         for frame in frames

--- a/src/video_selection/services/select_primary_video_stream.py
+++ b/src/video_selection/services/select_primary_video_stream.py
@@ -1,0 +1,17 @@
+"""Primary Video Streamを決定する。"""
+
+from ..models.media_probe import MediaProbe
+from ..models.media_stream import MediaStream
+
+
+def select_primary_video_stream(probe: MediaProbe) -> MediaStream:
+    """coverを除外しdefault、stream indexの順で表示映像を選ぶ。"""
+    candidates = tuple(
+        stream
+        for stream in probe.streams
+        if stream.kind == "video" and not stream.is_attached_picture
+    )
+    if not candidates:
+        msg = "Primary Video Streamとなる表示映像streamがありません"
+        raise ValueError(msg)
+    return min(candidates, key=lambda stream: (not stream.is_default, stream.index))

--- a/src/video_selection/services/stage_version.py
+++ b/src/video_selection/services/stage_version.py
@@ -1,0 +1,12 @@
+"""Processing Stageごとのalgorithm version。"""
+
+from ..models.processing_stage import ProcessingStage
+
+
+def stage_version(stage: ProcessingStage) -> str:
+    """Stage Fingerprintとmanifestへ使うversionを返す。"""
+    if stage is ProcessingStage.SCAN_VIDEO:
+        return "video-scan-v1"
+    if stage is ProcessingStage.EXTRACT_FRAME_CANDIDATES:
+        return "frame-candidate-extraction-v1"
+    return "walking-skeleton-0"

--- a/src/video_selection/services/validate_video_set_snapshot.py
+++ b/src/video_selection/services/validate_video_set_snapshot.py
@@ -2,31 +2,62 @@
 
 import hashlib
 import os
+from pathlib import Path
+from typing import NoReturn
 
 from ..models.video_set import VideoSet
+from ..models.video_source import VideoSource
 from .discover_video_paths import discover_video_paths
 
 
 def validate_video_set_snapshot(video_set: VideoSet) -> None:
     """相対path列、stat、contentが発見時から不変か検証する。"""
+    for source, current_path in _validate_paths_and_stats(video_set):
+        _validate_source_content(source, current_path)
+
+
+def validate_video_source_snapshot(
+    video_set: VideoSet,
+    source: VideoSource,
+) -> None:
+    """全体path/statと対象Video Sourceのcontentを検証する。"""
+    current_sources = _validate_paths_and_stats(video_set)
+    for expected, current_path in current_sources:
+        if expected == source:
+            _validate_source_content(source, current_path)
+            return
+    _raise_snapshot_changed()
+
+
+def _validate_paths_and_stats(
+    video_set: VideoSet,
+) -> tuple[tuple[VideoSource, Path], ...]:
     current_paths = discover_video_paths(video_set.input_folder, video_set.recursive)
     current_relative_paths = tuple(
         path.relative_to(video_set.input_folder).as_posix() for path in current_paths
     )
     if current_relative_paths != video_set.relative_paths:
         _raise_snapshot_changed()
-    for source, current_path in zip(video_set.sources, current_paths, strict=True):
-        before_stat = current_path.stat()
-        if _stat_signature(before_stat) != source.stat_signature:
+    current_sources = tuple(zip(video_set.sources, current_paths, strict=True))
+    for source, current_path in current_sources:
+        if _stat_signature(current_path.stat()) != source.stat_signature:
             _raise_snapshot_changed()
-        with current_path.open("rb") as video_file:
-            current_fingerprint = hashlib.file_digest(video_file, "sha256").hexdigest()
-        after_stat = current_path.stat()
-        if (
-            _stat_signature(after_stat) != source.stat_signature
-            or current_fingerprint != source.fingerprint
-        ):
-            _raise_snapshot_changed()
+    return current_sources
+
+
+def _validate_source_content(source: VideoSource, current_path: Path) -> None:
+    """一つのsourceをstat-content-statの順で照合する。"""
+    before_stat = current_path.stat()
+    if _stat_signature(before_stat) != source.stat_signature:
+        _raise_snapshot_changed()
+    with current_path.open("rb") as video_file:
+        current_fingerprint = hashlib.file_digest(video_file, "sha256").hexdigest()
+    after_stat = current_path.stat()
+    if (
+        _stat_signature(after_stat) != source.stat_signature
+        or current_fingerprint != source.fingerprint
+    ):
+        _raise_snapshot_changed()
 
 
 def _stat_signature(stat: os.stat_result) -> tuple[int, int, int, int]:
@@ -38,6 +69,6 @@ def _stat_signature(stat: os.stat_result) -> tuple[int, int, int, int]:
     )
 
 
-def _raise_snapshot_changed() -> None:
+def _raise_snapshot_changed() -> NoReturn:
     msg = "Video Set snapshotが変更されました"
     raise ValueError(msg)

--- a/src/video_selection/services/video_stage_artifacts.py
+++ b/src/video_selection/services/video_stage_artifacts.py
@@ -1,0 +1,479 @@
+"""Video Stage domain resultとCompleted Stage JSONを相互変換する。"""
+
+from collections.abc import Mapping
+from dataclasses import asdict
+from fractions import Fraction
+from pathlib import Path, PurePosixPath
+from typing import cast
+
+from ..models.candidate_moment import CandidateMoment, MomentEvidence
+from ..models.content_reject_reason import ContentRejectReason
+from ..models.frame_candidate import FrameCandidate
+from ..models.frame_candidate_extraction import FrameCandidateExtraction
+from ..models.frame_candidate_extraction_metrics import (
+    FrameCandidateExtractionMetrics,
+)
+from ..models.heartbeat_proxy import HeartbeatProxy
+from ..models.media_stream import MediaStream, MediaStreamKind
+from ..models.neutral_image_analysis import NeutralImageAnalysis
+from ..models.neutral_image_metrics import NeutralImageMetrics
+from ..models.scene_signal import SceneSignal
+from ..models.timeline_segment import TimelineSegment
+from ..models.video_duration import VideoDuration
+from ..models.video_scan_metrics import VideoScanMetrics
+from ..models.video_scan_result import VideoScanResult
+from ..models.video_timeline import VideoTimeline
+
+_SCAN_SCHEMA = "game-screen-pick/video-scan@1.0.0"
+_EXTRACTION_SCHEMA = "game-screen-pick/frame-candidate-extraction@1.0.0"
+
+
+def serialize_video_scan(scan: VideoScanResult, stage_root: Path) -> dict[str, object]:
+    """Video Scan Resultをpath非依存のJSON artifactへ変換する。"""
+    return {
+        "schema": _SCAN_SCHEMA,
+        "primary_stream": _serialize_stream(scan.primary_stream),
+        "timeline": {
+            "origin_pts": scan.timeline.origin_pts,
+            "time_base": _serialize_fraction(scan.timeline.time_base),
+            "duration": _serialize_fraction(scan.timeline.duration.seconds),
+            "segments": [
+                {
+                    "id": segment.identifier,
+                    "start": _serialize_fraction(segment.start),
+                    "end": _serialize_fraction(segment.end),
+                }
+                for segment in scan.timeline.segments
+            ],
+        },
+        "heartbeats": [
+            {
+                "source_pts": heartbeat.source_pts,
+                "video_time": _serialize_fraction(heartbeat.video_time),
+                "proxy_path": _relative_artifact_path(
+                    heartbeat.proxy_path,
+                    stage_root,
+                ),
+                "quality_score": heartbeat.quality_score,
+                "eligible": heartbeat.eligible,
+            }
+            for heartbeat in scan.heartbeats
+        ],
+        "scene_signals": [
+            {
+                "source_pts": scene.source_pts,
+                "video_time": _serialize_fraction(scene.video_time),
+                "quality_score": scene.quality_score,
+                "eligible": scene.eligible,
+            }
+            for scene in scan.scene_signals
+        ],
+        "metrics": {
+            **asdict(scan.metrics),
+            "input_duration": _serialize_fraction(scan.metrics.input_duration),
+        },
+    }
+
+
+def restore_video_scan(
+    artifact: Mapping[str, object],
+    stage_root: Path,
+) -> VideoScanResult:
+    """検証済みCompleted Stage JSONからVideo Scan Resultを復元する。"""
+    if artifact.get("schema") != _SCAN_SCHEMA:
+        msg = "Video Scan artifact schemaが不正です"
+        raise ValueError(msg)
+    timeline_value = _mapping(artifact.get("timeline"))
+    metrics_value = _mapping(artifact.get("metrics"))
+    timeline = VideoTimeline(
+        origin_pts=_integer(timeline_value.get("origin_pts")),
+        time_base=_fraction(timeline_value.get("time_base")),
+        duration=VideoDuration(_fraction(timeline_value.get("duration"))),
+        segments=tuple(
+            TimelineSegment(
+                identifier=_string(item.get("id")),
+                start=_fraction(item.get("start")),
+                end=_fraction(item.get("end")),
+            )
+            for item in _mapping_list(timeline_value.get("segments"))
+        ),
+    )
+    heartbeats = tuple(
+        HeartbeatProxy(
+            source_pts=_integer(item.get("source_pts")),
+            video_time=_fraction(item.get("video_time")),
+            proxy_path=_artifact_path(stage_root, item.get("proxy_path")),
+            quality_score=_number(item.get("quality_score")),
+            eligible=_boolean(item.get("eligible")),
+        )
+        for item in _mapping_list(artifact.get("heartbeats"))
+    )
+    scene_signals = tuple(
+        SceneSignal(
+            source_pts=_integer(item.get("source_pts")),
+            video_time=_fraction(item.get("video_time")),
+            quality_score=_number(item.get("quality_score")),
+            eligible=_boolean(item.get("eligible")),
+        )
+        for item in _mapping_list(artifact.get("scene_signals"))
+    )
+    return VideoScanResult(
+        primary_stream=_restore_stream(_mapping(artifact.get("primary_stream"))),
+        timeline=timeline,
+        heartbeats=heartbeats,
+        scene_signals=scene_signals,
+        metrics=VideoScanMetrics(
+            input_duration=_fraction(metrics_value.get("input_duration")),
+            wall_seconds=_number(metrics_value.get("wall_seconds")),
+            cpu_seconds=_number(metrics_value.get("cpu_seconds")),
+            input_seconds_per_wall_second=_number(
+                metrics_value.get("input_seconds_per_wall_second")
+            ),
+            decode_backend=_string(metrics_value.get("decode_backend")),
+            decode_pass_count=_integer(metrics_value.get("decode_pass_count")),
+            heartbeat_count=_integer(metrics_value.get("heartbeat_count")),
+            heartbeat_bytes=_integer(metrics_value.get("heartbeat_bytes")),
+            heartbeat_max_gap_seconds=_number(
+                metrics_value.get("heartbeat_max_gap_seconds")
+            ),
+            heartbeat_p95_gap_seconds=_number(
+                metrics_value.get("heartbeat_p95_gap_seconds")
+            ),
+            scene_signal_count=_integer(metrics_value.get("scene_signal_count")),
+            timeline_segment_count=_integer(
+                metrics_value.get("timeline_segment_count")
+            ),
+        ),
+    )
+
+
+def serialize_frame_candidate_extraction(
+    extraction: FrameCandidateExtraction,
+    metrics: FrameCandidateExtractionMetrics,
+    stage_root: Path,
+) -> dict[str, object]:
+    """Frame Candidate抽出結果をCompleted Stage JSONへ変換する。"""
+    return {
+        "schema": _EXTRACTION_SCHEMA,
+        "moments": [_serialize_moment(moment) for moment in extraction.moments],
+        "candidates": [
+            {
+                "id": candidate.identifier,
+                "video_fingerprint": candidate.video_fingerprint,
+                "stream_index": candidate.stream_index,
+                "source_pts": candidate.source_pts,
+                "origin_pts": candidate.origin_pts,
+                "time_base": _serialize_fraction(
+                    _required_fraction(candidate.time_base)
+                ),
+                "video_time": _serialize_fraction(
+                    _required_fraction(candidate.video_time)
+                ),
+                "proxy_path": _relative_artifact_path(
+                    _required_path(candidate.proxy_path),
+                    stage_root,
+                ),
+                "analysis": _serialize_analysis(_required_analysis(candidate.analysis)),
+            }
+            for candidate in extraction.candidates
+        ],
+        "diagnostics": {
+            "native_frame_count": extraction.native_frame_count,
+            "reject_breakdown": extraction.reject_breakdown,
+            "deduplicated_frame_count": extraction.deduplicated_frame_count,
+            "zero_frame_moment_count": extraction.zero_frame_moment_count,
+        },
+        "metrics": asdict(metrics),
+    }
+
+
+def restore_frame_candidate_extraction(
+    artifact: Mapping[str, object],
+    stage_root: Path,
+) -> tuple[FrameCandidateExtraction, FrameCandidateExtractionMetrics]:
+    """Completed Stage JSONからFrame Candidate抽出結果とmetricを復元する。"""
+    if artifact.get("schema") != _EXTRACTION_SCHEMA:
+        msg = "Frame Candidate Extraction artifact schemaが不正です"
+        raise ValueError(msg)
+    diagnostics = _mapping(artifact.get("diagnostics"))
+    metrics_value = _mapping(artifact.get("metrics"))
+    candidates = tuple(
+        _restore_candidate(item, stage_root)
+        for item in _mapping_list(artifact.get("candidates"))
+    )
+    extraction = FrameCandidateExtraction(
+        moments=tuple(
+            _restore_moment(item) for item in _mapping_list(artifact.get("moments"))
+        ),
+        candidates=candidates,
+        native_frame_count=_integer(diagnostics.get("native_frame_count")),
+        reject_breakdown=_integer_mapping(diagnostics.get("reject_breakdown")),
+        deduplicated_frame_count=_integer(diagnostics.get("deduplicated_frame_count")),
+        zero_frame_moment_count=_integer(diagnostics.get("zero_frame_moment_count")),
+    )
+    metrics = FrameCandidateExtractionMetrics(
+        wall_seconds=_number(metrics_value.get("wall_seconds")),
+        cpu_seconds=_number(metrics_value.get("cpu_seconds")),
+        density_cap=_integer(metrics_value.get("density_cap")),
+        actual_moment_count=_integer(metrics_value.get("actual_moment_count")),
+        native_frame_count=_integer(metrics_value.get("native_frame_count")),
+        reject_breakdown=_integer_mapping(metrics_value.get("reject_breakdown")),
+        deduplicated_frame_count=_integer(
+            metrics_value.get("deduplicated_frame_count")
+        ),
+        zero_frame_moment_count=_integer(metrics_value.get("zero_frame_moment_count")),
+        frame_candidate_count=_integer(metrics_value.get("frame_candidate_count")),
+        frame_candidate_bytes=_integer(metrics_value.get("frame_candidate_bytes")),
+    )
+    return extraction, metrics
+
+
+def _serialize_stream(stream: MediaStream) -> dict[str, object]:
+    return {
+        "index": stream.index,
+        "kind": stream.kind,
+        "codec_name": stream.codec_name,
+        "time_base": (
+            None if stream.time_base is None else _serialize_fraction(stream.time_base)
+        ),
+        "start_pts": stream.start_pts,
+        "duration_ts": stream.duration_ts,
+        "width": stream.width,
+        "height": stream.height,
+        "sample_rate": stream.sample_rate,
+        "channels": stream.channels,
+        "language": stream.language,
+        "is_default": stream.is_default,
+        "is_forced": stream.is_forced,
+        "is_attached_picture": stream.is_attached_picture,
+    }
+
+
+def _restore_stream(value: Mapping[str, object]) -> MediaStream:
+    kind = _string(value.get("kind"))
+    if kind not in {"video", "audio", "subtitle", "data", "attachment"}:
+        msg = "Media Stream kindが不正です"
+        raise ValueError(msg)
+    time_base_value = value.get("time_base")
+    return MediaStream(
+        index=_integer(value.get("index")),
+        kind=cast(MediaStreamKind, kind),
+        codec_name=_string(value.get("codec_name")),
+        time_base=None if time_base_value is None else _fraction(time_base_value),
+        start_pts=_optional_integer(value.get("start_pts")),
+        duration_ts=_optional_integer(value.get("duration_ts")),
+        width=_optional_integer(value.get("width")),
+        height=_optional_integer(value.get("height")),
+        sample_rate=_optional_integer(value.get("sample_rate")),
+        channels=_optional_integer(value.get("channels")),
+        language=_optional_string(value.get("language")),
+        is_default=_boolean(value.get("is_default")),
+        is_forced=_boolean(value.get("is_forced")),
+        is_attached_picture=_boolean(value.get("is_attached_picture")),
+    )
+
+
+def _serialize_moment(moment: CandidateMoment) -> dict[str, object]:
+    return {
+        "id": moment.identifier,
+        "source_pts": moment.source_pts,
+        "anchor_time": _serialize_fraction(moment.anchor_time),
+        "timeline_segment_id": moment.timeline_segment_id,
+        "evidence": list(moment.evidence),
+        "proxy_quality_score": moment.proxy_quality_score,
+        "frame_candidate_ids": list(moment.frame_candidate_ids),
+    }
+
+
+def _restore_moment(value: Mapping[str, object]) -> CandidateMoment:
+    evidence_values = _string_list(value.get("evidence"))
+    if any(item not in {"heartbeat", "scene"} for item in evidence_values):
+        msg = "Candidate Moment evidenceが不正です"
+        raise ValueError(msg)
+    return CandidateMoment(
+        identifier=_string(value.get("id")),
+        source_pts=_integer(value.get("source_pts")),
+        anchor_time=_fraction(value.get("anchor_time")),
+        timeline_segment_id=_string(value.get("timeline_segment_id")),
+        evidence=cast(tuple[MomentEvidence, ...], evidence_values),
+        proxy_quality_score=_number(value.get("proxy_quality_score")),
+        frame_candidate_ids=_string_list(value.get("frame_candidate_ids")),
+    )
+
+
+def _serialize_analysis(analysis: NeutralImageAnalysis) -> dict[str, object]:
+    return {
+        "source_pts": analysis.source_pts,
+        "metrics": asdict(analysis.metrics),
+        "quality_score": analysis.quality_score,
+        "visual_feature": list(analysis.visual_feature),
+        "grayscale_signature_hex": analysis.grayscale_signature.hex(),
+        "reject_reason": (
+            None if analysis.reject_reason is None else analysis.reject_reason.value
+        ),
+    }
+
+
+def _restore_analysis(value: Mapping[str, object]) -> NeutralImageAnalysis:
+    metrics = _mapping(value.get("metrics"))
+    reason_value = value.get("reject_reason")
+    try:
+        reason = (
+            None if reason_value is None else ContentRejectReason(_string(reason_value))
+        )
+        signature = bytes.fromhex(_string(value.get("grayscale_signature_hex")))
+    except ValueError as error:
+        msg = "Neutral Image Analysis artifactが不正です"
+        raise ValueError(msg) from error
+    return NeutralImageAnalysis(
+        source_pts=_integer(value.get("source_pts")),
+        metrics=NeutralImageMetrics(
+            **{
+                field_name: _number(metrics.get(field_name))
+                for field_name in NeutralImageMetrics.__dataclass_fields__
+            }
+        ),
+        quality_score=_number(value.get("quality_score")),
+        visual_feature=tuple(
+            _number(item) for item in _list(value.get("visual_feature"))
+        ),
+        grayscale_signature=signature,
+        reject_reason=reason,
+    )
+
+
+def _restore_candidate(
+    value: Mapping[str, object],
+    stage_root: Path,
+) -> FrameCandidate:
+    proxy_path = _artifact_path(stage_root, value.get("proxy_path"))
+    return FrameCandidate(
+        identifier=_string(value.get("id")),
+        image_bytes=proxy_path.read_bytes(),
+        video_fingerprint=_string(value.get("video_fingerprint")),
+        stream_index=_integer(value.get("stream_index")),
+        source_pts=_integer(value.get("source_pts")),
+        origin_pts=_integer(value.get("origin_pts")),
+        time_base=_fraction(value.get("time_base")),
+        video_time=_fraction(value.get("video_time")),
+        analysis=_restore_analysis(_mapping(value.get("analysis"))),
+        proxy_path=proxy_path,
+    )
+
+
+def _serialize_fraction(value: Fraction) -> dict[str, int]:
+    return {"numerator": value.numerator, "denominator": value.denominator}
+
+
+def _fraction(value: object) -> Fraction:
+    mapping = _mapping(value)
+    denominator = _integer(mapping.get("denominator"))
+    if denominator == 0:
+        msg = "exact time denominatorは0にできません"
+        raise ValueError(msg)
+    return Fraction(_integer(mapping.get("numerator")), denominator)
+
+
+def _relative_artifact_path(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError as error:
+        msg = "Video Stage proxyはStage root配下にある必要があります"
+        raise ValueError(msg) from error
+
+
+def _artifact_path(root: Path, value: object) -> Path:
+    relative = PurePosixPath(_string(value))
+    if relative.is_absolute() or ".." in relative.parts or not relative.parts:
+        msg = "Video Stage artifact pathが不正です"
+        raise ValueError(msg)
+    path = root.joinpath(*relative.parts)
+    if not path.is_file() or path.is_symlink():
+        msg = "Video Stage proxy artifactがありません"
+        raise ValueError(msg)
+    return path
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+        msg = "Video Stage artifactにはobjectが必要です"
+        raise ValueError(msg)
+    return cast(Mapping[str, object], value)
+
+
+def _list(value: object) -> list[object]:
+    if not isinstance(value, list):
+        msg = "Video Stage artifactにはarrayが必要です"
+        raise ValueError(msg)
+    return value
+
+
+def _mapping_list(value: object) -> tuple[Mapping[str, object], ...]:
+    return tuple(_mapping(item) for item in _list(value))
+
+
+def _string_list(value: object) -> tuple[str, ...]:
+    return tuple(_string(item) for item in _list(value))
+
+
+def _integer_mapping(value: object) -> dict[str, int]:
+    return {key: _integer(item) for key, item in _mapping(value).items()}
+
+
+def _string(value: object) -> str:
+    if type(value) is not str:
+        msg = "Video Stage artifactにはstringが必要です"
+        raise ValueError(msg)
+    return value
+
+
+def _optional_string(value: object) -> str | None:
+    return None if value is None else _string(value)
+
+
+def _integer(value: object) -> int:
+    if type(value) is not int:
+        msg = "Video Stage artifactにはintegerが必要です"
+        raise ValueError(msg)
+    return value
+
+
+def _optional_integer(value: object) -> int | None:
+    return None if value is None else _integer(value)
+
+
+def _number(value: object) -> float:
+    if type(value) not in {int, float}:
+        msg = "Video Stage artifactにはnumberが必要です"
+        raise ValueError(msg)
+    return float(cast(int | float, value))
+
+
+def _boolean(value: object) -> bool:
+    if type(value) is not bool:
+        msg = "Video Stage artifactにはbooleanが必要です"
+        raise ValueError(msg)
+    return value
+
+
+def _required_fraction(value: Fraction | None) -> Fraction:
+    if value is None:
+        msg = "Frame Candidateにexact timeがありません"
+        raise ValueError(msg)
+    return value
+
+
+def _required_path(value: Path | None) -> Path:
+    if value is None:
+        msg = "Frame Candidate Proxy pathがありません"
+        raise ValueError(msg)
+    return value
+
+
+def _required_analysis(
+    value: NeutralImageAnalysis | None,
+) -> NeutralImageAnalysis:
+    if value is None:
+        msg = "Frame CandidateにNeutral Image Analysisがありません"
+        raise ValueError(msg)
+    return value

--- a/src/video_selection/services/video_stage_processor.py
+++ b/src/video_selection/services/video_stage_processor.py
@@ -1,0 +1,330 @@
+"""Video Sourceを2つのVideo Stageへ直列で通す。"""
+
+import resource
+import shutil
+import time
+from dataclasses import replace
+from fractions import Fraction
+from pathlib import Path
+
+from ..models.candidate_moment import CandidateMoment
+from ..models.effective_configuration import EffectiveConfiguration
+from ..models.frame_candidate_extraction_metrics import (
+    FrameCandidateExtractionMetrics,
+)
+from ..models.media_runtime_identity import MediaRuntimeIdentity
+from ..models.media_stream import MediaStream
+from ..models.processing_stage import VIDEO_STAGE_ORDER, ProcessingStage
+from ..models.video_scan_result import VideoScanResult
+from ..models.video_set import VideoSet
+from ..models.video_source import VideoSource
+from ..models.video_stage_result import VideoStageResult
+from ..protocols.run_observer import RunObserver
+from ..protocols.video_stage_media_runtime import VideoStageMediaRuntime
+from .analyze_neutral_images import (
+    BLUR_REJECT_VARIANCE_MIN,
+    NEUTRAL_ANALYSIS_ALGORITHM_VERSION,
+)
+from .build_refinement_pts_ranges import build_refinement_pts_ranges
+from .build_video_scan_result import build_video_scan_result
+from .discover_candidate_moments import discover_candidate_moments
+from .processing_stage_runner import ProcessingStageRunner
+from .refine_candidate_moments import refine_candidate_moments
+from .select_primary_video_stream import select_primary_video_stream
+from .validate_video_set_snapshot import validate_video_set_snapshot
+from .video_stage_artifacts import (
+    restore_frame_candidate_extraction,
+    restore_video_scan,
+    serialize_frame_candidate_extraction,
+    serialize_video_scan,
+)
+
+_SCAN_ALGORITHM_VERSION = "video-scan-v1"
+_TIMELINE_ALGORITHM_VERSION = "exact-timeline-v1"
+_SCAN_PROXY_ANALYSIS_VERSION = "scan-proxy-analysis-v1"
+_HEARTBEAT_PROXY_CONTRACT = "ffmpeg-mjpeg-960-q3-no-metadata-v1"
+_CANDIDATE_EXTRACTION_VERSION = "frame-candidate-extraction-v1"
+_CONTENT_REJECT_VERSION = "content-reject-v1"
+_DEDUPE_VERSION = "grayscale-64x36-mad-2-v1"
+_ENTITY_ID_VERSION = "video-entity-id-v1"
+_CANDIDATE_PROXY_CONTRACT = "ffmpeg-mjpeg-960-q3-no-metadata-v1"
+
+
+class VideoStageProcessor:
+    """Video Order順にsource-localなscanとcandidate抽出を確定する。"""
+
+    def __init__(
+        self,
+        media_runtime: VideoStageMediaRuntime,
+        observer: RunObserver,
+    ) -> None:
+        self._media_runtime = media_runtime
+        self._observer = observer
+
+    def process(
+        self,
+        video_set: VideoSet,
+        configuration: EffectiveConfiguration,
+    ) -> tuple[VideoStageResult, ...]:
+        """各Video Sourceをscanからcandidate抽出まで直列処理する。"""
+        validate_video_set_snapshot(video_set)
+        runtime_identity = self._media_runtime.preflight()
+        results: list[VideoStageResult] = []
+        for source in video_set.sources:
+            results.append(
+                self._process_source(
+                    video_set,
+                    source,
+                    configuration,
+                    runtime_identity,
+                )
+            )
+        return tuple(results)
+
+    def _process_source(
+        self,
+        video_set: VideoSet,
+        source: VideoSource,
+        configuration: EffectiveConfiguration,
+        runtime_identity: MediaRuntimeIdentity,
+    ) -> VideoStageResult:
+        """一つのVideo Sourceの2 Stageを確定または再利用する。"""
+        validate_video_set_snapshot(video_set)
+        primary_stream = select_primary_video_stream(
+            self._media_runtime.probe(source.path)
+        )
+        runner = ProcessingStageRunner(
+            configuration.processing_cache_folder,
+            self._observer,
+            subject_namespace="videos",
+            subject_fingerprint=source.fingerprint,
+            before_stage=lambda: validate_video_set_snapshot(video_set),
+            stage_order=VIDEO_STAGE_ORDER,
+        )
+        scan_input = _scan_semantic_input(
+            source,
+            primary_stream,
+            runtime_identity,
+            configuration,
+        )
+        scan_bundle = runner.reuse_bundle(ProcessingStage.SCAN_VIDEO, scan_input)
+        if scan_bundle is None:
+            scan_bundle = runner.complete_artifacts(
+                ProcessingStage.SCAN_VIDEO,
+                scan_input,
+                lambda stage_root: self._produce_scan_artifact(
+                    source,
+                    primary_stream,
+                    configuration,
+                    stage_root,
+                ),
+            )
+        scan = restore_video_scan(scan_bundle.artifact, scan_bundle.root)
+        discovery = discover_candidate_moments(
+            video_fingerprint=source.fingerprint,
+            timeline=scan.timeline,
+            heartbeats=scan.heartbeats,
+            scene_signals=scan.scene_signals,
+            density_per_minute=configuration.candidate_density_per_minute,
+            refinement_radius_seconds=configuration.refinement_radius_seconds,
+        )
+        scan_fingerprint = runner.completed_stages[0].fingerprint.value
+        extraction_input = _extraction_semantic_input(
+            source,
+            scan_fingerprint,
+            configuration,
+        )
+        extraction_bundle = runner.reuse_bundle(
+            ProcessingStage.EXTRACT_FRAME_CANDIDATES,
+            extraction_input,
+        )
+        if extraction_bundle is None:
+            extraction_bundle = runner.complete_artifacts(
+                ProcessingStage.EXTRACT_FRAME_CANDIDATES,
+                extraction_input,
+                lambda stage_root: self._produce_extraction_artifact(
+                    source,
+                    scan,
+                    discovery.density_cap,
+                    discovery.moments,
+                    configuration,
+                    stage_root,
+                ),
+            )
+        extraction, extraction_metrics = restore_frame_candidate_extraction(
+            extraction_bundle.artifact,
+            extraction_bundle.root,
+        )
+        return VideoStageResult(
+            source=source,
+            scan=scan,
+            extraction=extraction,
+            extraction_metrics=extraction_metrics,
+            completed_stages=runner.completed_stages,
+        )
+
+    def _produce_scan_artifact(
+        self,
+        source: VideoSource,
+        primary_stream: MediaStream,
+        configuration: EffectiveConfiguration,
+        stage_root: Path,
+    ) -> dict[str, object]:
+        """single-decode scanを実行しscene一時画像を除去する。"""
+        native_scan = self._media_runtime.scan_video(
+            source.path,
+            primary_stream,
+            stage_root,
+            heartbeat_interval_seconds=configuration.heartbeat_interval_seconds,
+            scene_change_threshold=configuration.scene_change_threshold,
+            scene_min_interval_seconds=configuration.scene_min_interval_seconds,
+            decode_backend=configuration.decode_backend,
+        )
+        try:
+            scan = build_video_scan_result(
+                native_scan=native_scan,
+                primary_stream=primary_stream,
+                video_fingerprint=source.fingerprint,
+                decode_backend=configuration.decode_backend,
+            )
+            return serialize_video_scan(scan, stage_root)
+        finally:
+            shutil.rmtree(stage_root / ".scene-proxies", ignore_errors=True)
+
+    def _produce_extraction_artifact(
+        self,
+        source: VideoSource,
+        scan: VideoScanResult,
+        density_cap: int,
+        moments: tuple[CandidateMoment, ...],
+        configuration: EffectiveConfiguration,
+        stage_root: Path,
+    ) -> dict[str, object]:
+        """native refinementとcandidate proxy確定を実行する。"""
+        usage_before = resource.getrusage(resource.RUSAGE_CHILDREN)
+        started_at = time.monotonic()
+        pts_ranges = build_refinement_pts_ranges(
+            scan.timeline,
+            moments,
+            configuration.refinement_radius_seconds,
+        )
+        frames = (
+            tuple(
+                self._media_runtime.scan_video_frame_ranges(
+                    source.path,
+                    scan.primary_stream.index,
+                    pts_ranges,
+                    960,
+                )
+            )
+            if pts_ranges
+            else ()
+        )
+        extraction = refine_candidate_moments(
+            video_fingerprint=source.fingerprint,
+            timeline=scan.timeline,
+            moments=moments,
+            frames=frames,
+            refinement_radius_seconds=configuration.refinement_radius_seconds,
+            max_frame_candidates=configuration.max_frame_candidates,
+        )
+        encoded_candidates = []
+        for candidate in extraction.candidates:
+            if candidate.decoded_frame is None:
+                msg = "Frame Candidate Proxy用のnative frameがありません"
+                raise ValueError(msg)
+            proxy_path = stage_root / "candidates" / f"{candidate.identifier}.jpg"
+            self._media_runtime.write_mjpeg_proxy(
+                candidate.decoded_frame,
+                proxy_path,
+                quality=3,
+            )
+            encoded_candidates.append(
+                replace(
+                    candidate,
+                    image_bytes=proxy_path.read_bytes(),
+                    proxy_path=proxy_path,
+                    decoded_frame=None,
+                )
+            )
+        extraction = replace(extraction, candidates=tuple(encoded_candidates))
+        wall_seconds = time.monotonic() - started_at
+        usage_after = resource.getrusage(resource.RUSAGE_CHILDREN)
+        cpu_seconds = (
+            usage_after.ru_utime
+            - usage_before.ru_utime
+            + usage_after.ru_stime
+            - usage_before.ru_stime
+        )
+        metrics = FrameCandidateExtractionMetrics(
+            wall_seconds=wall_seconds,
+            cpu_seconds=cpu_seconds,
+            density_cap=density_cap,
+            actual_moment_count=len(extraction.moments),
+            native_frame_count=extraction.native_frame_count,
+            reject_breakdown=extraction.reject_breakdown,
+            deduplicated_frame_count=extraction.deduplicated_frame_count,
+            zero_frame_moment_count=extraction.zero_frame_moment_count,
+            frame_candidate_count=len(extraction.candidates),
+            frame_candidate_bytes=sum(
+                len(candidate.image_bytes) for candidate in extraction.candidates
+            ),
+        )
+        return serialize_frame_candidate_extraction(extraction, metrics, stage_root)
+
+
+def _scan_semantic_input(
+    source: VideoSource,
+    stream: MediaStream,
+    runtime_identity: MediaRuntimeIdentity,
+    configuration: EffectiveConfiguration,
+) -> dict[str, object]:
+    return {
+        "video_fingerprint": source.fingerprint,
+        "primary_video_stream": {
+            "index": stream.index,
+            "codec_name": stream.codec_name,
+            "time_base": _fraction_value(stream.time_base),
+            "width": stream.width,
+            "height": stream.height,
+        },
+        "media_runtime_identity": {
+            "ffmpeg_version": runtime_identity.ffmpeg_version,
+            "ffprobe_version": runtime_identity.ffprobe_version,
+        },
+        "decode_backend": configuration.decode_backend,
+        "heartbeat_interval_seconds": configuration.heartbeat_interval_seconds,
+        "scene_change_threshold": configuration.scene_change_threshold,
+        "scene_min_interval_seconds": configuration.scene_min_interval_seconds,
+        "heartbeat_proxy_contract": _HEARTBEAT_PROXY_CONTRACT,
+        "scan_algorithm": _SCAN_ALGORITHM_VERSION,
+        "timeline_algorithm": _TIMELINE_ALGORITHM_VERSION,
+        "scan_proxy_analysis": _SCAN_PROXY_ANALYSIS_VERSION,
+    }
+
+
+def _extraction_semantic_input(
+    source: VideoSource,
+    scan_fingerprint: str,
+    configuration: EffectiveConfiguration,
+) -> dict[str, object]:
+    return {
+        "video_fingerprint": source.fingerprint,
+        "upstream_scan_fingerprint": scan_fingerprint,
+        "density_per_minute": configuration.candidate_density_per_minute,
+        "refinement_radius_seconds": configuration.refinement_radius_seconds,
+        "max_frame_candidates": configuration.max_frame_candidates,
+        "candidate_extraction_algorithm": _CANDIDATE_EXTRACTION_VERSION,
+        "neutral_analysis_algorithm": NEUTRAL_ANALYSIS_ALGORITHM_VERSION,
+        "blur_reject_variance_min": BLUR_REJECT_VARIANCE_MIN,
+        "content_reject_algorithm": _CONTENT_REJECT_VERSION,
+        "source_local_dedupe_algorithm": _DEDUPE_VERSION,
+        "entity_id_algorithm": _ENTITY_ID_VERSION,
+        "candidate_proxy_contract": _CANDIDATE_PROXY_CONTRACT,
+    }
+
+
+def _fraction_value(value: Fraction | None) -> dict[str, int] | None:
+    if value is None:
+        return None
+    return {"numerator": value.numerator, "denominator": value.denominator}

--- a/src/video_selection/services/video_stage_processor.py
+++ b/src/video_selection/services/video_stage_processor.py
@@ -96,6 +96,7 @@ class VideoStageProcessor:
         runtime_identity: MediaRuntimeIdentity,
     ) -> VideoStageResult:
         """一つのVideo Sourceの2 Stageを確定または再利用する。"""
+        validate_video_source_snapshot(video_set, source)
         primary_stream = select_primary_video_stream(
             self._media_runtime.probe(source.path)
         )

--- a/src/video_selection/services/video_stage_processor.py
+++ b/src/video_selection/services/video_stage_processor.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from ..models.candidate_moment import CandidateMoment
 from ..models.effective_configuration import EffectiveConfiguration
+from ..models.frame_candidate_extraction import FrameCandidateExtraction
 from ..models.frame_candidate_extraction_metrics import (
     FrameCandidateExtractionMetrics,
 )
@@ -29,9 +30,15 @@ from .build_refinement_pts_ranges import build_refinement_pts_ranges
 from .build_video_scan_result import build_video_scan_result
 from .discover_candidate_moments import discover_candidate_moments
 from .processing_stage_runner import ProcessingStageRunner
-from .refine_candidate_moments import refine_candidate_moments
+from .refine_candidate_moments import (
+    combine_refined_candidate_groups,
+    iter_refined_candidate_groups,
+)
 from .select_primary_video_stream import select_primary_video_stream
-from .validate_video_set_snapshot import validate_video_set_snapshot
+from .validate_video_set_snapshot import (
+    validate_video_set_snapshot,
+    validate_video_source_snapshot,
+)
 from .video_stage_artifacts import (
     restore_frame_candidate_extraction,
     restore_video_scan,
@@ -39,12 +46,12 @@ from .video_stage_artifacts import (
     serialize_video_scan,
 )
 
-_SCAN_ALGORITHM_VERSION = "video-scan-v1"
+_SCAN_ALGORITHM_VERSION = "video-scan-v2"
 _TIMELINE_ALGORITHM_VERSION = "exact-timeline-v1"
 _SCAN_PROXY_ANALYSIS_VERSION = "scan-proxy-analysis-v1"
 _HEARTBEAT_PROXY_CONTRACT = "ffmpeg-mjpeg-960-q3-no-metadata-v1"
-_CANDIDATE_EXTRACTION_VERSION = "frame-candidate-extraction-v1"
-_CONTENT_REJECT_VERSION = "content-reject-v1"
+_CANDIDATE_EXTRACTION_VERSION = "frame-candidate-extraction-v2"
+_CONTENT_REJECT_VERSION = "content-reject-v2"
 _DEDUPE_VERSION = "grayscale-64x36-mad-2-v1"
 _ENTITY_ID_VERSION = "video-entity-id-v1"
 _CANDIDATE_PROXY_CONTRACT = "ffmpeg-mjpeg-960-q3-no-metadata-v1"
@@ -89,7 +96,6 @@ class VideoStageProcessor:
         runtime_identity: MediaRuntimeIdentity,
     ) -> VideoStageResult:
         """一つのVideo Sourceの2 Stageを確定または再利用する。"""
-        validate_video_set_snapshot(video_set)
         primary_stream = select_primary_video_stream(
             self._media_runtime.probe(source.path)
         )
@@ -98,7 +104,7 @@ class VideoStageProcessor:
             self._observer,
             subject_namespace="videos",
             subject_fingerprint=source.fingerprint,
-            before_stage=lambda: validate_video_set_snapshot(video_set),
+            before_stage=lambda: validate_video_source_snapshot(video_set, source),
             stage_order=VIDEO_STAGE_ORDER,
         )
         scan_input = _scan_semantic_input(
@@ -171,6 +177,8 @@ class VideoStageProcessor:
         stage_root: Path,
     ) -> dict[str, object]:
         """single-decode scanを実行しscene一時画像を除去する。"""
+        cpu_before = _stage_cpu_seconds()
+        started_at = time.monotonic()
         native_scan = self._media_runtime.scan_video(
             source.path,
             primary_stream,
@@ -187,9 +195,20 @@ class VideoStageProcessor:
                 video_fingerprint=source.fingerprint,
                 decode_backend=configuration.decode_backend,
             )
-            return serialize_video_scan(scan, stage_root)
+            artifact = serialize_video_scan(scan, stage_root)
         finally:
             shutil.rmtree(stage_root / ".scene-proxies", ignore_errors=True)
+        wall_seconds = time.monotonic() - started_at
+        cpu_seconds = _stage_cpu_seconds() - cpu_before
+        metrics = _artifact_metrics(artifact)
+        metrics["wall_seconds"] = wall_seconds
+        metrics["cpu_seconds"] = cpu_seconds
+        metrics["input_seconds_per_wall_second"] = (
+            float(scan.timeline.duration.seconds) / wall_seconds
+            if wall_seconds > 0
+            else 0.0
+        )
+        return artifact
 
     def _produce_extraction_artifact(
         self,
@@ -201,7 +220,7 @@ class VideoStageProcessor:
         stage_root: Path,
     ) -> dict[str, object]:
         """native refinementとcandidate proxy確定を実行する。"""
-        usage_before = resource.getrusage(resource.RUSAGE_CHILDREN)
+        cpu_before = _stage_cpu_seconds()
         started_at = time.monotonic()
         pts_ranges = build_refinement_pts_ranges(
             scan.timeline,
@@ -209,18 +228,16 @@ class VideoStageProcessor:
             configuration.refinement_radius_seconds,
         )
         frames = (
-            tuple(
-                self._media_runtime.scan_video_frame_ranges(
-                    source.path,
-                    scan.primary_stream.index,
-                    pts_ranges,
-                    960,
-                )
+            self._media_runtime.scan_video_frame_ranges(
+                source.path,
+                scan.primary_stream.index,
+                pts_ranges,
+                960,
             )
             if pts_ranges
-            else ()
+            else iter(())
         )
-        extraction = refine_candidate_moments(
+        groups = iter_refined_candidate_groups(
             video_fingerprint=source.fingerprint,
             timeline=scan.timeline,
             moments=moments,
@@ -228,8 +245,42 @@ class VideoStageProcessor:
             refinement_radius_seconds=configuration.refinement_radius_seconds,
             max_frame_candidates=configuration.max_frame_candidates,
         )
+        encoded_groups: list[FrameCandidateExtraction] = []
+        for group in groups:
+            encoded_groups.append(self._encode_candidate_group(group, stage_root))
+            # 次groupのdecode前に選抜前RGBへの最後の参照を解放する。
+            del group
+        extraction = combine_refined_candidate_groups(moments, tuple(encoded_groups))
+        metrics = FrameCandidateExtractionMetrics(
+            wall_seconds=0.0,
+            cpu_seconds=0.0,
+            density_cap=density_cap,
+            actual_moment_count=len(extraction.moments),
+            native_frame_count=extraction.native_frame_count,
+            reject_breakdown=extraction.reject_breakdown,
+            deduplicated_frame_count=extraction.deduplicated_frame_count,
+            zero_frame_moment_count=extraction.zero_frame_moment_count,
+            frame_candidate_count=len(extraction.candidates),
+            frame_candidate_bytes=sum(
+                len(candidate.image_bytes) for candidate in extraction.candidates
+            ),
+        )
+        artifact = serialize_frame_candidate_extraction(extraction, metrics, stage_root)
+        wall_seconds = time.monotonic() - started_at
+        cpu_seconds = _stage_cpu_seconds() - cpu_before
+        artifact_metrics = _artifact_metrics(artifact)
+        artifact_metrics["wall_seconds"] = wall_seconds
+        artifact_metrics["cpu_seconds"] = cpu_seconds
+        return artifact
+
+    def _encode_candidate_group(
+        self,
+        group: FrameCandidateExtraction,
+        stage_root: Path,
+    ) -> FrameCandidateExtraction:
+        """一つのrefinement groupのproxyを書きRGB artifactを解放する。"""
         encoded_candidates = []
-        for candidate in extraction.candidates:
+        for candidate in group.candidates:
             if candidate.decoded_frame is None:
                 msg = "Frame Candidate Proxy用のnative frameがありません"
                 raise ValueError(msg)
@@ -247,30 +298,7 @@ class VideoStageProcessor:
                     decoded_frame=None,
                 )
             )
-        extraction = replace(extraction, candidates=tuple(encoded_candidates))
-        wall_seconds = time.monotonic() - started_at
-        usage_after = resource.getrusage(resource.RUSAGE_CHILDREN)
-        cpu_seconds = (
-            usage_after.ru_utime
-            - usage_before.ru_utime
-            + usage_after.ru_stime
-            - usage_before.ru_stime
-        )
-        metrics = FrameCandidateExtractionMetrics(
-            wall_seconds=wall_seconds,
-            cpu_seconds=cpu_seconds,
-            density_cap=density_cap,
-            actual_moment_count=len(extraction.moments),
-            native_frame_count=extraction.native_frame_count,
-            reject_breakdown=extraction.reject_breakdown,
-            deduplicated_frame_count=extraction.deduplicated_frame_count,
-            zero_frame_moment_count=extraction.zero_frame_moment_count,
-            frame_candidate_count=len(extraction.candidates),
-            frame_candidate_bytes=sum(
-                len(candidate.image_bytes) for candidate in extraction.candidates
-            ),
-        )
-        return serialize_frame_candidate_extraction(extraction, metrics, stage_root)
+        return replace(group, candidates=tuple(encoded_candidates))
 
 
 def _scan_semantic_input(
@@ -291,6 +319,7 @@ def _scan_semantic_input(
         "media_runtime_identity": {
             "ffmpeg_version": runtime_identity.ffmpeg_version,
             "ffprobe_version": runtime_identity.ffprobe_version,
+            "build_capability_sha256": runtime_identity.build_capability_sha256,
         },
         "decode_backend": configuration.decode_backend,
         "heartbeat_interval_seconds": configuration.heartbeat_interval_seconds,
@@ -328,3 +357,22 @@ def _fraction_value(value: Fraction | None) -> dict[str, int] | None:
     if value is None:
         return None
     return {"numerator": value.numerator, "denominator": value.denominator}
+
+
+def _stage_cpu_seconds() -> float:
+    self_usage = resource.getrusage(resource.RUSAGE_SELF)
+    child_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    return (
+        self_usage.ru_utime
+        + self_usage.ru_stime
+        + child_usage.ru_utime
+        + child_usage.ru_stime
+    )
+
+
+def _artifact_metrics(artifact: dict[str, object]) -> dict[str, object]:
+    metrics = artifact.get("metrics")
+    if not isinstance(metrics, dict):
+        msg = "Video Stage artifactにmetric objectがありません"
+        raise ValueError(msg)
+    return metrics

--- a/tests/video_selection/application/test_video_selection_application.py
+++ b/tests/video_selection/application/test_video_selection_application.py
@@ -15,7 +15,10 @@ from src.video_selection.models.frame_candidate import FrameCandidate
 from src.video_selection.models.legacy_cache_cleanup_diagnostic import (
     LegacyCacheCleanupDiagnostic,
 )
-from src.video_selection.models.processing_stage import ProcessingStage
+from src.video_selection.models.processing_stage import (
+    VIDEO_SET_STAGE_ORDER,
+    ProcessingStage,
+)
 from src.video_selection.models.resolved_model_identity import ResolvedModelIdentity
 from src.video_selection.models.run_status import RunStatus
 from src.video_selection.models.selected_image import SelectedImage
@@ -140,15 +143,16 @@ def test_run_publishes_normalized_fake_result_atomically(tmp_path: Path) -> None
         "1. [frame-001](images/0001_frame-001.webp) — "
         "主人公が草原を進んでいる\n"
     )
-    assert tuple(stage.stage for stage in observer.completed_stages) == tuple(
-        ProcessingStage
+    assert (
+        tuple(stage.stage for stage in observer.completed_stages)
+        == VIDEO_SET_STAGE_ORDER
     )
     manifests = tuple(
         (input_folder / ".game-screen-pick" / "cache" / "video-sets").glob(
             "*/*/*/manifest.json"
         )
     )
-    assert len(manifests) == len(ProcessingStage)
+    assert len(manifests) == len(VIDEO_SET_STAGE_ORDER)
 
 
 def test_final_snapshot_failure_discards_staged_output(

--- a/tests/video_selection/fakes/fake_video_stage_media_runtime.py
+++ b/tests/video_selection/fakes/fake_video_stage_media_runtime.py
@@ -1,6 +1,7 @@
 """Video Stage processor test用MediaRuntime fake。"""
 
-from collections.abc import Iterator
+import time
+from collections.abc import Callable, Iterator
 from fractions import Fraction
 from pathlib import Path
 
@@ -18,14 +19,38 @@ from src.video_selection.models.scanned_video_frame import ScannedVideoFrame
 class FakeVideoStageMediaRuntime:
     """決定的なscanとnative frameを返し呼び出し順を記録するfake。"""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        runtime_identity: MediaRuntimeIdentity | None = None,
+        on_preflight: Callable[[], None] | None = None,
+        distant_moments: bool = False,
+        require_streaming_refinement: bool = False,
+        cpu_burn_seconds: float = 0.0,
+        reported_scan_wall_seconds: float = 0.1,
+        reported_scan_cpu_seconds: float = 0.05,
+    ) -> None:
         self.scan_calls: list[Path] = []
         self.range_calls: list[Path] = []
         self.call_order: list[tuple[str, str]] = []
+        self._runtime_identity = runtime_identity or MediaRuntimeIdentity(
+            "6.1.1-test",
+            "6.1.1-test",
+            "0" * 64,
+        )
+        self._on_preflight = on_preflight
+        self._distant_moments = distant_moments
+        self._require_streaming_refinement = require_streaming_refinement
+        self._cpu_burn_seconds = cpu_burn_seconds
+        self._reported_scan_wall_seconds = reported_scan_wall_seconds
+        self._reported_scan_cpu_seconds = reported_scan_cpu_seconds
+        self._candidate_proxy_write_count = 0
 
     def preflight(self) -> MediaRuntimeIdentity:
         """固定runtime identityを返す。"""
-        return MediaRuntimeIdentity("6.1.1-test", "6.1.1-test")
+        if self._on_preflight is not None:
+            self._on_preflight()
+        return self._runtime_identity
 
     def probe(self, media_path: Path) -> MediaProbe:
         """一つのdefault video streamを返す。"""
@@ -72,25 +97,35 @@ class FakeVideoStageMediaRuntime:
         )
         self.scan_calls.append(media_path)
         self.call_order.append(("scan", media_path.name))
+        self._burn_cpu()
         heartbeat_folder = artifact_folder / "heartbeats"
         scene_folder = artifact_folder / ".scene-proxies"
         heartbeat_folder.mkdir(parents=True)
         scene_folder.mkdir()
+        heartbeat_pts = (0, 400) if self._distant_moments else (0, 10)
+        last_frame_pts = 490 if self._distant_moments else 10
+        last_frame_duration_ts = 10
         heartbeats = tuple(
             self._write_scan_frame(heartbeat_folder / f"{pts:012d}.jpg", pts)
-            for pts in (0, 10)
+            for pts in heartbeat_pts
         )
-        scenes = (self._write_scan_frame(scene_folder / "000000000010.jpg", 10),)
+        scene_pts = heartbeat_pts[-1]
+        scenes = (
+            self._write_scan_frame(
+                scene_folder / f"{scene_pts:012d}.jpg",
+                scene_pts,
+            ),
+        )
         return NativeVideoScan(
             stream_index=stream.index,
             origin_pts=0,
-            last_frame_pts=10,
-            last_frame_duration_ts=10,
+            last_frame_pts=last_frame_pts,
+            last_frame_duration_ts=last_frame_duration_ts,
             time_base=Fraction(1, 10),
             heartbeats=heartbeats,
             scene_frames=scenes,
-            wall_seconds=0.1,
-            cpu_seconds=0.05,
+            wall_seconds=self._reported_scan_wall_seconds,
+            cpu_seconds=self._reported_scan_cpu_seconds,
             decode_pass_count=1,
         )
 
@@ -105,8 +140,17 @@ class FakeVideoStageMediaRuntime:
         del max_dimension
         self.range_calls.append(media_path)
         self.call_order.append(("refine", media_path.name))
-        for pts in (0, 5, 10, 15):
+        self._burn_cpu()
+        frame_pts = (0, 5, 395, 400, 405) if self._distant_moments else (0, 5, 10, 15)
+        for pts in frame_pts:
             if any(start <= pts < end for start, end in pts_ranges):
+                if (
+                    self._require_streaming_refinement
+                    and pts == 400
+                    and self._candidate_proxy_write_count == 0
+                ):
+                    msg = "次のrefinement groupより前にproxyが書かれていません"
+                    raise AssertionError(msg)
                 yield self._decoded_frame(stream_index, pts)
 
     def write_mjpeg_proxy(
@@ -128,6 +172,14 @@ class FakeVideoStageMediaRuntime:
             raise RuntimeError("test JPEG encode failed")
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_bytes(encoded.tobytes())
+        if "candidates" in output_path.parts:
+            self._candidate_proxy_write_count += 1
+
+    def _burn_cpu(self) -> None:
+        """Stage resource metric test用にcurrent processのCPUを消費する。"""
+        started_at = time.process_time()
+        while time.process_time() - started_at < self._cpu_burn_seconds:
+            pass
 
     def _write_scan_frame(self, path: Path, pts: int) -> ScannedVideoFrame:
         frame = self._decoded_frame(0, pts)

--- a/tests/video_selection/fakes/fake_video_stage_media_runtime.py
+++ b/tests/video_selection/fakes/fake_video_stage_media_runtime.py
@@ -1,0 +1,158 @@
+"""Video Stage processor test用MediaRuntime fake。"""
+
+from collections.abc import Iterator
+from fractions import Fraction
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from src.video_selection.models.decoded_video_frame import DecodedVideoFrame
+from src.video_selection.models.media_probe import MediaProbe
+from src.video_selection.models.media_runtime_identity import MediaRuntimeIdentity
+from src.video_selection.models.media_stream import MediaStream
+from src.video_selection.models.native_video_scan import NativeVideoScan
+from src.video_selection.models.scanned_video_frame import ScannedVideoFrame
+
+
+class FakeVideoStageMediaRuntime:
+    """決定的なscanとnative frameを返し呼び出し順を記録するfake。"""
+
+    def __init__(self) -> None:
+        self.scan_calls: list[Path] = []
+        self.range_calls: list[Path] = []
+        self.call_order: list[tuple[str, str]] = []
+
+    def preflight(self) -> MediaRuntimeIdentity:
+        """固定runtime identityを返す。"""
+        return MediaRuntimeIdentity("6.1.1-test", "6.1.1-test")
+
+    def probe(self, media_path: Path) -> MediaProbe:
+        """一つのdefault video streamを返す。"""
+        self.call_order.append(("probe", media_path.name))
+        return MediaProbe(
+            format_names=("matroska",),
+            streams=(
+                MediaStream(
+                    index=0,
+                    kind="video",
+                    codec_name="ffv1",
+                    time_base=Fraction(1, 10),
+                    start_pts=0,
+                    duration_ts=20,
+                    width=64,
+                    height=48,
+                    sample_rate=None,
+                    channels=None,
+                    language=None,
+                    is_default=True,
+                    is_forced=False,
+                    is_attached_picture=False,
+                ),
+            ),
+        )
+
+    def scan_video(
+        self,
+        media_path: Path,
+        stream: MediaStream,
+        artifact_folder: Path,
+        *,
+        heartbeat_interval_seconds: float,
+        scene_change_threshold: float,
+        scene_min_interval_seconds: float,
+        decode_backend: str,
+    ) -> NativeVideoScan:
+        """2件のheartbeatと1件の一時scene frameを生成する。"""
+        del (
+            heartbeat_interval_seconds,
+            scene_change_threshold,
+            scene_min_interval_seconds,
+            decode_backend,
+        )
+        self.scan_calls.append(media_path)
+        self.call_order.append(("scan", media_path.name))
+        heartbeat_folder = artifact_folder / "heartbeats"
+        scene_folder = artifact_folder / ".scene-proxies"
+        heartbeat_folder.mkdir(parents=True)
+        scene_folder.mkdir()
+        heartbeats = tuple(
+            self._write_scan_frame(heartbeat_folder / f"{pts:012d}.jpg", pts)
+            for pts in (0, 10)
+        )
+        scenes = (self._write_scan_frame(scene_folder / "000000000010.jpg", 10),)
+        return NativeVideoScan(
+            stream_index=stream.index,
+            origin_pts=0,
+            last_frame_pts=10,
+            last_frame_duration_ts=10,
+            time_base=Fraction(1, 10),
+            heartbeats=heartbeats,
+            scene_frames=scenes,
+            wall_seconds=0.1,
+            cpu_seconds=0.05,
+            decode_pass_count=1,
+        )
+
+    def scan_video_frame_ranges(
+        self,
+        media_path: Path,
+        stream_index: int,
+        pts_ranges: tuple[tuple[int, int], ...],
+        max_dimension: int,
+    ) -> Iterator[DecodedVideoFrame]:
+        """range内のnative test frameを返す。"""
+        del max_dimension
+        self.range_calls.append(media_path)
+        self.call_order.append(("refine", media_path.name))
+        for pts in (0, 5, 10, 15):
+            if any(start <= pts < end for start, end in pts_ranges):
+                yield self._decoded_frame(stream_index, pts)
+
+    def write_mjpeg_proxy(
+        self,
+        frame: DecodedVideoFrame,
+        output_path: Path,
+        *,
+        quality: int,
+    ) -> None:
+        """test用JPEG proxyを保存する。"""
+        del quality
+        rgb = np.frombuffer(frame.pixels, dtype=np.uint8).reshape(
+            frame.height,
+            frame.width,
+            3,
+        )
+        success, encoded = cv2.imencode(".jpg", cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR))
+        if not success:
+            raise RuntimeError("test JPEG encode failed")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(encoded.tobytes())
+
+    def _write_scan_frame(self, path: Path, pts: int) -> ScannedVideoFrame:
+        frame = self._decoded_frame(0, pts)
+        self.write_mjpeg_proxy(frame, path, quality=3)
+        return ScannedVideoFrame(
+            source_pts=pts,
+            duration_ts=5,
+            time_base=Fraction(1, 10),
+            width=frame.width,
+            height=frame.height,
+            image_path=path,
+        )
+
+    @staticmethod
+    def _decoded_frame(stream_index: int, pts: int) -> DecodedVideoFrame:
+        rows, columns = np.indices((48, 64))
+        values = ((rows // 3 + columns // 4 + pts // 5) % 3 * 90 + 25).astype(np.uint8)
+        rgb = np.stack((values, np.roll(values, 5, axis=1), 255 - values), axis=2)
+        return DecodedVideoFrame(
+            stream_index=stream_index,
+            pts=pts,
+            duration_ts=5,
+            time_base=Fraction(1, 10),
+            width=64,
+            height=48,
+            pixel_format="rgb24",
+            pixels=rgb.tobytes(),
+        )

--- a/tests/video_selection/services/test_analyze_neutral_images.py
+++ b/tests/video_selection/services/test_analyze_neutral_images.py
@@ -1,0 +1,130 @@
+"""Neutral Image Analysisのtest。"""
+
+from fractions import Fraction
+
+import cv2
+import numpy as np
+import pytest
+
+from src.video_selection.models.content_reject_reason import ContentRejectReason
+from src.video_selection.models.decoded_video_frame import DecodedVideoFrame
+from src.video_selection.services.analyze_neutral_images import analyze_neutral_images
+
+
+def _frame(source_pts: int, rgb: np.ndarray) -> DecodedVideoFrame:
+    height, width = rgb.shape[:2]
+    return DecodedVideoFrame(
+        stream_index=0,
+        pts=source_pts,
+        duration_ts=1,
+        time_base=Fraction(1, 10),
+        width=width,
+        height=height,
+        pixel_format="rgb24",
+        pixels=rgb.astype(np.uint8).tobytes(),
+    )
+
+
+def _checkerboard() -> np.ndarray:
+    rows, columns = np.indices((48, 64))
+    values = ((rows // 4 + columns // 4) % 2 * 180 + 35).astype(np.uint8)
+    return np.stack((values, np.roll(values, 5, axis=1), 255 - values), axis=2)
+
+
+@pytest.mark.parametrize(
+    ("rgb", "expected_reason"),
+    [
+        pytest.param(
+            np.zeros((48, 64, 3), dtype=np.uint8),
+            ContentRejectReason.BLACKOUT,
+            id="blackout",
+        ),
+        pytest.param(
+            np.full((48, 64, 3), 255, dtype=np.uint8),
+            ContentRejectReason.WHITEOUT,
+            id="whiteout",
+        ),
+        pytest.param(
+            np.full((48, 64, 3), (35, 90, 145), dtype=np.uint8),
+            ContentRejectReason.SINGLE_TONE,
+            id="single-tone",
+        ),
+    ],
+)
+def test_absolute_invalid_frame_has_stable_reject_reason(
+    rgb: np.ndarray,
+    expected_reason: ContentRejectReason,
+) -> None:
+    """明確な無効frameがstable Content Reject Reasonで除外されること。
+
+    Arrange:
+        - 黒、白、または単色のRGB frameが用意される
+    Act:
+        - model-free Neutral Image Analysisが実行される
+    Assert:
+        - 対応するstable reasonが返されること
+    """
+    # Arrange
+    frame = _frame(0, rgb)
+
+    # Act
+    analysis = analyze_neutral_images((frame,))[0]
+
+    # Assert
+    assert analysis.reject_reason is expected_reason
+    assert not analysis.eligible
+
+
+def test_smooth_blurred_frame_is_rejected_without_model_inference() -> None:
+    """低周波だけのぼけframeがversioned閾値で除外されること。
+
+    Arrange:
+        - 色と輝度範囲はあるがedgeを持たない滑らかなframeが用意される
+    Act:
+        - Neutral Image Analysisが実行される
+    Assert:
+        - blurとして除外されること
+    """
+    # Arrange
+    gradient = np.tile(np.linspace(20, 220, 64, dtype=np.uint8), (48, 1))
+    smooth = cv2.GaussianBlur(
+        np.stack((gradient, np.flipud(gradient), gradient), axis=2),
+        (15, 15),
+        0,
+    )
+
+    # Act
+    analysis = analyze_neutral_images((_frame(0, smooth),))[0]
+
+    # Assert
+    assert analysis.reject_reason is ContentRejectReason.BLUR
+
+
+def test_visual_feature_is_l2_normalized_and_temporal_transition_is_rejected() -> None:
+    """model-free視覚特徴と前後関係から遷移frameが解析されること。
+
+    Arrange:
+        - 同じ高情報frameの間に暗いoverlay frameが置かれる
+    Act:
+        - 動画内分布を使うNeutral Image Analysisが実行される
+    Assert:
+        - 有効frameのHSV・輝度・edge特徴がL2正規化されること
+        - 中央frameだけがtemporal transitionとして除外されること
+    """
+    # Arrange
+    detailed = _checkerboard()
+    dark_overlay = (detailed.astype(np.float32) * 0.22 + 12).astype(np.uint8)
+    frames = (
+        _frame(0, detailed),
+        _frame(1, dark_overlay),
+        _frame(2, detailed),
+    )
+
+    # Act
+    analyses = analyze_neutral_images(frames)
+
+    # Assert
+    assert analyses[0].reject_reason is None
+    assert analyses[2].reject_reason is None
+    assert np.linalg.norm(analyses[0].visual_feature) == pytest.approx(1.0)
+    assert analyses[1].reject_reason is ContentRejectReason.TEMPORAL_TRANSITION

--- a/tests/video_selection/services/test_analyze_neutral_images.py
+++ b/tests/video_selection/services/test_analyze_neutral_images.py
@@ -128,3 +128,29 @@ def test_visual_feature_is_l2_normalized_and_temporal_transition_is_rejected() -
     assert analyses[2].reject_reason is None
     assert np.linalg.norm(analyses[0].visual_feature) == pytest.approx(1.0)
     assert analyses[1].reject_reason is ContentRejectReason.TEMPORAL_TRANSITION
+
+
+def test_temporal_transition_requires_exact_native_frame_adjacency() -> None:
+    """離れたsampleがtemporal transitionの前後frameにされないこと。
+
+    Arrange:
+        - 同じ高情報frameの間に暗いoverlayが離れたPTSで用意される
+    Act:
+        - Neutral Image Analysisが実行される
+    Assert:
+        - 中央sampleがtemporal transitionとして除外されないこと
+    """
+    # Arrange
+    detailed = _checkerboard()
+    dark_overlay = (detailed.astype(np.float32) * 0.22 + 12).astype(np.uint8)
+    frames = (
+        _frame(0, detailed),
+        _frame(10, dark_overlay),
+        _frame(20, detailed),
+    )
+
+    # Act
+    analyses = analyze_neutral_images(frames)
+
+    # Assert
+    assert analyses[1].reject_reason is not ContentRejectReason.TEMPORAL_TRANSITION

--- a/tests/video_selection/services/test_build_exact_timeline.py
+++ b/tests/video_selection/services/test_build_exact_timeline.py
@@ -1,0 +1,111 @@
+"""exact video timeline構築のtest。"""
+
+from fractions import Fraction
+
+import pytest
+
+from src.video_selection.models.media_stream import MediaStream
+from src.video_selection.services.build_exact_timeline import build_exact_timeline
+
+
+def _stream(
+    *,
+    start_pts: int | None = None,
+    duration_ts: int | None = None,
+) -> MediaStream:
+    return MediaStream(
+        index=0,
+        kind="video",
+        codec_name="ffv1",
+        time_base=Fraction(1, 1000),
+        start_pts=start_pts,
+        duration_ts=duration_ts,
+        width=64,
+        height=48,
+        sample_rate=None,
+        channels=None,
+        language=None,
+        is_default=True,
+        is_forced=False,
+        is_attached_picture=False,
+    )
+
+
+def test_frame_duration_builds_gapless_timeline_with_later_boundary_ownership() -> None:
+    """最終frame終端とscene境界からgapのないtimelineが構築されること。
+
+    Arrange:
+        - originが100で最終frame終端が1秒となるVFR timingが用意される
+        - 0.25秒と0.75秒にscene signalが用意される
+    Act:
+        - exact timelineが構築される
+    Assert:
+        - 3区間が0から1秒をgapとoverlapなしで覆うこと
+        - 0.25秒境界が後側区間に所属すること
+    """
+    # Arrange / Act
+    timeline = build_exact_timeline(
+        video_fingerprint="a" * 64,
+        stream=_stream(),
+        origin_pts=100,
+        last_frame_pts=850,
+        last_frame_duration_ts=250,
+        scene_pts=(350, 850, 1100),
+    )
+
+    # Assert
+    assert timeline.duration.seconds == Fraction(1)
+    assert [(item.start, item.end) for item in timeline.segments] == [
+        (Fraction(0), Fraction(1, 4)),
+        (Fraction(1, 4), Fraction(3, 4)),
+        (Fraction(3, 4), Fraction(1)),
+    ]
+    assert timeline.segment_at(Fraction(1, 4)) == timeline.segments[1]
+    assert all(item.identifier.startswith("seg_") for item in timeline.segments)
+    assert all(len(item.identifier) == 68 for item in timeline.segments)
+
+
+def test_stream_duration_is_used_only_when_last_frame_duration_is_missing() -> None:
+    """最終frame duration欠落時だけstreamのexact終端が使われること。
+
+    Arrange:
+        - exactなstream startとdurationを持つtimingが用意される
+    Act:
+        - 最終frame durationなしでtimelineが構築される
+    Assert:
+        - stream終端からoriginを引いた3/4秒がVideo Durationになること
+    """
+    # Arrange / Act
+    timeline = build_exact_timeline(
+        video_fingerprint="b" * 64,
+        stream=_stream(start_pts=100, duration_ts=1000),
+        origin_pts=350,
+        last_frame_pts=850,
+        last_frame_duration_ts=None,
+        scene_pts=(),
+    )
+
+    # Assert
+    assert timeline.duration.seconds == Fraction(3, 4)
+
+
+def test_timeline_without_exact_positive_end_fails_fast() -> None:
+    """exactな正の終端を得られないtimelineが拒否されること。
+
+    Arrange:
+        - frame durationとstream durationの両方を欠くtimingが用意される
+    Act:
+        - timeline構築が試行される
+    Assert:
+        - floatやframe間隔で推測されず失敗すること
+    """
+    # Arrange / Act / Assert
+    with pytest.raises(ValueError, match="Video Duration"):
+        build_exact_timeline(
+            video_fingerprint="c" * 64,
+            stream=_stream(),
+            origin_pts=0,
+            last_frame_pts=1000,
+            last_frame_duration_ts=None,
+            scene_pts=(),
+        )

--- a/tests/video_selection/services/test_build_video_scan_result.py
+++ b/tests/video_selection/services/test_build_video_scan_result.py
@@ -1,0 +1,113 @@
+"""Video Scan result構築のtest。"""
+
+import gc
+import weakref
+from fractions import Fraction
+from pathlib import Path
+
+import pytest
+
+import src.video_selection.services.build_video_scan_result as scan_result_module
+from src.video_selection.models.decoded_video_frame import DecodedVideoFrame
+from src.video_selection.models.media_stream import MediaStream
+from src.video_selection.models.native_video_scan import NativeVideoScan
+from src.video_selection.models.scanned_video_frame import ScannedVideoFrame
+
+
+def test_heartbeat_proxies_are_analyzed_without_retaining_all_decoded_rgb(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Heartbeat Proxyのdecoded RGBが全件同時保持されず解析されること。
+
+    Arrange:
+        - 複数のHeartbeat Proxyと生存frame数を記録するdecoderが用意される
+    Act:
+        - Native Video ScanからVideo Scan resultが構築される
+    Assert:
+        - 次のproxy decode時に保持される既存decoded frameが1件以下であること
+        - 全Heartbeat Proxyがresultへ変換されること
+    """
+    # Arrange
+    heartbeat_folder = tmp_path / "heartbeats"
+    heartbeat_folder.mkdir()
+    scanned_frames = tuple(
+        ScannedVideoFrame(
+            source_pts=pts,
+            duration_ts=1,
+            time_base=Fraction(1),
+            width=2,
+            height=2,
+            image_path=heartbeat_folder / f"{pts:012d}.jpg",
+        )
+        for pts in range(8)
+    )
+    for frame in scanned_frames:
+        frame.image_path.write_bytes(b"proxy")
+    native_scan = NativeVideoScan(
+        stream_index=0,
+        origin_pts=0,
+        last_frame_pts=7,
+        last_frame_duration_ts=1,
+        time_base=Fraction(1),
+        heartbeats=scanned_frames,
+        scene_frames=(),
+        wall_seconds=1.0,
+        cpu_seconds=0.5,
+        decode_pass_count=1,
+    )
+    primary_stream = MediaStream(
+        index=0,
+        kind="video",
+        codec_name="ffv1",
+        time_base=Fraction(1),
+        start_pts=0,
+        duration_ts=8,
+        width=2,
+        height=2,
+        sample_rate=None,
+        channels=None,
+        language=None,
+        is_default=True,
+        is_forced=False,
+        is_attached_picture=False,
+    )
+    frame_references: list[weakref.ReferenceType[DecodedVideoFrame]] = []
+    max_retained_before_decode = 0
+
+    def decode_proxy(
+        frame: ScannedVideoFrame,
+        stream_index: int,
+    ) -> DecodedVideoFrame:
+        nonlocal max_retained_before_decode
+        gc.collect()
+        max_retained_before_decode = max(
+            max_retained_before_decode,
+            sum(reference() is not None for reference in frame_references),
+        )
+        decoded = DecodedVideoFrame(
+            stream_index=stream_index,
+            pts=frame.source_pts,
+            duration_ts=frame.duration_ts,
+            time_base=frame.time_base,
+            width=2,
+            height=2,
+            pixel_format="rgb24",
+            pixels=bytes([frame.source_pts] * 12),
+        )
+        frame_references.append(weakref.ref(decoded))
+        return decoded
+
+    monkeypatch.setattr(scan_result_module, "_decode_proxy", decode_proxy)
+
+    # Act
+    result = scan_result_module.build_video_scan_result(
+        native_scan=native_scan,
+        primary_stream=primary_stream,
+        video_fingerprint="d" * 64,
+        decode_backend="software",
+    )
+
+    # Assert
+    assert len(result.heartbeats) == len(scanned_frames)
+    assert max_retained_before_decode <= 1

--- a/tests/video_selection/services/test_completed_stage_writer.py
+++ b/tests/video_selection/services/test_completed_stage_writer.py
@@ -365,3 +365,67 @@ def test_artifact_or_manifest_write_failure_is_not_reusable(
     stage_root = cache_folder / "videos" / subject_fingerprint / stage.value
     assert not (stage_root / fingerprint.value).exists()
     assert tuple(stage_root.glob("*.tmp")) == ()
+
+
+def test_multi_artifact_stage_requires_every_artifact_to_be_intact(
+    tmp_path: Path,
+) -> None:
+    """複数artifactがすべて健全な場合だけCompleted Stageが復元されること。
+
+    Arrange:
+        - JSON artifactと2件のproxy画像を生成するproducerが用意される
+    Act:
+        - Stageが確定され、片方のproxyが後から破損される
+    Assert:
+        - 確定直後はartifactとStage rootが復元されること
+        - 1件でも破損した後はStage全体が再利用されないこと
+    """
+    # Arrange
+    cache_folder = tmp_path / "cache"
+    subject_fingerprint = "1" * 64
+    stage = ProcessingStage.EXTRACT_FRAME_CANDIDATES
+    semantic_input = {"algorithm": "candidate-v1"}
+    fingerprint = build_stage_fingerprint(stage, (), semantic_input)
+    writer = CompletedStageWriter(
+        cache_folder,
+        subject_namespace="videos",
+        subject_fingerprint=subject_fingerprint,
+    )
+
+    def produce_artifacts(stage_folder: Path) -> dict[str, object]:
+        proxy_folder = stage_folder / "candidates"
+        proxy_folder.mkdir()
+        (proxy_folder / "first.jpg").write_bytes(b"first-proxy")
+        (proxy_folder / "second.jpg").write_bytes(b"second-proxy")
+        return {
+            "candidate_proxy_paths": [
+                "candidates/first.jpg",
+                "candidates/second.jpg",
+            ]
+        }
+
+    # Act
+    writer.write_artifacts(
+        stage,
+        fingerprint,
+        (),
+        semantic_input,
+        produce_artifacts,
+    )
+    restored = writer.read_bundle(stage, fingerprint, (), semantic_input)
+
+    # Assert
+    assert restored is not None
+    assert restored.artifact == {
+        "candidate_proxy_paths": [
+            "candidates/first.jpg",
+            "candidates/second.jpg",
+        ]
+    }
+    assert restored.root.joinpath("candidates/first.jpg").read_bytes() == b"first-proxy"
+
+    # Act
+    restored.root.joinpath("candidates/second.jpg").write_bytes(b"corrupt")
+
+    # Assert
+    assert writer.read_bundle(stage, fingerprint, (), semantic_input) is None

--- a/tests/video_selection/services/test_discover_candidate_moments.py
+++ b/tests/video_selection/services/test_discover_candidate_moments.py
@@ -1,7 +1,9 @@
 """Candidate Moment discoveryのtest。"""
 
+from collections.abc import Iterator
 from fractions import Fraction
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from src.video_selection.models.heartbeat_proxy import HeartbeatProxy
 from src.video_selection.models.scene_signal import SceneSignal
@@ -111,3 +113,44 @@ def test_same_exact_anchor_merges_heartbeat_and_scene_evidence() -> None:
     assert moment.evidence == ("heartbeat", "scene")
     assert moment.identifier.startswith("mom_")
     assert len(moment.identifier) == 68
+
+
+def test_scene_quality_lookup_does_not_rescan_all_heartbeats() -> None:
+    """scene品質参照でheartbeat全体がsceneごとに再走査されないこと。
+
+    Arrange:
+        - timeline順のheartbeatと多数のscene signalが用意される
+        - heartbeat iterableの走査回数が記録される
+    Act:
+        - 各scene周辺の品質を使ってCandidate Momentが発見される
+    Assert:
+        - heartbeat iterableの全走査が定数回に抑えられること
+    """
+    # Arrange
+    heartbeat_values = tuple(_heartbeat(second, 0.70) for second in range(50))
+    scenes = tuple(
+        SceneSignal(second, Fraction(second), 0.80, True) for second in range(50)
+    )
+    heartbeat_iteration_count = 0
+
+    def iterate_heartbeats() -> Iterator[HeartbeatProxy]:
+        nonlocal heartbeat_iteration_count
+        heartbeat_iteration_count += 1
+        return iter(heartbeat_values)
+
+    heartbeats = MagicMock()
+    heartbeats.__iter__.side_effect = iterate_heartbeats
+
+    # Act
+    discovery = discover_candidate_moments(
+        video_fingerprint="c" * 64,
+        timeline=_timeline(),
+        heartbeats=heartbeats,
+        scene_signals=scenes,
+        density_per_minute=60.0,
+        refinement_radius_seconds=1.0,
+    )
+
+    # Assert
+    assert discovery.moments
+    assert heartbeat_iteration_count <= 2

--- a/tests/video_selection/services/test_discover_candidate_moments.py
+++ b/tests/video_selection/services/test_discover_candidate_moments.py
@@ -1,0 +1,113 @@
+"""Candidate Moment discoveryのtest。"""
+
+from fractions import Fraction
+from pathlib import Path
+
+from src.video_selection.models.heartbeat_proxy import HeartbeatProxy
+from src.video_selection.models.scene_signal import SceneSignal
+from src.video_selection.models.timeline_segment import TimelineSegment
+from src.video_selection.models.video_duration import VideoDuration
+from src.video_selection.models.video_timeline import VideoTimeline
+from src.video_selection.services.discover_candidate_moments import (
+    discover_candidate_moments,
+)
+
+
+def _timeline() -> VideoTimeline:
+    return VideoTimeline(
+        origin_pts=0,
+        time_base=Fraction(1),
+        duration=VideoDuration(Fraction(90)),
+        segments=(
+            TimelineSegment("seg_" + "1" * 64, Fraction(0), Fraction(45)),
+            TimelineSegment("seg_" + "2" * 64, Fraction(45), Fraction(90)),
+        ),
+    )
+
+
+def _heartbeat(
+    second: int,
+    quality_score: float,
+    *,
+    eligible: bool = True,
+) -> HeartbeatProxy:
+    return HeartbeatProxy(
+        source_pts=second,
+        video_time=Fraction(second),
+        proxy_path=Path(f"heartbeats/{second}.jpg"),
+        quality_score=quality_score,
+        eligible=eligible,
+    )
+
+
+def test_density_keeps_best_anchor_and_allows_empty_windows() -> None:
+    """各density windowで最大1件だけが選ばれ空区間が保持されること。
+
+    Arrange:
+        - 90秒timelineにheartbeatとscene signalが配置される
+        - 最後の30秒には無効なheartbeatだけが配置される
+    Act:
+        - 毎分2件、refinement半径2秒でMomentが発見される
+    Assert:
+        - 最初のwindowではscene画像の高い画質を持つanchorが選ばれること
+        - 2番目はheartbeat、最後は0件となること
+    """
+    # Arrange
+    heartbeats = (
+        _heartbeat(5, 0.60),
+        _heartbeat(10, 0.80),
+        _heartbeat(35, 0.70),
+        _heartbeat(65, 0.99, eligible=False),
+    )
+    scenes = (
+        SceneSignal(6, Fraction(6), 0.90, True),
+        SceneSignal(66, Fraction(66), 1.00, False),
+    )
+
+    # Act
+    discovery = discover_candidate_moments(
+        video_fingerprint="a" * 64,
+        timeline=_timeline(),
+        heartbeats=heartbeats,
+        scene_signals=scenes,
+        density_per_minute=2.0,
+        refinement_radius_seconds=2.0,
+    )
+
+    # Assert
+    assert discovery.density_cap == 3
+    assert [item.anchor_time for item in discovery.moments] == [
+        Fraction(6),
+        Fraction(35),
+    ]
+    assert discovery.moments[0].evidence == ("scene",)
+    assert discovery.moments[0].timeline_segment_id == "seg_" + "1" * 64
+
+
+def test_same_exact_anchor_merges_heartbeat_and_scene_evidence() -> None:
+    """同じexact anchorの複数根拠が一つのCandidate Momentへ統合されること。
+
+    Arrange:
+        - 同じPTSにheartbeatとscene signalが用意される
+    Act:
+        - Candidate Momentが発見される
+    Assert:
+        - 一つのMomentが両方のevidenceを持つこと
+        - IDがmom_と64桁SHA-256で構成されること
+    """
+    # Arrange / Act
+    discovery = discover_candidate_moments(
+        video_fingerprint="b" * 64,
+        timeline=_timeline(),
+        heartbeats=(_heartbeat(15, 0.70),),
+        scene_signals=(SceneSignal(15, Fraction(15), 0.75, True),),
+        density_per_minute=2.0,
+        refinement_radius_seconds=1.0,
+    )
+
+    # Assert
+    assert len(discovery.moments) == 1
+    moment = discovery.moments[0]
+    assert moment.evidence == ("heartbeat", "scene")
+    assert moment.identifier.startswith("mom_")
+    assert len(moment.identifier) == 68

--- a/tests/video_selection/services/test_processing_stage_runner.py
+++ b/tests/video_selection/services/test_processing_stage_runner.py
@@ -192,3 +192,57 @@ def test_snapshot_validation_failure_prevents_stage_cache_mutation(
         )
     assert observer.completed_stages == []
     assert not (cache_folder / "video-sets").exists()
+
+
+def test_video_stage_runner_completes_scan_before_candidate_extraction(
+    tmp_path: Path,
+) -> None:
+    """動画単位のStageがscanからcandidate抽出の順で確定されること。
+
+    Arrange:
+        - Video Stage専用の順序を持つrunnerが用意される
+    Act:
+        - scanの複数artifactとcandidate抽出artifactが順番に確定される
+    Assert:
+        - 2つのCompleted Stageが動画用順序で通知されること
+        - scanのproxy artifactが検証済みbundleから参照されること
+    """
+    # Arrange
+    cache_folder = tmp_path / "cache"
+    observer = RecordingRunObserver()
+    runner = ProcessingStageRunner(
+        cache_folder,
+        observer,
+        subject_namespace="videos",
+        subject_fingerprint="2" * 64,
+        stage_order=(
+            ProcessingStage.SCAN_VIDEO,
+            ProcessingStage.EXTRACT_FRAME_CANDIDATES,
+        ),
+    )
+
+    def produce_scan(stage_folder: Path) -> dict[str, object]:
+        heartbeat_folder = stage_folder / "heartbeats"
+        heartbeat_folder.mkdir()
+        (heartbeat_folder / "000.jpg").write_bytes(b"heartbeat")
+        return {"heartbeat_proxy_paths": ["heartbeats/000.jpg"]}
+
+    # Act
+    scan_bundle = runner.complete_artifacts(
+        ProcessingStage.SCAN_VIDEO,
+        {"scan_algorithm": "v1"},
+        produce_scan,
+    )
+    runner.complete(
+        ProcessingStage.EXTRACT_FRAME_CANDIDATES,
+        {"candidate_algorithm": "v1"},
+        {"candidate_ids": []},
+    )
+
+    # Assert
+    assert [item.stage for item in runner.completed_stages] == [
+        ProcessingStage.SCAN_VIDEO,
+        ProcessingStage.EXTRACT_FRAME_CANDIDATES,
+    ]
+    assert observer.completed_stages == list(runner.completed_stages)
+    assert scan_bundle.root.joinpath("heartbeats/000.jpg").read_bytes() == b"heartbeat"

--- a/tests/video_selection/services/test_refine_candidate_moments.py
+++ b/tests/video_selection/services/test_refine_candidate_moments.py
@@ -1,0 +1,161 @@
+"""Frame Refinementのtest。"""
+
+from fractions import Fraction
+
+import numpy as np
+
+from src.video_selection.models.candidate_moment import CandidateMoment
+from src.video_selection.models.content_reject_reason import ContentRejectReason
+from src.video_selection.models.decoded_video_frame import DecodedVideoFrame
+from src.video_selection.models.timeline_segment import TimelineSegment
+from src.video_selection.models.video_duration import VideoDuration
+from src.video_selection.models.video_timeline import VideoTimeline
+from src.video_selection.services.refine_candidate_moments import (
+    refine_candidate_moments,
+)
+
+
+def _timeline(duration_seconds: int = 5) -> VideoTimeline:
+    return VideoTimeline(
+        origin_pts=0,
+        time_base=Fraction(1, 10),
+        duration=VideoDuration(Fraction(duration_seconds)),
+        segments=(
+            TimelineSegment(
+                "seg_" + "1" * 64,
+                Fraction(0),
+                Fraction(duration_seconds),
+            ),
+        ),
+    )
+
+
+def _moment(digest_character: str, second: Fraction) -> CandidateMoment:
+    return CandidateMoment(
+        identifier="mom_" + digest_character * 64,
+        source_pts=int(second * 10),
+        anchor_time=second,
+        timeline_segment_id="seg_" + "1" * 64,
+        evidence=("heartbeat",),
+        proxy_quality_score=0.8,
+    )
+
+
+def _detailed_frame(source_pts: int, shift: int = 0) -> DecodedVideoFrame:
+    rows, columns = np.indices((48, 64))
+    values = ((rows // 3 + columns // 4 + shift) % 3 * 90 + 25).astype(np.uint8)
+    rgb = np.stack(
+        (values, np.roll(values, shift + 3, axis=1), 255 - values),
+        axis=2,
+    )
+    return DecodedVideoFrame(
+        stream_index=0,
+        pts=source_pts,
+        duration_ts=1,
+        time_base=Fraction(1, 10),
+        width=64,
+        height=48,
+        pixel_format="rgb24",
+        pixels=rgb.tobytes(),
+    )
+
+
+def test_overlapping_moments_share_same_pts_frame_candidate() -> None:
+    """重なるMomentから同一PTSのFrame Candidateが共有されること。
+
+    Arrange:
+        - refinement範囲が重なる2つのMomentと3つのnative frameが用意される
+    Act:
+        - 各Momentから最大2frameが選抜される
+    Assert:
+        - 両Momentが少なくとも一つの同じFrame Candidate IDを参照すること
+        - Video Source内のFrame Candidate IDが重複生成されないこと
+    """
+    # Arrange
+    moments = (
+        _moment("2", Fraction(2)),
+        _moment("3", Fraction(3)),
+    )
+    frames = (
+        _detailed_frame(10, 0),
+        _detailed_frame(20, 1),
+        _detailed_frame(30, 2),
+    )
+
+    # Act
+    extraction = refine_candidate_moments(
+        video_fingerprint="a" * 64,
+        timeline=_timeline(),
+        moments=moments,
+        frames=frames,
+        refinement_radius_seconds=1.1,
+        max_frame_candidates=2,
+    )
+
+    # Assert
+    first_ids = set(extraction.moments[0].frame_candidate_ids)
+    second_ids = set(extraction.moments[1].frame_candidate_ids)
+    assert first_ids & second_ids
+    assert len({item.identifier for item in extraction.candidates}) == len(
+        extraction.candidates
+    )
+    assert all(item.identifier.startswith("frm_") for item in extraction.candidates)
+
+
+def test_per_moment_deduplication_and_zero_frame_moment_are_reported() -> None:
+    """近似重複がMoment内だけで除外され0-frame Momentが保持されること。
+
+    Arrange:
+        - 同一画面に近い2frame、黒frame、frameを持たないMomentが用意される
+    Act:
+        - Frame Refinementが実行される
+    Assert:
+        - 近似重複の片方だけが最初のMomentへ残ること
+        - 黒frameがstable reasonへ集計されること
+        - 最後のMomentが0-frameのまま診断対象として保持されること
+    """
+    # Arrange
+    detailed = _detailed_frame(10, 0)
+    almost_same_pixels = np.frombuffer(detailed.pixels, dtype=np.uint8).copy()
+    almost_same_pixels[::97] = np.minimum(almost_same_pixels[::97] + 1, 255)
+    almost_same = DecodedVideoFrame(
+        stream_index=0,
+        pts=11,
+        duration_ts=1,
+        time_base=Fraction(1, 10),
+        width=64,
+        height=48,
+        pixel_format="rgb24",
+        pixels=almost_same_pixels.tobytes(),
+    )
+    black = DecodedVideoFrame(
+        stream_index=0,
+        pts=40,
+        duration_ts=1,
+        time_base=Fraction(1, 10),
+        width=64,
+        height=48,
+        pixel_format="rgb24",
+        pixels=bytes(64 * 48 * 3),
+    )
+    moments = (
+        _moment("4", Fraction(1)),
+        _moment("5", Fraction(4)),
+    )
+
+    # Act
+    extraction = refine_candidate_moments(
+        video_fingerprint="b" * 64,
+        timeline=_timeline(),
+        moments=moments,
+        frames=(detailed, almost_same, black),
+        refinement_radius_seconds=0.2,
+        max_frame_candidates=3,
+    )
+
+    # Assert
+    assert len(extraction.moments[0].frame_candidate_ids) == 1
+    assert extraction.moments[1].frame_candidate_ids == ()
+    assert extraction.deduplicated_frame_count == 1
+    assert extraction.zero_frame_moment_count == 1
+    assert extraction.reject_breakdown[ContentRejectReason.BLACKOUT.value] == 1

--- a/tests/video_selection/services/test_select_primary_video_stream.py
+++ b/tests/video_selection/services/test_select_primary_video_stream.py
@@ -1,0 +1,83 @@
+"""Primary Video Stream選択のtest。"""
+
+from fractions import Fraction
+
+import pytest
+
+from src.video_selection.models.media_probe import MediaProbe
+from src.video_selection.models.media_stream import MediaStream
+from src.video_selection.services.select_primary_video_stream import (
+    select_primary_video_stream,
+)
+
+
+def _video_stream(
+    index: int,
+    *,
+    is_default: bool = False,
+    is_attached_picture: bool = False,
+) -> MediaStream:
+    return MediaStream(
+        index=index,
+        kind="video",
+        codec_name="ffv1",
+        time_base=Fraction(1, 1000),
+        start_pts=0,
+        duration_ts=1000,
+        width=1920,
+        height=1080,
+        sample_rate=None,
+        channels=None,
+        language=None,
+        is_default=is_default,
+        is_forced=False,
+        is_attached_picture=is_attached_picture,
+    )
+
+
+def test_default_motion_stream_is_selected_before_lower_index_cover() -> None:
+    """静止coverが除外されdefaultの表示映像streamが選択されること。
+
+    Arrange:
+        - 最小indexのattached pictureと複数の表示映像streamが用意される
+    Act:
+        - Primary Video Streamが選択される
+    Assert:
+        - default dispositionを持つ表示映像streamが返されること
+    """
+    # Arrange
+    probe = MediaProbe(
+        format_names=("matroska",),
+        streams=(
+            _video_stream(0, is_attached_picture=True),
+            _video_stream(1),
+            _video_stream(2, is_default=True),
+        ),
+    )
+
+    # Act
+    selected = select_primary_video_stream(probe)
+
+    # Assert
+    assert selected.index == 2
+
+
+def test_media_without_motion_video_stream_is_rejected() -> None:
+    """表示映像streamがないmediaが拒否されること。
+
+    Arrange:
+        - attached pictureだけを持つprobeが用意される
+    Act:
+        - Primary Video Streamの選択が試行される
+    Assert:
+        - 表示映像stream不足として失敗すること
+    """
+    # Arrange
+    probe = MediaProbe(
+        format_names=("matroska",),
+        streams=(_video_stream(0, is_attached_picture=True),),
+    )
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="Primary Video Stream"):
+        select_primary_video_stream(probe)

--- a/tests/video_selection/services/test_video_stage_processor.py
+++ b/tests/video_selection/services/test_video_stage_processor.py
@@ -1,0 +1,164 @@
+"""Video Stage processorの統合style test。"""
+
+from dataclasses import replace
+from pathlib import Path
+
+from src.video_selection.models.effective_configuration import EffectiveConfiguration
+from src.video_selection.models.processing_stage import ProcessingStage
+from src.video_selection.services.discover_video_set import discover_video_set
+from src.video_selection.services.video_stage_processor import VideoStageProcessor
+from tests.video_selection.fakes.fake_video_stage_media_runtime import (
+    FakeVideoStageMediaRuntime,
+)
+from tests.video_selection.fakes.recording_run_observer import RecordingRunObserver
+
+
+def _configuration(input_folder: Path, output_folder: Path) -> EffectiveConfiguration:
+    return EffectiveConfiguration(
+        video_input_folder=input_folder,
+        output_folder=output_folder,
+    )
+
+
+def test_video_sources_are_serial_and_video_stage_cache_is_source_local(
+    tmp_path: Path,
+) -> None:
+    """動画が直列処理されpath、順序、downstream設定から独立して再利用されること。
+
+    Arrange:
+        - 異なる内容を持つ2動画のVideo SetとVideo Stage processorが用意される
+    Act:
+        - 初回処理後に動画をrenameして順序とdownstream設定を変えて再実行される
+        - 続いてCandidate Moment Densityだけを変えて再実行される
+    Assert:
+        - 各動画がscanからrefinementまでVideo Order順に直列処理されること
+        - rename、順序、downstream変更では両Stageが再利用されること
+        - density変更ではscanだけが再利用されcandidate抽出だけ再計算されること
+        - scene一時画像がCompleted Stageへ永続化されないこと
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    first_path = input_folder / "01-first.mp4"
+    second_path = input_folder / "02-second.mp4"
+    first_path.write_bytes(b"first-video")
+    second_path.write_bytes(b"second-video")
+    configuration = _configuration(input_folder, tmp_path / "output")
+    first_video_set = discover_video_set(input_folder)
+    first_runtime = FakeVideoStageMediaRuntime()
+
+    # Act
+    first_results = VideoStageProcessor(
+        first_runtime,
+        RecordingRunObserver(),
+    ).process(first_video_set, configuration)
+
+    # Assert
+    assert first_runtime.call_order == [
+        ("probe", "01-first.mp4"),
+        ("scan", "01-first.mp4"),
+        ("refine", "01-first.mp4"),
+        ("probe", "02-second.mp4"),
+        ("scan", "02-second.mp4"),
+        ("refine", "02-second.mp4"),
+    ]
+    assert all(
+        [item.stage for item in result.completed_stages]
+        == [ProcessingStage.SCAN_VIDEO, ProcessingStage.EXTRACT_FRAME_CANDIDATES]
+        for result in first_results
+    )
+    assert not tuple(configuration.processing_cache_folder.rglob(".scene-proxies"))
+
+    # Arrange
+    first_path.rename(input_folder / "99-renamed.mp4")
+    second_path.rename(input_folder / "01-renamed.mp4")
+    reordered_video_set = discover_video_set(input_folder)
+    cached_runtime = FakeVideoStageMediaRuntime()
+    downstream_changed = replace(
+        configuration,
+        image_count=7,
+        scene_hint="downstream only",
+        spoiler_sensitivity="high",
+        similarity_threshold=0.9,
+    )
+
+    # Act
+    cached_results = VideoStageProcessor(
+        cached_runtime,
+        RecordingRunObserver(),
+    ).process(reordered_video_set, downstream_changed)
+
+    # Assert
+    assert cached_runtime.scan_calls == []
+    assert cached_runtime.range_calls == []
+    assert {
+        result.source.fingerprint: tuple(
+            stage.fingerprint.value for stage in result.completed_stages
+        )
+        for result in cached_results
+    } == {
+        result.source.fingerprint: tuple(
+            stage.fingerprint.value for stage in result.completed_stages
+        )
+        for result in first_results
+    }
+
+    # Arrange
+    density_runtime = FakeVideoStageMediaRuntime()
+    density_changed = replace(configuration, candidate_density_per_minute=4.0)
+
+    # Act
+    VideoStageProcessor(
+        density_runtime,
+        RecordingRunObserver(),
+    ).process(reordered_video_set, density_changed)
+
+    # Assert
+    assert density_runtime.scan_calls == []
+    assert [path.name for path in density_runtime.range_calls] == [
+        "01-renamed.mp4",
+        "99-renamed.mp4",
+    ]
+
+
+def test_corrupt_candidate_proxy_recomputes_only_candidate_stage(
+    tmp_path: Path,
+) -> None:
+    """破損したcandidate proxyが検知され上流scanを残して再計算されること。
+
+    Arrange:
+        - scanとcandidate抽出がCompleted Stageとして確定済みである
+        - candidate proxyの一つがmanifest確定後に破損される
+    Act:
+        - 同じVideo Identityと設定でVideo Stageが再実行される
+    Assert:
+        - scanは再利用されcandidate抽出だけが再実行されること
+        - 破損bytesが新しいMJPEG proxyへ置き換えられること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    (input_folder / "video.mp4").write_bytes(b"video-content")
+    configuration = _configuration(input_folder, tmp_path / "output")
+    video_set = discover_video_set(input_folder)
+    initial_result = VideoStageProcessor(
+        FakeVideoStageMediaRuntime(),
+        RecordingRunObserver(),
+    ).process(video_set, configuration)[0]
+    proxy_path = initial_result.extraction.candidates[0].proxy_path
+    assert proxy_path is not None
+    proxy_path.write_bytes(b"corrupt-proxy")
+    repair_runtime = FakeVideoStageMediaRuntime()
+
+    # Act
+    repaired_result = VideoStageProcessor(
+        repair_runtime,
+        RecordingRunObserver(),
+    ).process(video_set, configuration)[0]
+
+    # Assert
+    assert repair_runtime.scan_calls == []
+    assert [path.name for path in repair_runtime.range_calls] == ["video.mp4"]
+    repaired_proxy_path = repaired_result.extraction.candidates[0].proxy_path
+    assert repaired_proxy_path is not None
+    assert repaired_proxy_path.read_bytes() != b"corrupt-proxy"

--- a/tests/video_selection/services/test_video_stage_processor.py
+++ b/tests/video_selection/services/test_video_stage_processor.py
@@ -171,7 +171,7 @@ def test_corrupt_candidate_proxy_recomputes_only_candidate_stage(
 def test_same_stat_change_is_checked_when_affected_source_reaches_video_stage(
     tmp_path: Path,
 ) -> None:
-    """対象外sourceの同一stat変更が、そのsourceのStage直前に検知されること。
+    """対象外sourceの同一stat変更が、そのsourceのprobe前に検知されること。
 
     Arrange:
         - 異なる内容を持つ2動画の発見済みVideo Setが用意される
@@ -179,7 +179,7 @@ def test_same_stat_change_is_checked_when_affected_source_reaches_video_stage(
     Act:
         - Video Stage処理がVideo Order順に実行される
     Assert:
-        - 1本目の両Stageは完了し、2本目のscan直前で変更が拒否されること
+        - 1本目の両Stageは完了し、2本目のprobe前で変更が拒否されること
     """
     # Arrange
     input_folder = tmp_path / "videos"
@@ -211,7 +211,6 @@ def test_same_stat_change_is_checked_when_affected_source_reaches_video_stage(
         ("probe", "01-first.mp4"),
         ("scan", "01-first.mp4"),
         ("refine", "01-first.mp4"),
-        ("probe", "02-second.mp4"),
     ]
 
 

--- a/tests/video_selection/services/test_video_stage_processor.py
+++ b/tests/video_selection/services/test_video_stage_processor.py
@@ -1,9 +1,13 @@
 """Video Stage processorの統合style test。"""
 
+import os
 from dataclasses import replace
 from pathlib import Path
 
+import pytest
+
 from src.video_selection.models.effective_configuration import EffectiveConfiguration
+from src.video_selection.models.media_runtime_identity import MediaRuntimeIdentity
 from src.video_selection.models.processing_stage import ProcessingStage
 from src.video_selection.services.discover_video_set import discover_video_set
 from src.video_selection.services.video_stage_processor import VideoStageProcessor
@@ -162,3 +166,166 @@ def test_corrupt_candidate_proxy_recomputes_only_candidate_stage(
     repaired_proxy_path = repaired_result.extraction.candidates[0].proxy_path
     assert repaired_proxy_path is not None
     assert repaired_proxy_path.read_bytes() != b"corrupt-proxy"
+
+
+def test_same_stat_change_is_checked_when_affected_source_reaches_video_stage(
+    tmp_path: Path,
+) -> None:
+    """対象外sourceの同一stat変更が、そのsourceのStage直前に検知されること。
+
+    Arrange:
+        - 異なる内容を持つ2動画の発見済みVideo Setが用意される
+        - initial validation後に2本目だけが同一statの別内容へ変更される
+    Act:
+        - Video Stage処理がVideo Order順に実行される
+    Assert:
+        - 1本目の両Stageは完了し、2本目のscan直前で変更が拒否されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    first_path = input_folder / "01-first.mp4"
+    second_path = input_folder / "02-second.mp4"
+    first_path.write_bytes(b"first-video")
+    second_path.write_bytes(b"second-video")
+    configuration = _configuration(input_folder, tmp_path / "output")
+    video_set = discover_video_set(input_folder)
+    original_stat = second_path.stat()
+
+    def rewrite_second_source() -> None:
+        second_path.write_bytes(b"x" * original_stat.st_size)
+        os.utime(
+            second_path,
+            ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+        )
+
+    runtime = FakeVideoStageMediaRuntime(on_preflight=rewrite_second_source)
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="Video Set snapshotが変更されました"):
+        VideoStageProcessor(runtime, RecordingRunObserver()).process(
+            video_set,
+            configuration,
+        )
+    assert runtime.call_order == [
+        ("probe", "01-first.mp4"),
+        ("scan", "01-first.mp4"),
+        ("refine", "01-first.mp4"),
+        ("probe", "02-second.mp4"),
+    ]
+
+
+def test_refinement_is_streamed_between_distant_moment_groups(
+    tmp_path: Path,
+) -> None:
+    """離れたMoment groupの全RGB frameが同時に保持されないこと。
+
+    Arrange:
+        - 離れた2つのCandidate Momentとstreaming検査付きruntimeが用意される
+    Act:
+        - 一つのrange scanからFrame Candidateが抽出される
+    Assert:
+        - 後側groupのdecode継続前に前側groupのproxyが書かれること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    (input_folder / "video.mp4").write_bytes(b"video-content")
+    configuration = _configuration(input_folder, tmp_path / "output")
+    runtime = FakeVideoStageMediaRuntime(
+        distant_moments=True,
+        require_streaming_refinement=True,
+    )
+
+    # Act
+    result = VideoStageProcessor(runtime, RecordingRunObserver()).process(
+        discover_video_set(input_folder),
+        configuration,
+    )[0]
+
+    # Assert
+    assert len(result.extraction.moments) == 2
+    assert all(moment.frame_candidate_ids for moment in result.extraction.moments)
+
+
+def test_runtime_build_identity_change_recomputes_scan_stage(tmp_path: Path) -> None:
+    """同じversionでもbuild identity変更時にscan cacheが再計算されること。
+
+    Arrange:
+        - 同じVideo Identityとversionで異なるbuild digestを返すruntimeが用意される
+    Act:
+        - 最初のruntimeでcache確定後、別buildのruntimeで再実行される
+    Assert:
+        - scan-videoと下流candidate抽出が再計算されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    video_path = input_folder / "video.mp4"
+    video_path.write_bytes(b"video-content")
+    configuration = _configuration(input_folder, tmp_path / "output")
+    video_set = discover_video_set(input_folder)
+    first_runtime = FakeVideoStageMediaRuntime(
+        runtime_identity=MediaRuntimeIdentity(
+            "6.1.1-test",
+            "6.1.1-test",
+            "a" * 64,
+        )
+    )
+    VideoStageProcessor(first_runtime, RecordingRunObserver()).process(
+        video_set,
+        configuration,
+    )
+    changed_runtime = FakeVideoStageMediaRuntime(
+        runtime_identity=MediaRuntimeIdentity(
+            "6.1.1-test",
+            "6.1.1-test",
+            "b" * 64,
+        )
+    )
+
+    # Act
+    VideoStageProcessor(changed_runtime, RecordingRunObserver()).process(
+        video_set,
+        configuration,
+    )
+
+    # Assert
+    assert changed_runtime.scan_calls == [video_path]
+    assert changed_runtime.range_calls == [video_path]
+
+
+def test_stage_metrics_include_current_process_and_full_stage_time(
+    tmp_path: Path,
+) -> None:
+    """Video Stage metricにcurrent processを含む全Stage costが記録されること。
+
+    Arrange:
+        - native metricを0で返しscanとrefinement中にCPUを消費するruntimeが用意される
+    Act:
+        - Video Stageが初回計算される
+    Assert:
+        - scanとcandidate抽出のwall時間とCPU時間が正であること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    (input_folder / "video.mp4").write_bytes(b"video-content")
+    configuration = _configuration(input_folder, tmp_path / "output")
+    runtime = FakeVideoStageMediaRuntime(
+        cpu_burn_seconds=0.02,
+        reported_scan_wall_seconds=0.0,
+        reported_scan_cpu_seconds=0.0,
+    )
+
+    # Act
+    result = VideoStageProcessor(runtime, RecordingRunObserver()).process(
+        discover_video_set(input_folder),
+        configuration,
+    )[0]
+
+    # Assert
+    assert result.scan.metrics.wall_seconds >= 0.01
+    assert result.scan.metrics.cpu_seconds >= 0.01
+    assert result.extraction_metrics.wall_seconds >= 0.01
+    assert result.extraction_metrics.cpu_seconds >= 0.01

--- a/tests_ffmpeg/support/ffmpeg_fixture_factory.py
+++ b/tests_ffmpeg/support/ffmpeg_fixture_factory.py
@@ -62,6 +62,43 @@ def generate_vfr_video(output_path: Path) -> Path:
     return output_path
 
 
+def generate_scene_change_video(output_path: Path) -> Path:
+    """1秒ごとに明確なscene changeを持つ3秒fixtureを生成する。"""
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=red:size=64x48:rate=4:duration=1",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=64x48:rate=4:duration=1",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=blue:size=64x48:rate=4:duration=1",
+            "-filter_complex",
+            "[0:v][1:v][2:v]concat=n=3:v=1:a=0[video]",
+            "-map",
+            "[video]",
+            "-c:v",
+            "ffv1",
+            "-pix_fmt",
+            "yuv420p",
+            str(output_path),
+        ],
+        check=True,
+    )
+    return output_path
+
+
 def generate_av1_aac_video(output_path: Path) -> Path:
     """AV1 videoとAAC audioを持つ短いfixtureを生成する。"""
     subprocess.run(

--- a/tests_ffmpeg/video_selection/media/test_ffmpeg_media_runtime.py
+++ b/tests_ffmpeg/video_selection/media/test_ffmpeg_media_runtime.py
@@ -146,6 +146,48 @@ def test_preflight_accepts_ffmpeg_6_1_capability_flags(tmp_path: Path) -> None:
     assert identity.ffprobe_version == "6.1.1"
 
 
+def test_preflight_distinguishes_same_version_runtime_builds(tmp_path: Path) -> None:
+    """同じversionの異なるbuildが別Media Runtime Identityになること。
+
+    Arrange:
+        - versionが同じでbuild markerが異なる2組の対応tool pairが用意される
+    Act:
+        - 各runtimeのpreflightが実行される
+    Assert:
+        - buildとcapabilityから導出されたidentityが異なること
+    """
+    # Arrange
+    first_folder = tmp_path / "first"
+    second_folder = tmp_path / "second"
+    first_folder.mkdir()
+    second_folder.mkdir()
+    first_ffmpeg = first_folder / "ffmpeg"
+    first_ffprobe = first_folder / "ffprobe"
+    second_ffmpeg = second_folder / "ffmpeg"
+    second_ffprobe = second_folder / "ffprobe"
+    _write_capable_tool(first_ffmpeg, "ffmpeg", "first")
+    _write_capable_tool(first_ffprobe, "ffprobe", "first")
+    _write_capable_tool(second_ffmpeg, "ffmpeg", "second")
+    _write_capable_tool(second_ffprobe, "ffprobe", "second")
+    first_runtime = FfmpegMediaRuntime(
+        ffmpeg_executable=str(first_ffmpeg),
+        ffprobe_executable=str(first_ffprobe),
+    )
+    second_runtime = FfmpegMediaRuntime(
+        ffmpeg_executable=str(second_ffmpeg),
+        ffprobe_executable=str(second_ffprobe),
+    )
+
+    # Act
+    first_identity = first_runtime.preflight()
+    second_identity = second_runtime.preflight()
+
+    # Assert
+    assert first_identity.ffmpeg_version == second_identity.ffmpeg_version
+    assert first_identity.ffprobe_version == second_identity.ffprobe_version
+    assert first_identity != second_identity
+
+
 @pytest.mark.parametrize(
     "omitted_capability_option",
     ["-encoders", "-muxers"],

--- a/tests_ffmpeg/video_selection/media/test_ffmpeg_media_runtime.py
+++ b/tests_ffmpeg/video_selection/media/test_ffmpeg_media_runtime.py
@@ -7,16 +7,22 @@ from fractions import Fraction
 from pathlib import Path
 
 import pytest
+from PIL import Image
 
 from src.video_selection.media.ffmpeg_media_runtime import FfmpegMediaRuntime
+from src.video_selection.models.effective_configuration import EffectiveConfiguration
 from src.video_selection.models.media_runtime_error import MediaRuntimeError
 from src.video_selection.models.media_runtime_failure_reason import (
     MediaRuntimeFailureReason,
 )
+from src.video_selection.services.discover_video_set import discover_video_set
+from src.video_selection.services.video_stage_processor import VideoStageProcessor
+from tests.video_selection.fakes.recording_run_observer import RecordingRunObserver
 from tests_ffmpeg.support.ffmpeg_fixture_factory import (
     generate_av1_aac_video,
     generate_cfr_video,
     generate_corrupt_video,
+    generate_scene_change_video,
     generate_stream_matrix_video,
     generate_vfr_video,
 )
@@ -63,11 +69,13 @@ elif "-decoders" in arguments:
     print(" S..... subrip")
 elif "-encoders" in arguments:
     if {omitted_capability_option!r} != "-encoders":
+        print(" V....D mjpeg")
         print(" V....D ppm")
         print(" A....D pcm_s16le")
         print(" S..... srt")
 elif "-muxers" in arguments:
     if {omitted_capability_option!r} != "-muxers":
+        print(" E image2")
         print(" E image2pipe")
         print(" E s16le")
         print(" E srt")
@@ -77,9 +85,11 @@ elif "-filters" in arguments:
     print("T.C asetnsamples")
     print(" ... ashowinfo")
     print(" ... format")
+    print(" ... nullsink")
     print("..C scale")
     print(" ... select")
     print(" ... showinfo")
+    print(" ... split")
 else:
     print({probe_document!r})
 """
@@ -504,6 +514,61 @@ def test_scan_video_frames_preserves_vfr_source_timing(tmp_path: Path) -> None:
     ]
 
 
+def test_scan_video_emits_heartbeat_and_scene_signals_from_one_decode(
+    tmp_path: Path,
+) -> None:
+    """一回のdecodeからheartbeat proxyとscene signalが生成されること。
+
+    Arrange:
+        - 1秒ごとに内容が変わる3秒の実FFmpeg fixtureが用意される
+    Act:
+        - composite Video Scanが実行される
+    Assert:
+        - exactなorigin、最終frame終端、1秒heartbeatが返されること
+        - scene signalが320px以下の一時画像とともに返されること
+        - Heartbeat Proxyが960px以下のmetadataなしMJPEGとして保存されること
+        - decode passが1回として記録されること
+    """
+    # Arrange
+    video_path = generate_scene_change_video(tmp_path / "scenes.mkv")
+    runtime = FfmpegMediaRuntime()
+    stream = runtime.probe(video_path).streams[0]
+    artifact_folder = tmp_path / "scan-artifacts"
+
+    # Act
+    scan = runtime.scan_video(
+        video_path,
+        stream,
+        artifact_folder,
+        heartbeat_interval_seconds=1.0,
+        scene_change_threshold=0.25,
+        scene_min_interval_seconds=0.5,
+        decode_backend="cpu",
+    )
+
+    # Assert
+    assert scan.decode_pass_count == 1
+    assert scan.origin_pts == 0
+    assert scan.last_frame_duration_ts is not None
+    assert stream.time_base is not None
+    end_pts = scan.last_frame_pts + scan.last_frame_duration_ts
+    assert Fraction(end_pts) * stream.time_base == 3
+    assert [Fraction(item.source_pts) * item.time_base for item in scan.heartbeats] == [
+        Fraction(0),
+        Fraction(1),
+        Fraction(2),
+    ]
+    assert scan.scene_frames
+    assert all(max(item.width, item.height) <= 320 for item in scan.scene_frames)
+    assert all(item.image_path.exists() for item in scan.scene_frames)
+    assert all(max(item.width, item.height) <= 960 for item in scan.heartbeats)
+    assert all(item.image_path.suffix == ".jpg" for item in scan.heartbeats)
+    for heartbeat in scan.heartbeats:
+        with Image.open(heartbeat.image_path) as proxy:
+            assert proxy.format == "JPEG"
+            assert len(proxy.getexif()) == 0
+
+
 def test_extract_video_frame_returns_exact_requested_pts(tmp_path: Path) -> None:
     """指定されたsource PTSの一つのframe artifactが返されること。
 
@@ -534,6 +599,118 @@ def test_extract_video_frame_returns_exact_requested_pts(tmp_path: Path) -> None
     assert Fraction(frame.pts) * frame.time_base == Fraction(1, 2)
     assert (frame.width, frame.height, frame.pixel_format) == (64, 48, "rgb24")
     assert len(frame.pixels) == 64 * 48 * 3
+
+
+def test_scan_video_frame_ranges_preserves_vfr_frames_inside_half_open_ranges(
+    tmp_path: Path,
+) -> None:
+    """複数の半開PTS range内だけからnative VFR frameが返されること。
+
+    Arrange:
+        - 0、0.25、0.75、1.0秒にframeを持つVFR fixtureが用意される
+    Act:
+        - firstとmiddle-lastを覆う複数PTS rangeが一回でscanされる
+    Assert:
+        - range外frameや固定fps slotが追加されずexact PTSが返されること
+    """
+    # Arrange
+    video_path = generate_vfr_video(tmp_path / "vfr-ranges.mkv")
+    runtime = FfmpegMediaRuntime()
+
+    # Act
+    frames = tuple(
+        runtime.scan_video_frame_ranges(
+            video_path,
+            stream_index=0,
+            pts_ranges=((0, 1), (750, 1001)),
+            max_dimension=64,
+        )
+    )
+
+    # Assert
+    assert [frame.pts for frame in frames] == [0, 750, 1000]
+
+
+def test_write_mjpeg_proxy_encodes_selected_rgb_frame_without_source_metadata(
+    tmp_path: Path,
+) -> None:
+    """選抜済みRGB frameがmetadataなしMJPEG proxyへ保存されること。
+
+    Arrange:
+        - CFR fixtureからexact PTSで抽出されたRGB frameが用意される
+    Act:
+        - FFmpeg MJPEG q:v=3でcandidate proxyが保存される
+    Assert:
+        - JPEGが元frame寸法で読めEXIF metadataを持たないこと
+    """
+    # Arrange
+    video_path = generate_cfr_video(tmp_path / "proxy-source.mkv")
+    runtime = FfmpegMediaRuntime()
+    frame = runtime.extract_video_frame(video_path, 0, 0, 64)
+    proxy_path = tmp_path / "candidate.jpg"
+
+    # Act
+    runtime.write_mjpeg_proxy(frame, proxy_path, quality=3)
+
+    # Assert
+    with Image.open(proxy_path) as proxy:
+        assert proxy.format == "JPEG"
+        assert proxy.size == (64, 48)
+        assert len(proxy.getexif()) == 0
+
+
+def test_real_cfr_vfr_video_stage_preserves_exact_timeline_and_scene_boundaries(
+    tmp_path: Path,
+) -> None:
+    """実FFmpegのCFR/VFRがVideo Stageのexact成果物へ確定されること。
+
+    Arrange:
+        - VFR fixtureと明確なscene changeを持つCFR fixtureが用意される
+    Act:
+        - 両動画がVideo Order順にVideo Stage processorへ通される
+    Assert:
+        - VFR durationが5/4秒として保持されること
+        - scene境界を持つsegmentがgapとoverlapなく3秒を覆うこと
+        - Candidate ProxyだけがCompleted Stageに残りscene画像が残らないこと
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    generate_vfr_video(input_folder / "01-vfr.mkv")
+    generate_scene_change_video(input_folder / "02-scenes.mkv")
+    configuration = EffectiveConfiguration(
+        video_input_folder=input_folder,
+        output_folder=tmp_path / "output",
+    )
+    video_set = discover_video_set(input_folder)
+
+    # Act
+    results = VideoStageProcessor(
+        FfmpegMediaRuntime(),
+        RecordingRunObserver(),
+    ).process(video_set, configuration)
+
+    # Assert
+    assert results[0].scan.timeline.duration.seconds == Fraction(5, 4)
+    scene_timeline = results[1].scan.timeline
+    assert scene_timeline.duration.seconds == Fraction(3)
+    assert len(scene_timeline.segments) >= 2
+    assert scene_timeline.segments[0].start == 0
+    assert scene_timeline.segments[-1].end == 3
+    assert all(
+        left.end == right.start
+        for left, right in zip(
+            scene_timeline.segments,
+            scene_timeline.segments[1:],
+            strict=False,
+        )
+    )
+    assert not tuple(configuration.processing_cache_folder.rglob(".scene-proxies"))
+    assert all(
+        candidate.proxy_path is not None and candidate.proxy_path.suffix == ".jpg"
+        for result in results
+        for candidate in result.extraction.candidates
+    )
 
 
 def test_probe_reports_audio_and_embedded_subtitle_streams(


### PR DESCRIPTION
## 概要

- Video Identity単位で再利用する`scan-video`と`extract-frame-candidates`を追加
- FFmpegの一回のnative decodeからheartbeat、scene signal、exact timelineを生成
- Candidate Moment density、native refinement、model-free Neutral Image Analysis、source-local dedupeを実装
- heartbeat/candidate JPEGを含む複数artifact Completed Stageのatomic保存・破損検知・再計算を追加
- 動画rename・Video Order・downstream設定から独立したStage Fingerprintと比較可能metricを追加
- 内部Video Stageの契約をREADME、CONTEXT、`docs/video-stage.md`へ反映

## Review対応

- Stage直前のsnapshot検証を全体path/statと対象Video Sourceのcontentへ限定し、全動画再hashの二乗I/Oを解消
- 各Video Sourceのsnapshot検証をmedia probeより前にも実施
- heartbeat/scene proxyのdecoded RGBを1件ずつ測定・解放
- scene近傍heartbeat品質をtimeline順の単調windowで参照し、sceneごとの全走査を解消
- refinement frameを連続Window Group単位で処理し、proxy確定後にRGBを解放
- temporal rejectをexactなnative frame adjacencyへ限定
- FFmpeg/ffprobeのbuild・capability SHA-256をscan cache identityへ追加
- Stage全体のwall時間とcurrent＋child CPU時間をmetricへ記録

## 検証

- `uv run task test`（311 passed）
- `uv run task test-ffmpeg`（26 passed）
- `uv run vulture src/video_selection --min-confidence 80`
- WSL2 targetのFFmpeg 6.1.1でnamed filter graphとshowinfo形式を確認
- targetの4K AV1実動画先頭2秒をCPU `libdav1d`のsingle-decode graphで確認

## 非対象・後続

- public CLI、Context Cue、model lifecycle、Video Set Stage、最終選定、元解像度WebP公開は接続しない
- 14時間全量の性能・human quality受け入れはMigration Gateの後続検証で扱う

Closes #182
