### PR TITLE
feat: Scene CatalogとCandidate Annotationを実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## 動画入力版の設計と内部実装（公開前）
 
-複数のゲーム録画を一つのVideo Setとして扱う次期interfaceは、次の一つのcommandへ置き換える設計です。探索・content identity・Input Lock・Completed Stage cache、system FFmpeg/ffprobeを閉じ込めるMediaRuntimeに加え、動画単位のscan、exact timeline、Candidate Moment、native frame refinement、model-free Neutral Image Analysis、embedded subtitle/audio STTからのContext Cue収集、Ollama/Hugging Faceのmodel lifecycleとrun単位のidentity freezeまで内部実装済みです。Scene Catalog以降のVideo Set Stage、public CLIの接続と切り替えは後続Issueで行うため、このcommandはまだ実行できません。
+複数のゲーム録画を一つのVideo Setとして扱う次期interfaceは、次の一つのcommandへ置き換える設計です。探索・content identity・Input Lock・Completed Stage cache、system FFmpeg/ffprobeを閉じ込めるMediaRuntimeに加え、動画単位のscan、exact timeline、Candidate Moment、native frame refinement、model-free Neutral Image Analysis、embedded subtitle/audio STTからのContext Cue収集、Ollama/Hugging Faceのmodel lifecycleとrun単位のidentity freeze、共有Scene CatalogとMoment単位のCandidate Annotationまで内部実装済みです。決定的な最終selector、public CLIの接続と切り替えは後続Issueで行うため、このcommandはまだ実行できません。
 
 ```bash
 game-screen-pick \
@@ -17,6 +17,7 @@ game-screen-pick \
 
 - [動画入力とCLI](docs/video-input.md)
 - [動画単位のscan、timeline、Frame Candidate、Context Cue cache](docs/video-stage.md)
+- [共有Scene CatalogとCandidate Annotation Stage](docs/vision-stage.md)
 - [TOML、優先順位、model更新](docs/configuration.md)
 - [runtime、cache、進捗、エラー、WSL2運用](docs/operations.md)
 - [選択画像とreport](docs/report.md)

--- a/docs/vision-stage.md
+++ b/docs/vision-stage.md
@@ -21,6 +21,8 @@ Ollamaの`/api/chat`を次の2種類だけに使います。
 1. `build-scene-catalog`: Video Set共有の3〜8 sceneを一回生成します。`other`を必ず1件含め、そのScene Selection Roleは`ordinary`です。
 2. `annotate-candidate`: Selection ShortlistのCandidate Momentごとに独立して実行し、入力frameの一つをRepresentative Frameとして返します。
 
+各推論の直前に`/api/tags`でconfigured tagのlocal完全digestを再確認します。Model LifecycleでfreezeしたResolved Model Identityと異なる場合は、別digestの結果を同じfingerprintへ保存せず`ollama_model_identity_changed`で停止します。この確認はtagの更新や再解決を行いません。
+
 両方ともJSON Schema object全体、`stream=false`、`think=false`、`temperature=0`を送ります。JSON Schema検証後にも、Scene Slug、Frame Candidate ID、Context Cue IDが入力集合へ属すること、Context Cueの有無とRelevanceが整合することをlocalで検査します。annotation summary、Representative Frameの選択理由、spoiler evidenceに入力Context Cue本文が逐語再出力された応答はdomain invalidとして拒否します。
 
 Candidate Annotation v1は次の意味情報だけを返します。
@@ -37,7 +39,7 @@ Quality Score、model confidence、final score、soft coverage、eligible/select
 
 ## Retryとfailure
 
-同じsemantic入力で初回と一回のretryだけを行います。timeout、connection failure、HTTP 408/429/5xx、空・打ち切り応答、schema/domain validation failureがretry対象です。429の`Retry-After`は最大30秒まで尊重し、その他は1秒待ちます。
+同じsemantic入力で初回と一回のretryだけを行います。timeout、connection failure、HTTP 408/429/5xx、空・打ち切り応答、schema/domain validation failureがretry対象です。このHTTP分類は推論前の`/api/tags`確認にも適用します。429の`Retry-After`は秒数とHTTP-dateの両形式を解釈して最大30秒まで尊重し、その他は1秒待ちます。
 
 response/schema/domain validation retryではstable validation codeだけを追加し、raw responseを次promptへ戻しません。model出力が存在しないtransport retryでは元のpromptを変更しません。画像、Context Cue、Catalogを削る、代表画像を減らす、`other`へfallbackする、失敗したCandidateを黙って除外する処理は行いません。model不在と408/429以外のHTTP 4xxは即時fatalです。
 
@@ -55,7 +57,7 @@ fingerprintには、順序付きFrame Candidate IDと画像SHA-256、Context Cue
 - output pathとreport表示形式
 - model更新診断と`models.auto_upgrade`（実行identityが同じ場合）
 
-cache artifactには検証済みCatalog／Annotationと、identity、version、試行回数、stable validation code、画像・Cue件数、wall時間、token件数、done reasonだけを保存します。prompt body、raw response、chain of thought、Context Cue本文、absolute path、credentialは保存しません。
+cache artifactには検証済みCatalog／Annotationと、canonical形式を検証済みのmodel/runtime identity、version、試行回数、stable validation code、画像・Cue件数、wall時間、token件数、done reasonだけを保存します。prompt body、raw response、chain of thought、Context Cue本文、absolute path、credentialは保存しません。
 
 ## 検証
 
@@ -63,4 +65,4 @@ cache artifactには検証済みCatalog／Annotationと、identity、version、�
 uv run task test
 ```
 
-fake VisionRuntime goldenでschema invalid、domain invalid、transport failure、打ち切り応答、retry成功・失敗、Context Cue有無、raw text拒否、major spoiler evidence、warm cache、同一fingerprintの並行処理、途中失敗後のMoment単位再開を検証します。
+fake VisionRuntime goldenでmodel identity変更、schema invalid、domain invalid、transport failure、打ち切り応答、retry成功・失敗、秒数／HTTP-dateのRetry-After、Context Cue有無、短いCueを含むraw text拒否、canonical diagnostic identity、major spoiler evidence、warm cache、同一fingerprintの並行処理、途中失敗後のMoment単位再開を検証します。

--- a/docs/vision-stage.md
+++ b/docs/vision-stage.md
@@ -23,7 +23,7 @@ Ollamaの`/api/chat`を次の2種類だけに使います。
 
 各推論attemptの直前と応答受領直後に`/api/version`と`/api/tags`でOllama server versionとconfigured tagのlocal完全digestを再確認します。Model LifecycleでfreezeしたRuntime IdentityまたはResolved Model Identityと異なる場合は、別runtime／digestの結果を同じfingerprintへ保存せず停止します。この確認はtagの更新や再解決を行いません。
 
-両方ともJSON Schema object全体、`stream=false`、`think=false`、`temperature=0`を送ります。JSON Schema検証後にも、Scene Slug、Frame Candidate ID、Context Cue IDが入力集合へ属すること、Context Cueの有無とRelevanceが整合することをlocalで検査します。annotation summary、Representative Frameの選択理由、spoiler evidenceに入力Context Cue本文が逐語再出力された応答はdomain invalidとして拒否します。
+両方ともJSON Schema object全体、`stream=false`、`think=false`、`temperature=0`を送ります。JSON Schema検証後にも、Scene Slug、Frame Candidate ID、Context Cue IDが入力集合へ属すること、Context Cueの有無とRelevanceが整合することをlocalで検査します。annotation summary、Representative Frameの選択理由、spoiler evidenceに正規化後3文字以上の入力Context Cue本文が逐語再出力された応答はdomain invalidとして拒否します。1〜2文字の一般語は独立生成との区別がつかないため引用判定から除外します。
 
 Candidate Annotation v1は次の意味情報だけを返します。
 

--- a/docs/vision-stage.md
+++ b/docs/vision-stage.md
@@ -21,7 +21,7 @@ Ollamaの`/api/chat`を次の2種類だけに使います。
 1. `build-scene-catalog`: Video Set共有の3〜8 sceneを一回生成します。`other`を必ず1件含め、そのScene Selection Roleは`ordinary`です。
 2. `annotate-candidate`: Selection ShortlistのCandidate Momentごとに独立して実行し、入力frameの一つをRepresentative Frameとして返します。
 
-各推論の直前に`/api/tags`でconfigured tagのlocal完全digestを再確認します。Model LifecycleでfreezeしたResolved Model Identityと異なる場合は、別digestの結果を同じfingerprintへ保存せず`ollama_model_identity_changed`で停止します。この確認はtagの更新や再解決を行いません。
+各推論attemptの直前と応答受領直後に`/api/version`と`/api/tags`でOllama server versionとconfigured tagのlocal完全digestを再確認します。Model LifecycleでfreezeしたRuntime IdentityまたはResolved Model Identityと異なる場合は、別runtime／digestの結果を同じfingerprintへ保存せず停止します。この確認はtagの更新や再解決を行いません。
 
 両方ともJSON Schema object全体、`stream=false`、`think=false`、`temperature=0`を送ります。JSON Schema検証後にも、Scene Slug、Frame Candidate ID、Context Cue IDが入力集合へ属すること、Context Cueの有無とRelevanceが整合することをlocalで検査します。annotation summary、Representative Frameの選択理由、spoiler evidenceに入力Context Cue本文が逐語再出力された応答はdomain invalidとして拒否します。
 
@@ -65,4 +65,4 @@ cache artifactには検証済みCatalog／Annotationと、canonical形式を検�
 uv run task test
 ```
 
-fake VisionRuntime goldenでmodel identity変更、schema invalid、domain invalid、transport failure、打ち切り応答、retry成功・失敗、秒数／HTTP-dateのRetry-After、Context Cue有無、短いCueを含むraw text拒否、canonical diagnostic identity、major spoiler evidence、warm cache、同一fingerprintの並行処理、途中失敗後のMoment単位再開を検証します。
+fake VisionRuntime goldenで推論前後のmodel/runtime identity変更、schema invalid、domain invalid、transport failure、打ち切り応答、retry成功・失敗、秒数／HTTP-dateのRetry-After、Context Cue有無、短いCueを含むraw text拒否、canonical diagnostic identity、major spoiler evidence、warm cache、同一fingerprintの並行処理、途中失敗後のMoment単位再開を検証します。

--- a/docs/vision-stage.md
+++ b/docs/vision-stage.md
@@ -1,0 +1,66 @@
+# Video Set Vision Stage
+
+この文書は、公開前の動画入力selectorが共有Scene CatalogとCandidate Annotationを生成する内部契約を説明します。installed public CLIはIssue #190までscreenshot入力のままです。
+
+## Module seam
+
+`VideoSetVisionProcessor`は次の入力を一度に受け取り、model transport、strict validation、retry、Moment単位cacheを呼び出し側から隠します。
+
+- 一つのVideo Set
+- Neutral Image Analysisからlocalに選ばれた1〜24件のScene Catalog Representative Set
+- Representative Setを導出したFrame Candidate Extraction Stage fingerprint
+- 決定的なlocal順を持つSelection ShortlistのCandidate Annotation request
+- Effective Configurationとrun中にfreeze済みのResolved Models
+
+Scene Catalog Representative Setは要求画像枚数から独立します。Selection Shortlistの初期sizeと不足時の拡張は、決定的selectorとcapacity acceptanceを実装する後続Issue #186・#189が所有します。Candidate Annotation requestには1〜3件のFrame Candidate、versioned policyで選ばれた近傍Context Cue、Video Set Progress、Selection Intentを明示し、VisionRuntimeが暗黙に候補やCueを削りません。
+
+## Ollama operation
+
+Ollamaの`/api/chat`を次の2種類だけに使います。
+
+1. `build-scene-catalog`: Video Set共有の3〜8 sceneを一回生成します。`other`を必ず1件含め、そのScene Selection Roleは`ordinary`です。
+2. `annotate-candidate`: Selection ShortlistのCandidate Momentごとに独立して実行し、入力frameの一つをRepresentative Frameとして返します。
+
+両方ともJSON Schema object全体、`stream=false`、`think=false`、`temperature=0`を送ります。JSON Schema検証後にも、Scene Slug、Frame Candidate ID、Context Cue IDが入力集合へ属することをlocalで検査します。
+
+Candidate Annotation v1は次の意味情報だけを返します。
+
+- Scene Slug
+- Blog Image Type
+- Explanation Value
+- Screen Text Kind
+- Context Cue Relevanceと参照Cue ID
+- Spoiler Riskと引用を含まないevidence summary
+- annotation summaryとRepresentative Frameの選択理由
+
+Quality Score、model confidence、final score、soft coverage、eligible/selected flag、生成した逐語的画面テキスト、reasoning traceはschemaに含めません。最終採否はIssue #186の決定的selectorが所有します。
+
+## Retryとfailure
+
+同じsemantic入力で初回と一回のretryだけを行います。timeout、connection failure、HTTP 408/429/5xx、空・打ち切り応答、schema/domain validation failureがretry対象です。429の`Retry-After`は最大30秒まで尊重し、その他は1秒待ちます。
+
+validation retryではstable validation codeだけを追加し、raw responseを次promptへ戻しません。画像、Context Cue、Catalogを削る、代表画像を減らす、`other`へfallbackする、失敗したCandidateを黙って除外する処理は行いません。model不在と408/429以外のHTTP 4xxは即時fatalです。
+
+## Completed Stage cache
+
+Scene CatalogはVideo Setごとに一つ、Candidate AnnotationはCandidate Momentごとに一つのatomic Completed Stageです。一つのAnnotationが最終失敗した場合、最終選定とoutput公開へ進みませんが、それ以前に完了したCatalogとAnnotationは次回runで再利用されます。
+
+fingerprintには、順序付きFrame Candidate IDと画像SHA-256、Context Cue ID・正確な範囲・本文SHA-256、Cue選択policy、Scene Catalog fingerprint、Video Set Progress、Selection Intent、Resolved Model Identity、Ollama runtime identity、generation option、prompt/schema/stage/retry versionを含めます。
+
+次の値はmodel contentを変えないため含めません。
+
+- 要求画像枚数
+- spoiler sensitivityと決定的penalty
+- Blog Image Type Soft Coverage
+- output pathとreport表示形式
+- model更新診断と`models.auto_upgrade`（実行identityが同じ場合）
+
+cache artifactには検証済みCatalog／Annotationと、identity、version、試行回数、stable validation code、画像・Cue件数、wall時間、token件数、done reasonだけを保存します。prompt body、raw response、chain of thought、Context Cue本文、absolute path、credentialは保存しません。
+
+## 検証
+
+```bash
+uv run task test
+```
+
+fake VisionRuntime goldenでschema invalid、domain invalid、transport failure、retry成功・失敗、Context Cue有無、major spoiler evidence、warm cache、途中失敗後のMoment単位再開を検証します。

--- a/docs/vision-stage.md
+++ b/docs/vision-stage.md
@@ -23,7 +23,7 @@ Ollamaの`/api/chat`を次の2種類だけに使います。
 
 各推論attemptの直前と応答受領直後に`/api/version`と`/api/tags`でOllama server versionとconfigured tagのlocal完全digestを再確認します。Model LifecycleでfreezeしたRuntime IdentityまたはResolved Model Identityと異なる場合は、別runtime／digestの結果を同じfingerprintへ保存せず停止します。この確認はtagの更新や再解決を行いません。
 
-両方ともJSON Schema object全体、`stream=false`、`think=false`、`temperature=0`を送ります。JSON Schema検証後にも、Scene Slug、Frame Candidate ID、Context Cue IDが入力集合へ属すること、Context Cueの有無とRelevanceが整合することをlocalで検査します。annotation summary、Representative Frameの選択理由、spoiler evidenceに正規化後3文字以上の入力Context Cue本文が逐語再出力された応答はdomain invalidとして拒否します。1〜2文字の一般語は独立生成との区別がつかないため引用判定から除外します。
+両方ともJSON Schema object全体、`stream=false`、`think=false`、`temperature=0`を送ります。JSON Schema検証後にも、Scene SlugとContext Cue IDが入力集合へ属すること、Representative FrameのID・画像・metadataが入力Frame Candidateと一致すること、Context Cueの有無とRelevanceが整合することをlocalで検査します。annotation summary、Representative Frameの選択理由、spoiler evidenceに正規化後3文字以上の入力Context Cue本文が逐語再出力された応答はdomain invalidとして拒否します。1〜2文字の一般語は独立生成との区別がつかないため引用判定から除外します。
 
 Candidate Annotation v1は次の意味情報だけを返します。
 

--- a/docs/vision-stage.md
+++ b/docs/vision-stage.md
@@ -21,7 +21,7 @@ Ollamaの`/api/chat`を次の2種類だけに使います。
 1. `build-scene-catalog`: Video Set共有の3〜8 sceneを一回生成します。`other`を必ず1件含め、そのScene Selection Roleは`ordinary`です。
 2. `annotate-candidate`: Selection ShortlistのCandidate Momentごとに独立して実行し、入力frameの一つをRepresentative Frameとして返します。
 
-両方ともJSON Schema object全体、`stream=false`、`think=false`、`temperature=0`を送ります。JSON Schema検証後にも、Scene Slug、Frame Candidate ID、Context Cue IDが入力集合へ属することをlocalで検査します。
+両方ともJSON Schema object全体、`stream=false`、`think=false`、`temperature=0`を送ります。JSON Schema検証後にも、Scene Slug、Frame Candidate ID、Context Cue IDが入力集合へ属すること、Context Cueの有無とRelevanceが整合することをlocalで検査します。annotation summary、Representative Frameの選択理由、spoiler evidenceに入力Context Cue本文が逐語再出力された応答はdomain invalidとして拒否します。
 
 Candidate Annotation v1は次の意味情報だけを返します。
 
@@ -39,11 +39,11 @@ Quality Score、model confidence、final score、soft coverage、eligible/select
 
 同じsemantic入力で初回と一回のretryだけを行います。timeout、connection failure、HTTP 408/429/5xx、空・打ち切り応答、schema/domain validation failureがretry対象です。429の`Retry-After`は最大30秒まで尊重し、その他は1秒待ちます。
 
-validation retryではstable validation codeだけを追加し、raw responseを次promptへ戻しません。画像、Context Cue、Catalogを削る、代表画像を減らす、`other`へfallbackする、失敗したCandidateを黙って除外する処理は行いません。model不在と408/429以外のHTTP 4xxは即時fatalです。
+response/schema/domain validation retryではstable validation codeだけを追加し、raw responseを次promptへ戻しません。model出力が存在しないtransport retryでは元のpromptを変更しません。画像、Context Cue、Catalogを削る、代表画像を減らす、`other`へfallbackする、失敗したCandidateを黙って除外する処理は行いません。model不在と408/429以外のHTTP 4xxは即時fatalです。
 
 ## Completed Stage cache
 
-Scene CatalogはVideo Setごとに一つ、Candidate AnnotationはCandidate Momentごとに一つのatomic Completed Stageです。一つのAnnotationが最終失敗した場合、最終選定とoutput公開へ進みませんが、それ以前に完了したCatalogとAnnotationは次回runで再利用されます。
+Scene CatalogはVideo Setごとに一つ、Candidate AnnotationはCandidate Momentごとに一つのatomic Completed Stageです。同じStage Fingerprintの推論はfingerprint lock内で一度だけ実行し、並行workerも最初に確定したartifactを復元します。一つのAnnotationが最終失敗した場合、最終選定とoutput公開へ進みませんが、それ以前に完了したCatalogとAnnotationは次回runで再利用されます。
 
 fingerprintには、順序付きFrame Candidate IDと画像SHA-256、Context Cue ID・正確な範囲・本文SHA-256、Cue選択policy、Scene Catalog fingerprint、Video Set Progress、Selection Intent、Resolved Model Identity、Ollama runtime identity、generation option、prompt/schema/stage/retry versionを含めます。
 
@@ -63,4 +63,4 @@ cache artifactには検証済みCatalog／Annotationと、identity、version、�
 uv run task test
 ```
 
-fake VisionRuntime goldenでschema invalid、domain invalid、transport failure、retry成功・失敗、Context Cue有無、major spoiler evidence、warm cache、途中失敗後のMoment単位再開を検証します。
+fake VisionRuntime goldenでschema invalid、domain invalid、transport failure、打ち切り応答、retry成功・失敗、Context Cue有無、raw text拒否、major spoiler evidence、warm cache、同一fingerprintの並行処理、途中失敗後のMoment単位再開を検証します。

--- a/src/video_selection/application/video_selection_application.py
+++ b/src/video_selection/application/video_selection_application.py
@@ -9,11 +9,11 @@ from ..models.resolved_models import ResolvedModels
 from ..models.run_outcome import RunOutcome
 from ..models.run_status import RunStatus
 from ..models.video_set import VideoSet
+from ..protocols.candidate_batch_annotator import CandidateBatchAnnotator
 from ..protocols.context_collector import ContextCollector
 from ..protocols.frame_candidate_extractor import FrameCandidateExtractor
 from ..protocols.model_runtime import ModelRuntime
 from ..protocols.run_observer import RunObserver
-from ..protocols.vision_runtime import VisionRuntime
 from ..services.atomic_output_publisher import AtomicOutputPublisher
 from ..services.candidate_annotation_artifact import (
     build_candidate_annotation_artifact,
@@ -46,7 +46,7 @@ class VideoSelectionApplication:
         media_runtime: FrameCandidateExtractor,
         speech_runtime: ContextCollector,
         model_runtime: ModelRuntime,
-        vision_runtime: VisionRuntime,
+        vision_runtime: CandidateBatchAnnotator,
         observer: RunObserver,
     ) -> None:
         self._media_runtime = media_runtime

--- a/src/video_selection/model_runtime/ollama_model_store.py
+++ b/src/video_selection/model_runtime/ollama_model_store.py
@@ -4,6 +4,7 @@ import json
 import re
 from collections.abc import Callable, Mapping
 from typing import cast
+from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 from ..models.model_artifact import ModelArtifact
@@ -11,9 +12,11 @@ from ..models.model_artifact_invalid_error import ModelArtifactInvalidError
 from ..models.model_capability import ModelCapability
 from ..models.model_requirement import ModelRequirement
 from ..models.model_runtime_identity import ModelRuntimeIdentity
+from ..models.model_store_http_error import ModelStoreHttpError
 from ..models.model_store_kind import ModelStoreKind
 from ..models.model_store_unavailable_error import ModelStoreUnavailableError
 from ..models.resolved_model_identity import ResolvedModelIdentity
+from ..utils.http_retry_delay import http_retry_delay
 from .canonicalize_ollama_model_selector import (
     canonicalize_ollama_model_selector,
 )
@@ -59,6 +62,16 @@ class OllamaModelStore:
         _require_ollama_requirement(requirement)
         runtime_identity = self._runtime_identity()
         return self._resolve_local_artifact(requirement, runtime_identity)
+
+    def resolve_current_identity(
+        self,
+        configured_name: str,
+    ) -> ResolvedModelIdentity | None:
+        """local configured tagが現在指す完全identityだけを解決する。"""
+        if not configured_name.strip():
+            raise ValueError("Ollama model名が必要です")
+        resolved = self._resolve_current_model(configured_name)
+        return None if resolved is None else resolved[0]
 
     def synchronize(self, requirement: ModelRequirement) -> ModelArtifact:
         """configured tagをpullしpost-pull identityを解決する。"""
@@ -203,6 +216,22 @@ class OllamaModelStore:
         requirement: ModelRequirement,
         runtime_identity: ModelRuntimeIdentity,
     ) -> ModelArtifact | None:
+        resolved = self._resolve_current_model(requirement.configured_name)
+        if resolved is None:
+            return None
+        identity, canonical_name = resolved
+        return ModelArtifact(
+            identity=identity,
+            canonical_name=canonical_name,
+            runtime_identity=runtime_identity,
+            location=None,
+        )
+
+    def _resolve_current_model(
+        self,
+        configured_name: str,
+    ) -> tuple[ResolvedModelIdentity, str] | None:
+        """local一覧からidentityとcanonical nameを一度に解決する。"""
         response = _require_mapping(self._request("GET", "/api/tags", None))
         models = response.get("models")
         if not isinstance(models, list):
@@ -220,9 +249,7 @@ class OllamaModelStore:
                 for key in ("name", "model")
                 if isinstance((value := model.get(key)), str)
             )
-            if not any(
-                _names_match(requirement.configured_name, name) for name in names
-            ):
+            if not any(_names_match(configured_name, name) for name in names):
                 continue
             digest = model.get("digest")
             canonical_name = model.get("name")
@@ -238,12 +265,7 @@ class OllamaModelStore:
                 raise ModelArtifactInvalidError(
                     "Ollama local model identityを検証できませんでした"
                 ) from None
-            return ModelArtifact(
-                identity=identity,
-                canonical_name=canonical_name,
-                runtime_identity=runtime_identity,
-                location=None,
-            )
+            return identity, canonical_name
         return None
 
     def _request(
@@ -259,6 +281,14 @@ class OllamaModelStore:
                 payload,
                 self._timeout_seconds,
             )
+        except HTTPError as error:
+            retry_after = (
+                error.headers.get("Retry-After") if error.headers is not None else None
+            )
+            raise ModelStoreHttpError(
+                error.code,
+                retry_after_seconds=http_retry_delay(error.code, retry_after),
+            ) from None
         except (ModelArtifactInvalidError, ModelStoreUnavailableError):
             raise
         except Exception:

--- a/src/video_selection/model_runtime/ollama_model_store.py
+++ b/src/video_selection/model_runtime/ollama_model_store.py
@@ -60,18 +60,19 @@ class OllamaModelStore:
     def resolve_local(self, requirement: ModelRequirement) -> ModelArtifact | None:
         """exact configured tagのlocal manifest digestを解決する。"""
         _require_ollama_requirement(requirement)
-        runtime_identity = self._runtime_identity()
-        return self._resolve_local_artifact(requirement, runtime_identity)
+        return self.resolve_current_artifact(requirement.configured_name)
 
-    def resolve_current_identity(
+    def resolve_current_artifact(
         self,
         configured_name: str,
-    ) -> ResolvedModelIdentity | None:
-        """local configured tagが現在指す完全identityだけを解決する。"""
+    ) -> ModelArtifact | None:
+        """configured tagとserverから現在の完全artifactを解決する。"""
         if not configured_name.strip():
             raise ValueError("Ollama model名が必要です")
-        resolved = self._resolve_current_model(configured_name)
-        return None if resolved is None else resolved[0]
+        return self._resolve_local_artifact(
+            configured_name,
+            self._runtime_identity(),
+        )
 
     def synchronize(self, requirement: ModelRequirement) -> ModelArtifact:
         """configured tagをpullしpost-pull identityを解決する。"""
@@ -86,7 +87,10 @@ class OllamaModelStore:
         )
         if response.get("status") != "success":
             raise ModelArtifactInvalidError("Ollama pullの完了を確認できませんでした")
-        artifact = self._resolve_local_artifact(requirement, runtime_identity)
+        artifact = self._resolve_local_artifact(
+            requirement.configured_name,
+            runtime_identity,
+        )
         if artifact is None:
             raise ModelArtifactInvalidError(
                 "Ollama pull後のmodel identityを確認できませんでした"
@@ -143,13 +147,14 @@ class OllamaModelStore:
         _require_ollama_requirement(requirement)
         if artifact.identity.store_kind is not self.kind:
             raise ModelArtifactInvalidError("Ollama artifact kindが不正です")
-        current = self._resolve_local_artifact(
-            requirement,
-            artifact.runtime_identity,
-        )
-        if current is None or current.identity != artifact.identity:
+        current = self.resolve_current_artifact(requirement.configured_name)
+        if (
+            current is None
+            or current.identity != artifact.identity
+            or current.runtime_identity != artifact.runtime_identity
+        ):
             raise ModelArtifactInvalidError(
-                "Ollama tagがcapability検証中に変更されました"
+                "Ollama modelまたはruntimeがcapability検証中に変更されました"
             )
 
     def publish_validated(self, artifact: ModelArtifact) -> None:
@@ -213,10 +218,10 @@ class OllamaModelStore:
 
     def _resolve_local_artifact(
         self,
-        requirement: ModelRequirement,
+        configured_name: str,
         runtime_identity: ModelRuntimeIdentity,
     ) -> ModelArtifact | None:
-        resolved = self._resolve_current_model(requirement.configured_name)
+        resolved = self._resolve_current_model(configured_name)
         if resolved is None:
             return None
         identity, canonical_name = resolved

--- a/src/video_selection/models/candidate_annotation.py
+++ b/src/video_selection/models/candidate_annotation.py
@@ -1,13 +1,69 @@
-"""walking skeletonのCandidate Annotation。"""
+"""一つのCandidate Momentの意味annotation。"""
 
+import hashlib
 from dataclasses import dataclass
+from typing import Literal
 
 from .frame_candidate import FrameCandidate
+
+BlogImageType = Literal["normal_gameplay", "event", "menu", "title", "other"]
+ExplanationValue = Literal["none", "low", "medium", "high"]
+ScreenTextKind = Literal["none", "dialogue", "menu", "title", "hud", "other"]
+ContextCueRelevance = Literal["unavailable", "none", "weak", "strong"]
+SpoilerRisk = Literal["none", "low", "medium", "high"]
 
 
 @dataclass(frozen=True)
 class CandidateAnnotation:
-    """fake VisionRuntimeが返す最小annotation。"""
+    """Representative Frameと最終選定前の意味情報を保持する。"""
 
     candidate: FrameCandidate
     summary: str
+    candidate_moment_id: str | None = None
+    scene_slug: str = "other"
+    blog_image_type: BlogImageType = "other"
+    explanation_value: ExplanationValue = "none"
+    frame_choice_reason: str | None = None
+    screen_text_kind: ScreenTextKind = "none"
+    context_relevance: ContextCueRelevance = "unavailable"
+    supporting_context_cue_ids: tuple[str, ...] = ()
+    spoiler_risk: SpoilerRisk = "none"
+    spoiler_evidence: str = ""
+
+    def __post_init__(self) -> None:
+        """domain enum、所属ID、evidenceの整合を検証する。"""
+        if self.candidate_moment_id is None:
+            digest = hashlib.sha256(self.candidate.identifier.encode()).hexdigest()
+            object.__setattr__(self, "candidate_moment_id", f"mom_{digest}")
+        if self.frame_choice_reason is None:
+            object.__setattr__(self, "frame_choice_reason", self.summary)
+        moment_id = self.candidate_moment_id
+        if (
+            moment_id is None
+            or not moment_id.startswith("mom_")
+            or len(moment_id) != 68
+            or any(character not in "0123456789abcdef" for character in moment_id[4:])
+            or not self.summary.strip()
+            or not self.scene_slug.strip()
+            or not self.frame_choice_reason
+            or not self.frame_choice_reason.strip()
+            or self.blog_image_type
+            not in {"normal_gameplay", "event", "menu", "title", "other"}
+            or self.explanation_value not in {"none", "low", "medium", "high"}
+            or self.screen_text_kind
+            not in {"none", "dialogue", "menu", "title", "hud", "other"}
+            or self.context_relevance not in {"unavailable", "none", "weak", "strong"}
+            or self.spoiler_risk not in {"none", "low", "medium", "high"}
+            or len(self.supporting_context_cue_ids)
+            != len(set(self.supporting_context_cue_ids))
+            or self.context_relevance in {"unavailable", "none"}
+            and self.supporting_context_cue_ids
+            or self.context_relevance in {"weak", "strong"}
+            and not self.supporting_context_cue_ids
+            or self.spoiler_risk == "none"
+            and self.spoiler_evidence
+            or self.spoiler_risk != "none"
+            and not self.spoiler_evidence.strip()
+        ):
+            msg = "Candidate Annotationのdomain fieldが不正です"
+            raise ValueError(msg)

--- a/src/video_selection/models/candidate_annotation.py
+++ b/src/video_selection/models/candidate_annotation.py
@@ -23,7 +23,6 @@ CONTEXT_CUE_RELEVANCES = cast(
 SPOILER_RISKS = cast(tuple[SpoilerRisk, ...], get_args(SpoilerRisk))
 
 _MIN_VERBATIM_SPAN_LENGTH = 6
-_SHORT_CUE_LENGTH = 3
 
 
 def candidate_annotation_relationships_are_valid(
@@ -69,10 +68,6 @@ def candidate_annotation_free_text_is_safe(
         if (normalized := _normalize_verbatim_text(item))
     )
     for cue in normalized_cues:
-        if len(cue) <= _SHORT_CUE_LENGTH:
-            if cue in normalized_annotations:
-                return False
-            continue
         span_length = min(len(cue), _MIN_VERBATIM_SPAN_LENGTH)
         cue_spans = {
             cue[index : index + span_length]

--- a/src/video_selection/models/candidate_annotation.py
+++ b/src/video_selection/models/candidate_annotation.py
@@ -23,6 +23,7 @@ CONTEXT_CUE_RELEVANCES = cast(
 SPOILER_RISKS = cast(tuple[SpoilerRisk, ...], get_args(SpoilerRisk))
 
 _MIN_VERBATIM_SPAN_LENGTH = 6
+_MIN_VERBATIM_CUE_LENGTH = 3
 
 
 def candidate_annotation_relationships_are_valid(
@@ -65,7 +66,7 @@ def candidate_annotation_free_text_is_safe(
     normalized_cues = tuple(
         normalized
         for item in raw_context_texts
-        if (normalized := _normalize_verbatim_text(item))
+        if len(normalized := _normalize_verbatim_text(item)) >= _MIN_VERBATIM_CUE_LENGTH
     )
     for cue in normalized_cues:
         span_length = min(len(cue), _MIN_VERBATIM_SPAN_LENGTH)

--- a/src/video_selection/models/candidate_annotation.py
+++ b/src/video_selection/models/candidate_annotation.py
@@ -1,8 +1,9 @@
 """一つのCandidate Momentの意味annotation。"""
 
 import hashlib
+import unicodedata
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, cast, get_args
 
 from .frame_candidate import FrameCandidate
 
@@ -11,6 +12,89 @@ ExplanationValue = Literal["none", "low", "medium", "high"]
 ScreenTextKind = Literal["none", "dialogue", "menu", "title", "hud", "other"]
 ContextCueRelevance = Literal["unavailable", "none", "weak", "strong"]
 SpoilerRisk = Literal["none", "low", "medium", "high"]
+
+BLOG_IMAGE_TYPES = cast(tuple[BlogImageType, ...], get_args(BlogImageType))
+EXPLANATION_VALUES = cast(tuple[ExplanationValue, ...], get_args(ExplanationValue))
+SCREEN_TEXT_KINDS = cast(tuple[ScreenTextKind, ...], get_args(ScreenTextKind))
+CONTEXT_CUE_RELEVANCES = cast(
+    tuple[ContextCueRelevance, ...],
+    get_args(ContextCueRelevance),
+)
+SPOILER_RISKS = cast(tuple[SpoilerRisk, ...], get_args(SpoilerRisk))
+
+_MIN_VERBATIM_SPAN_LENGTH = 6
+_SHORT_CUE_LENGTH = 3
+
+
+def candidate_annotation_relationships_are_valid(
+    context_relevance: ContextCueRelevance,
+    supporting_context_cue_ids: tuple[str, ...],
+    spoiler_risk: SpoilerRisk,
+    spoiler_evidence: str,
+) -> bool:
+    """Annotation内のCue参照とSpoiler evidenceの相関を検証する。"""
+    if len(supporting_context_cue_ids) != len(set(supporting_context_cue_ids)):
+        return False
+    if bool(supporting_context_cue_ids) != (context_relevance in {"weak", "strong"}):
+        return False
+    if spoiler_risk == "none":
+        return not spoiler_evidence
+    return bool(spoiler_evidence.strip())
+
+
+def candidate_annotation_context_is_valid(
+    context_relevance: ContextCueRelevance,
+    supporting_context_cue_ids: tuple[str, ...],
+    available_context_cue_ids: tuple[str, ...],
+) -> bool:
+    """Cueの有無、relevance、参照IDの所属が整合することを検証する。"""
+    if not set(supporting_context_cue_ids).issubset(available_context_cue_ids):
+        return False
+    if not available_context_cue_ids:
+        return context_relevance == "unavailable" and not supporting_context_cue_ids
+    return context_relevance != "unavailable"
+
+
+def candidate_annotation_free_text_is_safe(
+    annotation_texts: tuple[str, ...],
+    raw_context_texts: tuple[str, ...],
+) -> bool:
+    """公開・cache対象の自由文にContext Cue本文が逐語再出力されないことを検証する。"""
+    normalized_annotations = tuple(
+        _normalize_verbatim_text(item) for item in annotation_texts
+    )
+    normalized_cues = tuple(
+        normalized
+        for item in raw_context_texts
+        if (normalized := _normalize_verbatim_text(item))
+    )
+    for cue in normalized_cues:
+        if len(cue) <= _SHORT_CUE_LENGTH:
+            if cue in normalized_annotations:
+                return False
+            continue
+        span_length = min(len(cue), _MIN_VERBATIM_SPAN_LENGTH)
+        cue_spans = {
+            cue[index : index + span_length]
+            for index in range(len(cue) - span_length + 1)
+        }
+        if any(
+            span in annotation
+            for annotation in normalized_annotations
+            for span in cue_spans
+        ):
+            return False
+    return True
+
+
+def _normalize_verbatim_text(value: str) -> str:
+    """Unicode、空白、句読点の表記差を除いて逐語一致を比較可能にする。"""
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    return "".join(
+        character
+        for character in normalized
+        if unicodedata.category(character)[0] in {"L", "N"}
+    )
 
 
 @dataclass(frozen=True)
@@ -47,23 +131,17 @@ class CandidateAnnotation:
             or not self.scene_slug.strip()
             or not self.frame_choice_reason
             or not self.frame_choice_reason.strip()
-            or self.blog_image_type
-            not in {"normal_gameplay", "event", "menu", "title", "other"}
-            or self.explanation_value not in {"none", "low", "medium", "high"}
-            or self.screen_text_kind
-            not in {"none", "dialogue", "menu", "title", "hud", "other"}
-            or self.context_relevance not in {"unavailable", "none", "weak", "strong"}
-            or self.spoiler_risk not in {"none", "low", "medium", "high"}
-            or len(self.supporting_context_cue_ids)
-            != len(set(self.supporting_context_cue_ids))
-            or self.context_relevance in {"unavailable", "none"}
-            and self.supporting_context_cue_ids
-            or self.context_relevance in {"weak", "strong"}
-            and not self.supporting_context_cue_ids
-            or self.spoiler_risk == "none"
-            and self.spoiler_evidence
-            or self.spoiler_risk != "none"
-            and not self.spoiler_evidence.strip()
+            or self.blog_image_type not in BLOG_IMAGE_TYPES
+            or self.explanation_value not in EXPLANATION_VALUES
+            or self.screen_text_kind not in SCREEN_TEXT_KINDS
+            or self.context_relevance not in CONTEXT_CUE_RELEVANCES
+            or self.spoiler_risk not in SPOILER_RISKS
+            or not candidate_annotation_relationships_are_valid(
+                self.context_relevance,
+                self.supporting_context_cue_ids,
+                self.spoiler_risk,
+                self.spoiler_evidence,
+            )
         ):
             msg = "Candidate Annotationのdomain fieldが不正です"
             raise ValueError(msg)

--- a/src/video_selection/models/candidate_annotation_request.py
+++ b/src/video_selection/models/candidate_annotation_request.py
@@ -1,0 +1,56 @@
+"""一つのCandidate Momentのannotation semantic入力。"""
+
+import re
+from dataclasses import dataclass
+from fractions import Fraction
+
+from .candidate_moment import CandidateMoment
+from .context_cue import ContextCue
+from .frame_candidate import FrameCandidate
+
+_POLICY_VERSION_PATTERN = re.compile(r"[0-9A-Za-z][0-9A-Za-z._/-]{0,127}")
+
+
+@dataclass(frozen=True)
+class CandidateAnnotationRequest:
+    """Moment、1〜3 frame、近傍Cue、進行位置、意図を保持する。"""
+
+    moment: CandidateMoment
+    frame_candidates: tuple[FrameCandidate, ...]
+    context_cues: tuple[ContextCue, ...]
+    video_set_progress: Fraction
+    selection_intent: str
+    cue_selection_policy_version: str
+
+    def __post_init__(self) -> None:
+        """Candidate Momentに属する一意な入力だけを受理する。"""
+        frame_ids = tuple(item.identifier for item in self.frame_candidates)
+        cue_ids = tuple(item.identifier for item in self.context_cues)
+        frame_video_ids = {
+            item.video_fingerprint
+            for item in self.frame_candidates
+            if item.video_fingerprint is not None
+        }
+        cue_video_ids = {
+            item.video_fingerprint
+            for item in self.context_cues
+            if item.video_fingerprint
+        }
+        if (
+            not 1 <= len(self.frame_candidates) <= 3
+            or frame_ids != self.moment.frame_candidate_ids
+            or len(frame_ids) != len(set(frame_ids))
+            or any(not item.image_bytes for item in self.frame_candidates)
+            or len(cue_ids) != len(set(cue_ids))
+            or not 0 <= self.video_set_progress < 1
+            or not self.selection_intent.strip()
+            or _POLICY_VERSION_PATTERN.fullmatch(self.cue_selection_policy_version)
+            is None
+            or len(frame_video_ids) > 1
+            or len(cue_video_ids) > 1
+            or frame_video_ids
+            and cue_video_ids
+            and frame_video_ids != cue_video_ids
+        ):
+            msg = "Candidate Annotation requestが不正です"
+            raise ValueError(msg)

--- a/src/video_selection/models/model_runtime_identity.py
+++ b/src/video_selection/models/model_runtime_identity.py
@@ -2,6 +2,7 @@
 
 import re
 from dataclasses import dataclass
+from typing import Self
 
 from .model_store_kind import ModelStoreKind
 
@@ -28,3 +29,15 @@ class ModelRuntimeIdentity:
             "ollama" if self.store_kind is ModelStoreKind.OLLAMA else "huggingface-hub"
         )
         return f"{prefix}:{self.version}"
+
+    @classmethod
+    def from_identifier(cls, identifier: str) -> Self:
+        """canonical identifierを検証してtyped identityへ戻す。"""
+        if identifier.startswith("ollama:"):
+            return cls(ModelStoreKind.OLLAMA, identifier.removeprefix("ollama:"))
+        if identifier.startswith("huggingface-hub:"):
+            return cls(
+                ModelStoreKind.HUGGING_FACE,
+                identifier.removeprefix("huggingface-hub:"),
+            )
+        raise ValueError("canonicalなmodel runtime identity identifierが必要です")

--- a/src/video_selection/models/model_store_http_error.py
+++ b/src/video_selection/models/model_store_http_error.py
@@ -1,0 +1,17 @@
+"""安全化済みのmodel store HTTP failure。"""
+
+from .model_store_unavailable_error import ModelStoreUnavailableError
+
+
+class ModelStoreHttpError(ModelStoreUnavailableError):
+    """外部detailを捨て、statusと再試行待機だけを保持する。"""
+
+    def __init__(
+        self,
+        status_code: int,
+        *,
+        retry_after_seconds: float = 1.0,
+    ) -> None:
+        self.status_code = status_code
+        self.retry_after_seconds = retry_after_seconds
+        super().__init__("Model store HTTP request failed")

--- a/src/video_selection/models/processing_stage.py
+++ b/src/video_selection/models/processing_stage.py
@@ -11,6 +11,8 @@ class ProcessingStage(StrEnum):
     EXTRACT_FRAME_CANDIDATES = "extract-frame-candidates"
     COLLECT_CONTEXT = "collect-context"
     RESOLVE_MODELS = "resolve-models"
+    BUILD_SCENE_CATALOG = "build-scene-catalog"
+    ANNOTATE_CANDIDATE = "annotate-candidate"
     ANNOTATE_CANDIDATES = "annotate-candidates"
     SELECT_IMAGES = "select-images"
 

--- a/src/video_selection/models/resolved_model_identity.py
+++ b/src/video_selection/models/resolved_model_identity.py
@@ -2,6 +2,7 @@
 
 import re
 from dataclasses import dataclass
+from typing import Self
 
 from .model_store_kind import ModelStoreKind
 
@@ -32,3 +33,12 @@ class ResolvedModelIdentity:
         """store間で衝突しないcanonical identityを返す。"""
         prefix = "ollama" if self.store_kind is ModelStoreKind.OLLAMA else "hf"
         return f"{prefix}:{self.value}"
+
+    @classmethod
+    def from_identifier(cls, identifier: str) -> Self:
+        """canonical identifierを検証してtyped identityへ戻す。"""
+        if identifier.startswith("ollama:"):
+            return cls(ModelStoreKind.OLLAMA, identifier.removeprefix("ollama:"))
+        if identifier.startswith("hf:"):
+            return cls(ModelStoreKind.HUGGING_FACE, identifier.removeprefix("hf:"))
+        raise ValueError("canonicalなmodel identity identifierが必要です")

--- a/src/video_selection/models/scene_catalog.py
+++ b/src/video_selection/models/scene_catalog.py
@@ -1,0 +1,37 @@
+"""Video Setを横断して共有するScene Catalog。"""
+
+from dataclasses import dataclass
+
+from .scene_catalog_entry import SceneCatalogEntry
+
+
+@dataclass(frozen=True)
+class SceneCatalog:
+    """3〜8件の重複しないsceneと分類先otherを保持する。"""
+
+    scenes: tuple[SceneCatalogEntry, ...]
+
+    def __post_init__(self) -> None:
+        """scene数、slug一意性、other roleを検証する。"""
+        slugs = tuple(scene.slug for scene in self.scenes)
+        other_scenes = tuple(scene for scene in self.scenes if scene.slug == "other")
+        if (
+            not 3 <= len(self.scenes) <= 8
+            or len(slugs) != len(set(slugs))
+            or len(other_scenes) != 1
+            or other_scenes[0].selection_role != "ordinary"
+        ):
+            msg = "Scene Catalogのscene数、slug、other roleが不正です"
+            raise ValueError(msg)
+
+    @property
+    def slugs(self) -> tuple[str, ...]:
+        """Catalog順のScene Slugを返す。"""
+        return tuple(scene.slug for scene in self.scenes)
+
+    def for_slug(self, slug: str) -> SceneCatalogEntry:
+        """指定slugのsceneを返す。"""
+        try:
+            return next(scene for scene in self.scenes if scene.slug == slug)
+        except StopIteration:
+            raise KeyError(slug) from None

--- a/src/video_selection/models/scene_catalog_entry.py
+++ b/src/video_selection/models/scene_catalog_entry.py
@@ -1,0 +1,31 @@
+"""共有Scene Catalogの一つのscene。"""
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+SceneSelectionRole = Literal["ordinary", "cinematic", "recurring_gameplay"]
+
+_SCENE_SLUG_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+
+
+@dataclass(frozen=True)
+class SceneCatalogEntry:
+    """scene slug、表示名、説明、選定roleを保持する。"""
+
+    slug: str
+    display_name: str
+    description: str
+    selection_role: SceneSelectionRole
+
+    def __post_init__(self) -> None:
+        """公開可能なscene fieldだけを受理する。"""
+        if (
+            _SCENE_SLUG_PATTERN.fullmatch(self.slug) is None
+            or not self.display_name.strip()
+            or not self.description.strip()
+            or self.selection_role
+            not in {"ordinary", "cinematic", "recurring_gameplay"}
+        ):
+            msg = "Scene Catalog entryが不正です"
+            raise ValueError(msg)

--- a/src/video_selection/models/scene_catalog_entry.py
+++ b/src/video_selection/models/scene_catalog_entry.py
@@ -2,11 +2,20 @@
 
 import re
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, cast, get_args
 
 SceneSelectionRole = Literal["ordinary", "cinematic", "recurring_gameplay"]
+SCENE_SELECTION_ROLES = cast(
+    tuple[SceneSelectionRole, ...],
+    get_args(SceneSelectionRole),
+)
 
 _SCENE_SLUG_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+
+
+def is_valid_scene_slug(value: str) -> bool:
+    """Scene Catalogで公開可能なslugであることを返す。"""
+    return _SCENE_SLUG_PATTERN.fullmatch(value) is not None
 
 
 @dataclass(frozen=True)
@@ -21,11 +30,10 @@ class SceneCatalogEntry:
     def __post_init__(self) -> None:
         """公開可能なscene fieldだけを受理する。"""
         if (
-            _SCENE_SLUG_PATTERN.fullmatch(self.slug) is None
+            not is_valid_scene_slug(self.slug)
             or not self.display_name.strip()
             or not self.description.strip()
-            or self.selection_role
-            not in {"ordinary", "cinematic", "recurring_gameplay"}
+            or self.selection_role not in SCENE_SELECTION_ROLES
         ):
             msg = "Scene Catalog entryが不正です"
             raise ValueError(msg)

--- a/src/video_selection/models/scene_catalog_request.py
+++ b/src/video_selection/models/scene_catalog_request.py
@@ -1,0 +1,28 @@
+"""Scene Catalog推論へ渡すsemantic入力。"""
+
+from dataclasses import dataclass
+
+from .frame_candidate import FrameCandidate
+
+
+@dataclass(frozen=True)
+class SceneCatalogRequest:
+    """最大24枚の代表画像とSelection Intentを保持する。"""
+
+    representatives: tuple[FrameCandidate, ...]
+    selection_intent: str
+    scene_hint: str | None = None
+
+    def __post_init__(self) -> None:
+        """代表画像数、内容、識別子、意図を検証する。"""
+        identifiers = tuple(item.identifier for item in self.representatives)
+        if (
+            not 1 <= len(self.representatives) <= 24
+            or len(identifiers) != len(set(identifiers))
+            or any(not item.image_bytes for item in self.representatives)
+            or not self.selection_intent.strip()
+            or self.scene_hint is not None
+            and not self.scene_hint.strip()
+        ):
+            msg = "Scene Catalog requestが不正です"
+            raise ValueError(msg)

--- a/src/video_selection/models/vision_inference_diagnostics.py
+++ b/src/video_selection/models/vision_inference_diagnostics.py
@@ -1,0 +1,68 @@
+"""一回のVision推論のprivacy-safe診断。"""
+
+import re
+from dataclasses import dataclass
+
+_SAFE_VALUE_PATTERN = re.compile(r"[0-9A-Za-z][0-9A-Za-z._:+/-]{0,255}")
+
+
+@dataclass(frozen=True)
+class VisionInferenceDiagnostics:
+    """再現に必要なidentity、回数、token、durationだけを保持する。"""
+
+    request_fingerprint: str
+    model_name: str
+    model_identity: str
+    runtime_identity: str
+    prompt_version: str
+    schema_version: str
+    stage_contract_version: str
+    retry_policy_version: str
+    cache_hit: bool
+    attempt_count: int
+    validation_code: str | None
+    image_count: int
+    context_cue_count: int
+    duration_seconds: float
+    prompt_eval_count: int | None
+    eval_count: int | None
+    done_reason: str | None
+
+    def __post_init__(self) -> None:
+        """pathや自由形式detailを持たない診断だけを受理する。"""
+        safe_values = (
+            self.prompt_version,
+            self.schema_version,
+            self.stage_contract_version,
+            self.retry_policy_version,
+        )
+        optional_safe_values = (self.validation_code, self.done_reason)
+        counts = (
+            self.attempt_count,
+            self.image_count,
+            self.context_cue_count,
+        )
+        optional_counts = (self.prompt_eval_count, self.eval_count)
+        if (
+            len(self.request_fingerprint) != 64
+            or any(
+                character not in "0123456789abcdef"
+                for character in self.request_fingerprint
+            )
+            or any(
+                _SAFE_VALUE_PATTERN.fullmatch(value) is None for value in safe_values
+            )
+            or any(
+                value is not None and _SAFE_VALUE_PATTERN.fullmatch(value) is None
+                for value in optional_safe_values
+            )
+            or self.attempt_count not in {1, 2}
+            or any(value < 0 for value in counts)
+            or any(value is not None and value < 0 for value in optional_counts)
+            or self.duration_seconds < 0
+            or not self.model_name.strip()
+            or not self.model_identity.strip()
+            or not self.runtime_identity.strip()
+        ):
+            msg = "Vision inference diagnosticsが不正です"
+            raise ValueError(msg)

--- a/src/video_selection/models/vision_inference_diagnostics.py
+++ b/src/video_selection/models/vision_inference_diagnostics.py
@@ -3,6 +3,9 @@
 import re
 from dataclasses import dataclass
 
+from .model_runtime_identity import ModelRuntimeIdentity
+from .resolved_model_identity import ResolvedModelIdentity
+
 _SAFE_VALUE_PATTERN = re.compile(r"[0-9A-Za-z][0-9A-Za-z._:+/-]{0,255}")
 
 
@@ -43,6 +46,16 @@ class VisionInferenceDiagnostics:
             self.context_cue_count,
         )
         optional_counts = (self.prompt_eval_count, self.eval_count)
+        try:
+            model_identity = ResolvedModelIdentity.from_identifier(self.model_identity)
+            runtime_identity = ModelRuntimeIdentity.from_identifier(
+                self.runtime_identity
+            )
+            canonical_identity_pair = (
+                model_identity.store_kind is runtime_identity.store_kind
+            )
+        except ValueError:
+            canonical_identity_pair = False
         if (
             len(self.request_fingerprint) != 64
             or any(
@@ -60,9 +73,8 @@ class VisionInferenceDiagnostics:
             or any(value < 0 for value in counts)
             or any(value is not None and value < 0 for value in optional_counts)
             or self.duration_seconds < 0
-            or not self.model_name.strip()
-            or not self.model_identity.strip()
-            or not self.runtime_identity.strip()
+            or _SAFE_VALUE_PATTERN.fullmatch(self.model_name) is None
+            or not canonical_identity_pair
         ):
             msg = "Vision inference diagnosticsが不正です"
             raise ValueError(msg)

--- a/src/video_selection/models/vision_runtime_error.py
+++ b/src/video_selection/models/vision_runtime_error.py
@@ -1,0 +1,21 @@
+"""VisionRuntimeの安全化済みfatal error。"""
+
+from .vision_runtime_failure_reason import VisionRuntimeFailureReason
+
+
+class VisionRuntimeError(RuntimeError):
+    """外部detailを含めずstable reasonとvalidation codeを運ぶ。"""
+
+    def __init__(
+        self,
+        reason: VisionRuntimeFailureReason,
+        *,
+        validation_code: str | None = None,
+        attempt_count: int = 1,
+        retry_after_seconds: float = 1.0,
+    ) -> None:
+        self.reason = reason
+        self.validation_code = validation_code
+        self.attempt_count = attempt_count
+        self.retry_after_seconds = retry_after_seconds
+        super().__init__(f"VisionRuntime failed: {reason.value}")

--- a/src/video_selection/models/vision_runtime_failure_reason.py
+++ b/src/video_selection/models/vision_runtime_failure_reason.py
@@ -1,0 +1,14 @@
+"""VisionRuntimeのstable failure reason。"""
+
+from enum import StrEnum
+
+
+class VisionRuntimeFailureReason(StrEnum):
+    """retryと運用表示で使う失敗分類。"""
+
+    TRANSPORT_FAILURE = "transport_failure"
+    RESPONSE_INVALID = "response_invalid"
+    SCHEMA_INVALID = "schema_invalid"
+    DOMAIN_INVALID = "domain_invalid"
+    MODEL_UNAVAILABLE = "model_unavailable"
+    INVALID_REQUEST = "invalid_request"

--- a/src/video_selection/models/vision_stage_result.py
+++ b/src/video_selection/models/vision_stage_result.py
@@ -1,0 +1,28 @@
+"""Video Set Vision Stageの完了結果。"""
+
+from dataclasses import dataclass
+
+from .candidate_annotation import CandidateAnnotation
+from .completed_stage import CompletedStage
+from .scene_catalog import SceneCatalog
+from .vision_inference_diagnostics import VisionInferenceDiagnostics
+
+
+@dataclass(frozen=True)
+class VisionStageResult:
+    """共有Catalog、Moment別Annotation、診断、完了Stageを保持する。"""
+
+    catalog: SceneCatalog
+    annotations: tuple[CandidateAnnotation, ...]
+    catalog_diagnostics: VisionInferenceDiagnostics
+    annotation_diagnostics: tuple[VisionInferenceDiagnostics, ...]
+    completed_stages: tuple[CompletedStage, ...]
+
+    def __post_init__(self) -> None:
+        """Annotation、診断、Completed Stageの件数を検証する。"""
+        if (
+            len(self.annotations) != len(self.annotation_diagnostics)
+            or len(self.completed_stages) != len(self.annotations) + 1
+        ):
+            msg = "Vision Stage resultの件数が一致しません"
+            raise ValueError(msg)

--- a/src/video_selection/protocols/candidate_batch_annotator.py
+++ b/src/video_selection/protocols/candidate_batch_annotator.py
@@ -1,0 +1,20 @@
+"""walking skeletonの一括Candidate Annotation port。"""
+
+from typing import Protocol
+
+from ..models.candidate_annotation import CandidateAnnotation
+from ..models.context_cue import ContextCue
+from ..models.frame_candidate import FrameCandidate
+from ..models.resolved_model import ResolvedModel
+
+
+class CandidateBatchAnnotator(Protocol):
+    """Issue #190までのwalking skeleton用移行seam。"""
+
+    def annotate_candidates(
+        self,
+        candidates: tuple[FrameCandidate, ...],
+        context_cues: tuple[ContextCue, ...],
+        model: ResolvedModel,
+    ) -> tuple[CandidateAnnotation, ...]:
+        """候補に対応するplaceholder annotationを返す。"""

--- a/src/video_selection/protocols/vision_runtime.py
+++ b/src/video_selection/protocols/vision_runtime.py
@@ -1,20 +1,33 @@
-"""VisionRuntimeのsemantic port。"""
+"""strict structured outputを生成するVisionRuntime port。"""
 
 from typing import Protocol
 
 from ..models.candidate_annotation import CandidateAnnotation
-from ..models.context_cue import ContextCue
-from ..models.frame_candidate import FrameCandidate
+from ..models.candidate_annotation_request import CandidateAnnotationRequest
 from ..models.resolved_model import ResolvedModel
+from ..models.scene_catalog import SceneCatalog
+from ..models.scene_catalog_request import SceneCatalogRequest
+from ..models.vision_inference_diagnostics import VisionInferenceDiagnostics
 
 
 class VisionRuntime(Protocol):
-    """Frame Candidateへ意味annotationを付ける境界。"""
+    """model transport、strict validation、retryを閉じ込めるseam。"""
 
-    def annotate_candidates(
+    def create_scene_catalog(
         self,
-        candidates: tuple[FrameCandidate, ...],
-        context_cues: tuple[ContextCue, ...],
+        request: SceneCatalogRequest,
         model: ResolvedModel,
-    ) -> tuple[CandidateAnnotation, ...]:
-        """候補に対応するCandidate Annotationを返す。"""
+        *,
+        num_ctx: int,
+    ) -> tuple[SceneCatalog, VisionInferenceDiagnostics]:
+        """共有Scene Catalogとprivacy-safe診断を返す。"""
+
+    def annotate_candidate(
+        self,
+        request: CandidateAnnotationRequest,
+        catalog: SceneCatalog,
+        model: ResolvedModel,
+        *,
+        num_ctx: int,
+    ) -> tuple[CandidateAnnotation, VisionInferenceDiagnostics]:
+        """一つのCandidate Momentのannotationと診断を返す。"""

--- a/src/video_selection/services/stage_version.py
+++ b/src/video_selection/services/stage_version.py
@@ -13,4 +13,8 @@ def stage_version(stage: ProcessingStage) -> str:
         return "context-collection-v1"
     if stage is ProcessingStage.RESOLVE_MODELS:
         return "model-resolution-v1"
+    if stage is ProcessingStage.BUILD_SCENE_CATALOG:
+        return "scene-catalog-v1"
+    if stage is ProcessingStage.ANNOTATE_CANDIDATE:
+        return "candidate-annotation-v1"
     return "walking-skeleton-0"

--- a/src/video_selection/services/video_set_vision_processor.py
+++ b/src/video_selection/services/video_set_vision_processor.py
@@ -1,0 +1,316 @@
+"""Video Set単位のScene CatalogとCandidate Annotation Stage。"""
+
+import hashlib
+from collections.abc import Mapping
+from fractions import Fraction
+
+from ..models.candidate_annotation import CandidateAnnotation
+from ..models.candidate_annotation_request import CandidateAnnotationRequest
+from ..models.completed_stage import CompletedStage
+from ..models.effective_configuration import EffectiveConfiguration
+from ..models.frame_candidate import FrameCandidate
+from ..models.model_role import ModelRole
+from ..models.processing_stage import ProcessingStage
+from ..models.resolved_model import ResolvedModel
+from ..models.resolved_models import ResolvedModels
+from ..models.scene_catalog import SceneCatalog
+from ..models.scene_catalog_request import SceneCatalogRequest
+from ..models.stage_fingerprint import StageFingerprint
+from ..models.video_set import VideoSet
+from ..models.vision_inference_diagnostics import VisionInferenceDiagnostics
+from ..models.vision_stage_result import VisionStageResult
+from ..protocols.run_observer import RunObserver
+from ..protocols.vision_runtime import VisionRuntime
+from ..vision.vision_contract import (
+    CANDIDATE_ANNOTATION_PROMPT_VERSION,
+    CANDIDATE_ANNOTATION_SCHEMA_VERSION,
+    CANDIDATE_ANNOTATION_STAGE_CONTRACT_VERSION,
+    RETRY_POLICY_VERSION,
+    SCENE_CATALOG_PROMPT_VERSION,
+    SCENE_CATALOG_SCHEMA_VERSION,
+    SCENE_CATALOG_STAGE_CONTRACT_VERSION,
+)
+from .build_stage_fingerprint import build_stage_fingerprint
+from .completed_stage_writer import CompletedStageWriter
+from .snapshot_frame_candidates import snapshot_frame_candidates
+from .validate_video_set_snapshot import validate_video_set_snapshot
+from .vision_stage_artifacts import (
+    restore_candidate_annotation,
+    restore_scene_catalog,
+    serialize_candidate_annotation,
+    serialize_scene_catalog,
+)
+
+
+class VideoSetVisionProcessor:
+    """VisionRuntimeとMoment単位atomic cacheを一つの深いmoduleに保つ。"""
+
+    def __init__(self, runtime: VisionRuntime, observer: RunObserver) -> None:
+        self._runtime = runtime
+        self._observer = observer
+
+    def process(
+        self,
+        *,
+        video_set: VideoSet,
+        representatives: tuple[FrameCandidate, ...],
+        representative_source_fingerprints: tuple[StageFingerprint, ...],
+        annotation_requests: tuple[CandidateAnnotationRequest, ...],
+        configuration: EffectiveConfiguration,
+        resolved_models: ResolvedModels,
+    ) -> VisionStageResult:
+        """共有Catalogと指定ShortlistのAnnotationを確定または再利用する。"""
+        selection_intent = _validate_inputs(
+            representatives,
+            representative_source_fingerprints,
+            annotation_requests,
+        )
+        writer = CompletedStageWriter(
+            configuration.processing_cache_folder,
+            subject_namespace="video-sets",
+            subject_fingerprint=video_set.fingerprint,
+        )
+        catalog_model = resolved_models.for_role(ModelRole.SCENE_CATALOG)
+        annotation_model = resolved_models.for_role(ModelRole.CANDIDATE_ANNOTATION)
+        catalog_request = SceneCatalogRequest(
+            representatives=representatives,
+            selection_intent=selection_intent,
+            scene_hint=configuration.scene_hint,
+        )
+        validate_video_set_snapshot(video_set)
+        catalog, catalog_diagnostics, catalog_stage = self._catalog_stage(
+            writer,
+            video_set,
+            catalog_request,
+            representative_source_fingerprints,
+            catalog_model,
+            configuration.scene_catalog_num_ctx,
+        )
+        annotations: list[CandidateAnnotation] = []
+        annotation_diagnostics: list[VisionInferenceDiagnostics] = []
+        completed_stages = [catalog_stage]
+        for request in annotation_requests:
+            validate_video_set_snapshot(video_set)
+            annotation, diagnostics, completed = self._annotation_stage(
+                writer,
+                video_set,
+                request,
+                catalog,
+                catalog_stage.fingerprint,
+                annotation_model,
+                configuration.candidate_annotation_num_ctx,
+            )
+            annotations.append(annotation)
+            annotation_diagnostics.append(diagnostics)
+            completed_stages.append(completed)
+        return VisionStageResult(
+            catalog=catalog,
+            annotations=tuple(annotations),
+            catalog_diagnostics=catalog_diagnostics,
+            annotation_diagnostics=tuple(annotation_diagnostics),
+            completed_stages=tuple(completed_stages),
+        )
+
+    def _catalog_stage(
+        self,
+        writer: CompletedStageWriter,
+        video_set: VideoSet,
+        request: SceneCatalogRequest,
+        upstream_fingerprints: tuple[StageFingerprint, ...],
+        model: ResolvedModel,
+        num_ctx: int,
+    ) -> tuple[SceneCatalog, VisionInferenceDiagnostics, CompletedStage]:
+        """Video Setごとに一つのScene Catalog Stageを扱う。"""
+        semantic_input = _catalog_semantic_input(video_set, request, model, num_ctx)
+        fingerprint = build_stage_fingerprint(
+            ProcessingStage.BUILD_SCENE_CATALOG,
+            upstream_fingerprints,
+            semantic_input,
+        )
+        artifact = writer.read(
+            ProcessingStage.BUILD_SCENE_CATALOG,
+            fingerprint,
+            upstream_fingerprints,
+            semantic_input,
+        )
+        if artifact is None:
+            catalog, diagnostics = self._runtime.create_scene_catalog(
+                request,
+                model,
+                num_ctx=num_ctx,
+            )
+            completed = writer.write(
+                ProcessingStage.BUILD_SCENE_CATALOG,
+                fingerprint,
+                upstream_fingerprints,
+                semantic_input,
+                serialize_scene_catalog(catalog, diagnostics),
+            )
+        else:
+            catalog, diagnostics = restore_scene_catalog(artifact)
+            completed = CompletedStage(
+                ProcessingStage.BUILD_SCENE_CATALOG,
+                fingerprint,
+            )
+        self._observer.stage_completed(completed)
+        return catalog, diagnostics, completed
+
+    def _annotation_stage(
+        self,
+        writer: CompletedStageWriter,
+        video_set: VideoSet,
+        request: CandidateAnnotationRequest,
+        catalog: SceneCatalog,
+        catalog_fingerprint: StageFingerprint,
+        model: ResolvedModel,
+        num_ctx: int,
+    ) -> tuple[CandidateAnnotation, VisionInferenceDiagnostics, CompletedStage]:
+        """一つのCandidate Momentだけを独立Stageとして扱う。"""
+        semantic_input = _annotation_semantic_input(
+            video_set,
+            request,
+            catalog_fingerprint,
+            model,
+            num_ctx,
+        )
+        upstream = (catalog_fingerprint,)
+        fingerprint = build_stage_fingerprint(
+            ProcessingStage.ANNOTATE_CANDIDATE,
+            upstream,
+            semantic_input,
+        )
+        artifact = writer.read(
+            ProcessingStage.ANNOTATE_CANDIDATE,
+            fingerprint,
+            upstream,
+            semantic_input,
+        )
+        if artifact is None:
+            annotation, diagnostics = self._runtime.annotate_candidate(
+                request,
+                catalog,
+                model,
+                num_ctx=num_ctx,
+            )
+            _validate_runtime_annotation(annotation, request, catalog)
+            completed = writer.write(
+                ProcessingStage.ANNOTATE_CANDIDATE,
+                fingerprint,
+                upstream,
+                semantic_input,
+                serialize_candidate_annotation(annotation, diagnostics),
+            )
+        else:
+            annotation, diagnostics = restore_candidate_annotation(
+                artifact,
+                request,
+                catalog,
+            )
+            completed = CompletedStage(
+                ProcessingStage.ANNOTATE_CANDIDATE,
+                fingerprint,
+            )
+        self._observer.stage_completed(completed)
+        return annotation, diagnostics, completed
+
+
+def _validate_inputs(
+    representatives: tuple[FrameCandidate, ...],
+    representative_source_fingerprints: tuple[StageFingerprint, ...],
+    requests: tuple[CandidateAnnotationRequest, ...],
+) -> str:
+    if not requests:
+        raise ValueError("Selection Shortlistには1件以上のCandidate Momentが必要です")
+    selection_intents = {request.selection_intent for request in requests}
+    moment_ids = tuple(request.moment.identifier for request in requests)
+    fingerprint_values = tuple(
+        fingerprint.value for fingerprint in representative_source_fingerprints
+    )
+    if (
+        not representative_source_fingerprints
+        or len(fingerprint_values) != len(set(fingerprint_values))
+        or any(
+            len(value) != 64
+            or any(character not in "0123456789abcdef" for character in value)
+            for value in fingerprint_values
+        )
+        or len(selection_intents) != 1
+        or len(moment_ids) != len(set(moment_ids))
+    ):
+        raise ValueError("Vision Stage inputのSelection IntentまたはMomentが不正です")
+    SceneCatalogRequest(representatives, next(iter(selection_intents)))
+    return next(iter(selection_intents))
+
+
+def _validate_runtime_annotation(
+    annotation: CandidateAnnotation,
+    request: CandidateAnnotationRequest,
+    catalog: SceneCatalog,
+) -> None:
+    frame_ids = {item.identifier for item in request.frame_candidates}
+    cue_ids = {item.identifier for item in request.context_cues}
+    if (
+        annotation.candidate_moment_id != request.moment.identifier
+        or annotation.candidate.identifier not in frame_ids
+        or annotation.scene_slug not in catalog.slugs
+        or not set(annotation.supporting_context_cue_ids).issubset(cue_ids)
+    ):
+        raise ValueError("VisionRuntimeがrequest外のCandidate Annotationを返しました")
+
+
+def _catalog_semantic_input(
+    video_set: VideoSet,
+    request: SceneCatalogRequest,
+    model: ResolvedModel,
+    num_ctx: int,
+) -> dict[str, object]:
+    return {
+        "video_set_fingerprint": video_set.fingerprint,
+        "representatives": list(snapshot_frame_candidates(request.representatives)),
+        "selection_intent": request.selection_intent,
+        "scene_hint": request.scene_hint,
+        "model": {**model.semantic_input(), "num_ctx": num_ctx},
+        "generation_options": {"temperature": 0, "stream": False, "think": False},
+        "prompt_version": SCENE_CATALOG_PROMPT_VERSION,
+        "schema_version": SCENE_CATALOG_SCHEMA_VERSION,
+        "stage_contract_version": SCENE_CATALOG_STAGE_CONTRACT_VERSION,
+        "retry_policy_version": RETRY_POLICY_VERSION,
+    }
+
+
+def _annotation_semantic_input(
+    video_set: VideoSet,
+    request: CandidateAnnotationRequest,
+    catalog_fingerprint: StageFingerprint,
+    model: ResolvedModel,
+    num_ctx: int,
+) -> dict[str, object]:
+    return {
+        "video_set_fingerprint": video_set.fingerprint,
+        "candidate_moment_id": request.moment.identifier,
+        "frame_candidates": list(snapshot_frame_candidates(request.frame_candidates)),
+        "context_cues": [
+            {
+                "id": cue.identifier,
+                "source_kind": cue.source_kind,
+                "start": _fraction_value(cue.start),
+                "end": _fraction_value(cue.end),
+                "text_sha256": hashlib.sha256(cue.text.encode()).hexdigest(),
+            }
+            for cue in request.context_cues
+        ],
+        "cue_selection_policy_version": request.cue_selection_policy_version,
+        "scene_catalog_fingerprint": catalog_fingerprint.value,
+        "video_set_progress": _fraction_value(request.video_set_progress),
+        "selection_intent": request.selection_intent,
+        "model": {**model.semantic_input(), "num_ctx": num_ctx},
+        "generation_options": {"temperature": 0, "stream": False, "think": False},
+        "prompt_version": CANDIDATE_ANNOTATION_PROMPT_VERSION,
+        "schema_version": CANDIDATE_ANNOTATION_SCHEMA_VERSION,
+        "stage_contract_version": CANDIDATE_ANNOTATION_STAGE_CONTRACT_VERSION,
+        "retry_policy_version": RETRY_POLICY_VERSION,
+    }
+
+
+def _fraction_value(value: Fraction) -> Mapping[str, int]:
+    return {"numerator": value.numerator, "denominator": value.denominator}

--- a/src/video_selection/services/video_set_vision_processor.py
+++ b/src/video_selection/services/video_set_vision_processor.py
@@ -1,10 +1,17 @@
 """Video Set単位のScene CatalogとCandidate Annotation Stage。"""
 
 import hashlib
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from fractions import Fraction
+from pathlib import Path
+from typing import TypeVar
 
-from ..models.candidate_annotation import CandidateAnnotation
+from ..models.candidate_annotation import (
+    CandidateAnnotation,
+    candidate_annotation_context_is_valid,
+    candidate_annotation_free_text_is_safe,
+    candidate_annotation_relationships_are_valid,
+)
 from ..models.candidate_annotation_request import CandidateAnnotationRequest
 from ..models.completed_stage import CompletedStage
 from ..models.effective_configuration import EffectiveConfiguration
@@ -40,6 +47,8 @@ from .vision_stage_artifacts import (
     serialize_candidate_annotation,
     serialize_scene_catalog,
 )
+
+VisionStageValue = TypeVar("VisionStageValue")
 
 
 class VideoSetVisionProcessor:
@@ -127,31 +136,21 @@ class VideoSetVisionProcessor:
             upstream_fingerprints,
             semantic_input,
         )
-        artifact = writer.read(
-            ProcessingStage.BUILD_SCENE_CATALOG,
-            fingerprint,
-            upstream_fingerprints,
-            semantic_input,
-        )
-        if artifact is None:
-            catalog, diagnostics = self._runtime.create_scene_catalog(
+        (catalog, diagnostics), completed = _execute_cached_vision_stage(
+            writer=writer,
+            stage=ProcessingStage.BUILD_SCENE_CATALOG,
+            fingerprint=fingerprint,
+            upstream_fingerprints=upstream_fingerprints,
+            semantic_input=semantic_input,
+            generate=lambda: self._runtime.create_scene_catalog(
                 request,
                 model,
                 num_ctx=num_ctx,
-            )
-            completed = writer.write(
-                ProcessingStage.BUILD_SCENE_CATALOG,
-                fingerprint,
-                upstream_fingerprints,
-                semantic_input,
-                serialize_scene_catalog(catalog, diagnostics),
-            )
-        else:
-            catalog, diagnostics = restore_scene_catalog(artifact)
-            completed = CompletedStage(
-                ProcessingStage.BUILD_SCENE_CATALOG,
-                fingerprint,
-            )
+            ),
+            serialize=lambda value: serialize_scene_catalog(*value),
+            restore=restore_scene_catalog,
+            artifact_label="Scene Catalog",
+        )
         self._observer.stage_completed(completed)
         return catalog, diagnostics, completed
 
@@ -179,39 +178,75 @@ class VideoSetVisionProcessor:
             upstream,
             semantic_input,
         )
-        artifact = writer.read(
-            ProcessingStage.ANNOTATE_CANDIDATE,
-            fingerprint,
-            upstream,
-            semantic_input,
-        )
-        if artifact is None:
-            annotation, diagnostics = self._runtime.annotate_candidate(
+
+        def generate() -> tuple[CandidateAnnotation, VisionInferenceDiagnostics]:
+            generated = self._runtime.annotate_candidate(
                 request,
                 catalog,
                 model,
                 num_ctx=num_ctx,
             )
+            annotation, diagnostics = generated
             _validate_runtime_annotation(annotation, request, catalog)
-            completed = writer.write(
-                ProcessingStage.ANNOTATE_CANDIDATE,
-                fingerprint,
-                upstream,
-                semantic_input,
-                serialize_candidate_annotation(annotation, diagnostics),
-            )
-        else:
-            annotation, diagnostics = restore_candidate_annotation(
+            return generated
+
+        (annotation, diagnostics), completed = _execute_cached_vision_stage(
+            writer=writer,
+            stage=ProcessingStage.ANNOTATE_CANDIDATE,
+            fingerprint=fingerprint,
+            upstream_fingerprints=upstream,
+            semantic_input=semantic_input,
+            generate=generate,
+            serialize=lambda value: serialize_candidate_annotation(*value),
+            restore=lambda artifact: restore_candidate_annotation(
                 artifact,
                 request,
                 catalog,
-            )
-            completed = CompletedStage(
-                ProcessingStage.ANNOTATE_CANDIDATE,
-                fingerprint,
-            )
+            ),
+            artifact_label="Candidate Annotation",
+        )
         self._observer.stage_completed(completed)
         return annotation, diagnostics, completed
+
+
+def _execute_cached_vision_stage(
+    *,
+    writer: CompletedStageWriter,
+    stage: ProcessingStage,
+    fingerprint: StageFingerprint,
+    upstream_fingerprints: tuple[StageFingerprint, ...],
+    semantic_input: Mapping[str, object],
+    generate: Callable[[], VisionStageValue],
+    serialize: Callable[[VisionStageValue], dict[str, object]],
+    restore: Callable[[Mapping[str, object]], VisionStageValue],
+    artifact_label: str,
+) -> tuple[VisionStageValue, CompletedStage]:
+    """同じfingerprintの生成と復元を一つのlock lifecycleで確定する。"""
+    generated: VisionStageValue | None = None
+
+    def produce(_stage_folder: Path) -> dict[str, object]:
+        nonlocal generated
+        generated = generate()
+        return serialize(generated)
+
+    completed = writer.write_artifacts(
+        stage,
+        fingerprint,
+        upstream_fingerprints,
+        semantic_input,
+        produce,
+    )
+    if generated is not None:
+        return generated, completed
+    artifact = writer.read(
+        stage,
+        fingerprint,
+        upstream_fingerprints,
+        semantic_input,
+    )
+    if artifact is None:
+        raise RuntimeError(f"確定した{artifact_label} artifactを復元できません")
+    return restore(artifact), completed
 
 
 def _validate_inputs(
@@ -249,12 +284,30 @@ def _validate_runtime_annotation(
     catalog: SceneCatalog,
 ) -> None:
     frame_ids = {item.identifier for item in request.frame_candidates}
-    cue_ids = {item.identifier for item in request.context_cues}
+    cue_ids = tuple(item.identifier for item in request.context_cues)
     if (
         annotation.candidate_moment_id != request.moment.identifier
         or annotation.candidate.identifier not in frame_ids
         or annotation.scene_slug not in catalog.slugs
-        or not set(annotation.supporting_context_cue_ids).issubset(cue_ids)
+        or not candidate_annotation_relationships_are_valid(
+            annotation.context_relevance,
+            annotation.supporting_context_cue_ids,
+            annotation.spoiler_risk,
+            annotation.spoiler_evidence,
+        )
+        or not candidate_annotation_context_is_valid(
+            annotation.context_relevance,
+            annotation.supporting_context_cue_ids,
+            cue_ids,
+        )
+        or not candidate_annotation_free_text_is_safe(
+            (
+                annotation.summary,
+                annotation.frame_choice_reason or "",
+                annotation.spoiler_evidence,
+            ),
+            tuple(item.text for item in request.context_cues),
+        )
     ):
         raise ValueError("VisionRuntimeがrequest外のCandidate Annotationを返しました")
 

--- a/src/video_selection/services/video_set_vision_processor.py
+++ b/src/video_selection/services/video_set_vision_processor.py
@@ -283,11 +283,12 @@ def _validate_runtime_annotation(
     request: CandidateAnnotationRequest,
     catalog: SceneCatalog,
 ) -> None:
-    frame_ids = {item.identifier for item in request.frame_candidates}
+    frames_by_id = {item.identifier: item for item in request.frame_candidates}
+    expected_candidate = frames_by_id.get(annotation.candidate.identifier)
     cue_ids = tuple(item.identifier for item in request.context_cues)
     if (
         annotation.candidate_moment_id != request.moment.identifier
-        or annotation.candidate.identifier not in frame_ids
+        or expected_candidate != annotation.candidate
         or annotation.scene_slug not in catalog.slugs
         or not candidate_annotation_relationships_are_valid(
             annotation.context_relevance,

--- a/src/video_selection/services/video_set_vision_processor.py
+++ b/src/video_selection/services/video_set_vision_processor.py
@@ -238,8 +238,9 @@ def _validate_inputs(
         or len(moment_ids) != len(set(moment_ids))
     ):
         raise ValueError("Vision Stage inputのSelection IntentまたはMomentが不正です")
-    SceneCatalogRequest(representatives, next(iter(selection_intents)))
-    return next(iter(selection_intents))
+    selection_intent = next(iter(selection_intents))
+    SceneCatalogRequest(representatives, selection_intent)
+    return selection_intent
 
 
 def _validate_runtime_annotation(

--- a/src/video_selection/services/vision_stage_artifacts.py
+++ b/src/video_selection/services/vision_stage_artifacts.py
@@ -4,16 +4,23 @@ from dataclasses import replace
 from typing import Mapping, cast
 
 from ..models.candidate_annotation import (
-    BlogImageType,
+    BLOG_IMAGE_TYPES,
+    CONTEXT_CUE_RELEVANCES,
+    EXPLANATION_VALUES,
+    SCREEN_TEXT_KINDS,
+    SPOILER_RISKS,
     CandidateAnnotation,
-    ContextCueRelevance,
-    ExplanationValue,
-    ScreenTextKind,
-    SpoilerRisk,
+    candidate_annotation_context_is_valid,
+    candidate_annotation_free_text_is_safe,
+    candidate_annotation_relationships_are_valid,
 )
 from ..models.candidate_annotation_request import CandidateAnnotationRequest
 from ..models.scene_catalog import SceneCatalog
-from ..models.scene_catalog_entry import SceneCatalogEntry, SceneSelectionRole
+from ..models.scene_catalog_entry import (
+    SCENE_SELECTION_ROLES,
+    SceneCatalogEntry,
+    SceneSelectionRole,
+)
 from ..models.vision_inference_diagnostics import VisionInferenceDiagnostics
 
 _CATALOG_SCHEMA = "game-screen-pick/scene-catalog@1.0.0"
@@ -98,24 +105,44 @@ def restore_candidate_annotation(
     spoiler_risk = annotation.get("spoiler_risk")
     spoiler_evidence = annotation.get("spoiler_evidence")
     frames = {item.identifier: item for item in request.frame_candidates}
-    cue_ids = {item.identifier for item in request.context_cues}
+    available_cue_ids = tuple(item.identifier for item in request.context_cues)
     if (
         candidate_moment_id != request.moment.identifier
         or not isinstance(representative_frame_id, str)
         or representative_frame_id not in frames
         or not isinstance(scene_slug, str)
         or scene_slug not in catalog.slugs
-        or blog_image_type not in {"normal_gameplay", "event", "menu", "title", "other"}
-        or explanation_value not in {"none", "low", "medium", "high"}
+        or blog_image_type not in BLOG_IMAGE_TYPES
+        or explanation_value not in EXPLANATION_VALUES
         or not isinstance(summary, str)
         or not isinstance(frame_choice_reason, str)
-        or screen_text_kind not in {"none", "dialogue", "menu", "title", "hud", "other"}
-        or context_relevance not in {"unavailable", "none", "weak", "strong"}
+        or screen_text_kind not in SCREEN_TEXT_KINDS
+        or context_relevance not in CONTEXT_CUE_RELEVANCES
         or not isinstance(raw_cue_ids, list)
         or not all(isinstance(item, str) for item in raw_cue_ids)
-        or not set(raw_cue_ids).issubset(cue_ids)
-        or spoiler_risk not in {"none", "low", "medium", "high"}
+        or spoiler_risk not in SPOILER_RISKS
         or not isinstance(spoiler_evidence, str)
+    ):
+        raise ValueError("Candidate Annotation artifact domainが不正です")
+    typed_context_relevance = context_relevance
+    typed_cue_ids = tuple(cast(list[str], raw_cue_ids))
+    typed_spoiler_risk = spoiler_risk
+    if (
+        not candidate_annotation_relationships_are_valid(
+            typed_context_relevance,
+            typed_cue_ids,
+            typed_spoiler_risk,
+            spoiler_evidence,
+        )
+        or not candidate_annotation_context_is_valid(
+            typed_context_relevance,
+            typed_cue_ids,
+            available_cue_ids,
+        )
+        or not candidate_annotation_free_text_is_safe(
+            (summary, frame_choice_reason, spoiler_evidence),
+            tuple(item.text for item in request.context_cues),
+        )
     ):
         raise ValueError("Candidate Annotation artifact domainが不正です")
     restored = CandidateAnnotation(
@@ -123,13 +150,13 @@ def restore_candidate_annotation(
         summary=summary,
         candidate_moment_id=candidate_moment_id,
         scene_slug=scene_slug,
-        blog_image_type=cast(BlogImageType, blog_image_type),
-        explanation_value=cast(ExplanationValue, explanation_value),
+        blog_image_type=blog_image_type,
+        explanation_value=explanation_value,
         frame_choice_reason=frame_choice_reason,
-        screen_text_kind=cast(ScreenTextKind, screen_text_kind),
-        context_relevance=cast(ContextCueRelevance, context_relevance),
-        supporting_context_cue_ids=tuple(cast(list[str], raw_cue_ids)),
-        spoiler_risk=cast(SpoilerRisk, spoiler_risk),
+        screen_text_kind=screen_text_kind,
+        context_relevance=typed_context_relevance,
+        supporting_context_cue_ids=typed_cue_ids,
+        spoiler_risk=typed_spoiler_risk,
         spoiler_evidence=spoiler_evidence,
     )
     diagnostics = _restore_diagnostics(artifact.get("diagnostics"))
@@ -156,7 +183,7 @@ def _restore_scene(value: object) -> SceneCatalogEntry:
         not isinstance(slug, str)
         or not isinstance(display_name, str)
         or not isinstance(description, str)
-        or selection_role not in {"ordinary", "cinematic", "recurring_gameplay"}
+        or selection_role not in SCENE_SELECTION_ROLES
     ):
         raise ValueError("Scene Catalog artifact entry fieldが不正です")
     return SceneCatalogEntry(

--- a/src/video_selection/services/vision_stage_artifacts.py
+++ b/src/video_selection/services/vision_stage_artifacts.py
@@ -1,0 +1,262 @@
+"""Scene CatalogとCandidate Annotationのcache artifact変換。"""
+
+from dataclasses import replace
+from typing import Mapping, cast
+
+from ..models.candidate_annotation import (
+    BlogImageType,
+    CandidateAnnotation,
+    ContextCueRelevance,
+    ExplanationValue,
+    ScreenTextKind,
+    SpoilerRisk,
+)
+from ..models.candidate_annotation_request import CandidateAnnotationRequest
+from ..models.scene_catalog import SceneCatalog
+from ..models.scene_catalog_entry import SceneCatalogEntry, SceneSelectionRole
+from ..models.vision_inference_diagnostics import VisionInferenceDiagnostics
+
+_CATALOG_SCHEMA = "game-screen-pick/scene-catalog@1.0.0"
+_ANNOTATION_SCHEMA = "game-screen-pick/candidate-annotation@1.0.0"
+
+
+def serialize_scene_catalog(
+    catalog: SceneCatalog,
+    diagnostics: VisionInferenceDiagnostics,
+) -> dict[str, object]:
+    """domain検証済みCatalogとsafe diagnosticsだけを保存する。"""
+    return {
+        "schema": _CATALOG_SCHEMA,
+        "scenes": [_scene_value(scene) for scene in catalog.scenes],
+        "diagnostics": _diagnostics_value(diagnostics),
+    }
+
+
+def restore_scene_catalog(
+    artifact: Mapping[str, object],
+) -> tuple[SceneCatalog, VisionInferenceDiagnostics]:
+    """Catalog artifactをstrictに復元してcache hitを記録する。"""
+    if artifact.get("schema") != _CATALOG_SCHEMA:
+        raise ValueError("Scene Catalog artifact schemaが不正です")
+    raw_scenes = artifact.get("scenes")
+    if not isinstance(raw_scenes, list):
+        raise ValueError("Scene Catalog artifact scenesが不正です")
+    scenes = tuple(_restore_scene(item) for item in raw_scenes)
+    diagnostics = _restore_diagnostics(artifact.get("diagnostics"))
+    return SceneCatalog(scenes), replace(diagnostics, cache_hit=True)
+
+
+def serialize_candidate_annotation(
+    annotation: CandidateAnnotation,
+    diagnostics: VisionInferenceDiagnostics,
+) -> dict[str, object]:
+    """model応答ではなく検証済みannotationとsafe diagnosticsを保存する。"""
+    return {
+        "schema": _ANNOTATION_SCHEMA,
+        "annotation": {
+            "candidate_moment_id": annotation.candidate_moment_id,
+            "representative_frame_id": annotation.candidate.identifier,
+            "scene_slug": annotation.scene_slug,
+            "blog_image_type": annotation.blog_image_type,
+            "explanation_value": annotation.explanation_value,
+            "annotation_summary": annotation.summary,
+            "frame_choice_reason": annotation.frame_choice_reason,
+            "screen_text_kind": annotation.screen_text_kind,
+            "context_relevance": annotation.context_relevance,
+            "supporting_context_cue_ids": list(annotation.supporting_context_cue_ids),
+            "spoiler_risk": annotation.spoiler_risk,
+            "spoiler_evidence": annotation.spoiler_evidence,
+        },
+        "diagnostics": _diagnostics_value(diagnostics),
+    }
+
+
+def restore_candidate_annotation(
+    artifact: Mapping[str, object],
+    request: CandidateAnnotationRequest,
+    catalog: SceneCatalog,
+) -> tuple[CandidateAnnotation, VisionInferenceDiagnostics]:
+    """Annotation artifactを現在のFrame/Cue/Catalogへ所属検証して復元する。"""
+    if artifact.get("schema") != _ANNOTATION_SCHEMA:
+        raise ValueError("Candidate Annotation artifact schemaが不正です")
+    raw_annotation = artifact.get("annotation")
+    if not isinstance(raw_annotation, dict) or not all(
+        isinstance(key, str) for key in raw_annotation
+    ):
+        raise ValueError("Candidate Annotation artifact fieldが不正です")
+    annotation = cast(dict[str, object], raw_annotation)
+    candidate_moment_id = annotation.get("candidate_moment_id")
+    representative_frame_id = annotation.get("representative_frame_id")
+    scene_slug = annotation.get("scene_slug")
+    blog_image_type = annotation.get("blog_image_type")
+    explanation_value = annotation.get("explanation_value")
+    summary = annotation.get("annotation_summary")
+    frame_choice_reason = annotation.get("frame_choice_reason")
+    screen_text_kind = annotation.get("screen_text_kind")
+    context_relevance = annotation.get("context_relevance")
+    raw_cue_ids = annotation.get("supporting_context_cue_ids")
+    spoiler_risk = annotation.get("spoiler_risk")
+    spoiler_evidence = annotation.get("spoiler_evidence")
+    frames = {item.identifier: item for item in request.frame_candidates}
+    cue_ids = {item.identifier for item in request.context_cues}
+    if (
+        candidate_moment_id != request.moment.identifier
+        or not isinstance(representative_frame_id, str)
+        or representative_frame_id not in frames
+        or not isinstance(scene_slug, str)
+        or scene_slug not in catalog.slugs
+        or blog_image_type not in {"normal_gameplay", "event", "menu", "title", "other"}
+        or explanation_value not in {"none", "low", "medium", "high"}
+        or not isinstance(summary, str)
+        or not isinstance(frame_choice_reason, str)
+        or screen_text_kind not in {"none", "dialogue", "menu", "title", "hud", "other"}
+        or context_relevance not in {"unavailable", "none", "weak", "strong"}
+        or not isinstance(raw_cue_ids, list)
+        or not all(isinstance(item, str) for item in raw_cue_ids)
+        or not set(raw_cue_ids).issubset(cue_ids)
+        or spoiler_risk not in {"none", "low", "medium", "high"}
+        or not isinstance(spoiler_evidence, str)
+    ):
+        raise ValueError("Candidate Annotation artifact domainが不正です")
+    restored = CandidateAnnotation(
+        candidate=frames[representative_frame_id],
+        summary=summary,
+        candidate_moment_id=candidate_moment_id,
+        scene_slug=scene_slug,
+        blog_image_type=cast(BlogImageType, blog_image_type),
+        explanation_value=cast(ExplanationValue, explanation_value),
+        frame_choice_reason=frame_choice_reason,
+        screen_text_kind=cast(ScreenTextKind, screen_text_kind),
+        context_relevance=cast(ContextCueRelevance, context_relevance),
+        supporting_context_cue_ids=tuple(cast(list[str], raw_cue_ids)),
+        spoiler_risk=cast(SpoilerRisk, spoiler_risk),
+        spoiler_evidence=spoiler_evidence,
+    )
+    diagnostics = _restore_diagnostics(artifact.get("diagnostics"))
+    return restored, replace(diagnostics, cache_hit=True)
+
+
+def _scene_value(scene: SceneCatalogEntry) -> dict[str, str]:
+    return {
+        "slug": scene.slug,
+        "display_name": scene.display_name,
+        "description": scene.description,
+        "selection_role": scene.selection_role,
+    }
+
+
+def _restore_scene(value: object) -> SceneCatalogEntry:
+    if not isinstance(value, dict):
+        raise ValueError("Scene Catalog artifact entryが不正です")
+    slug = value.get("slug")
+    display_name = value.get("display_name")
+    description = value.get("description")
+    selection_role = value.get("selection_role")
+    if (
+        not isinstance(slug, str)
+        or not isinstance(display_name, str)
+        or not isinstance(description, str)
+        or selection_role not in {"ordinary", "cinematic", "recurring_gameplay"}
+    ):
+        raise ValueError("Scene Catalog artifact entry fieldが不正です")
+    return SceneCatalogEntry(
+        slug,
+        display_name,
+        description,
+        cast(SceneSelectionRole, selection_role),
+    )
+
+
+def _diagnostics_value(
+    diagnostics: VisionInferenceDiagnostics,
+) -> dict[str, object]:
+    return {
+        "request_fingerprint": diagnostics.request_fingerprint,
+        "model_name": diagnostics.model_name,
+        "model_identity": diagnostics.model_identity,
+        "runtime_identity": diagnostics.runtime_identity,
+        "prompt_version": diagnostics.prompt_version,
+        "schema_version": diagnostics.schema_version,
+        "stage_contract_version": diagnostics.stage_contract_version,
+        "retry_policy_version": diagnostics.retry_policy_version,
+        "cache_hit": diagnostics.cache_hit,
+        "attempt_count": diagnostics.attempt_count,
+        "validation_code": diagnostics.validation_code,
+        "image_count": diagnostics.image_count,
+        "context_cue_count": diagnostics.context_cue_count,
+        "duration_seconds": diagnostics.duration_seconds,
+        "prompt_eval_count": diagnostics.prompt_eval_count,
+        "eval_count": diagnostics.eval_count,
+        "done_reason": diagnostics.done_reason,
+    }
+
+
+def _restore_diagnostics(value: object) -> VisionInferenceDiagnostics:
+    if not isinstance(value, dict):
+        raise ValueError("Vision diagnostics artifactが不正です")
+    required_strings = (
+        "request_fingerprint",
+        "model_name",
+        "model_identity",
+        "runtime_identity",
+        "prompt_version",
+        "schema_version",
+        "stage_contract_version",
+        "retry_policy_version",
+    )
+    if not all(isinstance(value.get(key), str) for key in required_strings):
+        raise ValueError("Vision diagnostics artifact fieldが不正です")
+    attempt_count = value.get("attempt_count")
+    image_count = value.get("image_count")
+    context_cue_count = value.get("context_cue_count")
+    duration_seconds = value.get("duration_seconds")
+    cache_hit = value.get("cache_hit")
+    if (
+        not isinstance(attempt_count, int)
+        or isinstance(attempt_count, bool)
+        or not isinstance(image_count, int)
+        or isinstance(image_count, bool)
+        or not isinstance(context_cue_count, int)
+        or isinstance(context_cue_count, bool)
+        or not isinstance(duration_seconds, int | float)
+        or isinstance(duration_seconds, bool)
+        or not isinstance(cache_hit, bool)
+    ):
+        raise ValueError("Vision diagnostics artifact numeric fieldが不正です")
+    validation_code = value.get("validation_code")
+    done_reason = value.get("done_reason")
+    prompt_eval_count = value.get("prompt_eval_count")
+    eval_count = value.get("eval_count")
+    if (
+        validation_code is not None
+        and not isinstance(validation_code, str)
+        or done_reason is not None
+        and not isinstance(done_reason, str)
+        or prompt_eval_count is not None
+        and (
+            not isinstance(prompt_eval_count, int)
+            or isinstance(prompt_eval_count, bool)
+        )
+        or eval_count is not None
+        and (not isinstance(eval_count, int) or isinstance(eval_count, bool))
+    ):
+        raise ValueError("Vision diagnostics artifact optional fieldが不正です")
+    return VisionInferenceDiagnostics(
+        request_fingerprint=cast(str, value["request_fingerprint"]),
+        model_name=cast(str, value["model_name"]),
+        model_identity=cast(str, value["model_identity"]),
+        runtime_identity=cast(str, value["runtime_identity"]),
+        prompt_version=cast(str, value["prompt_version"]),
+        schema_version=cast(str, value["schema_version"]),
+        stage_contract_version=cast(str, value["stage_contract_version"]),
+        retry_policy_version=cast(str, value["retry_policy_version"]),
+        cache_hit=cache_hit,
+        attempt_count=attempt_count,
+        validation_code=validation_code,
+        image_count=image_count,
+        context_cue_count=context_cue_count,
+        duration_seconds=float(duration_seconds),
+        prompt_eval_count=prompt_eval_count,
+        eval_count=eval_count,
+        done_reason=done_reason,
+    )

--- a/src/video_selection/utils/http_retry_delay.py
+++ b/src/video_selection/utils/http_retry_delay.py
@@ -1,0 +1,28 @@
+"""HTTP Retry-Afterを安全な待機秒へ変換する。"""
+
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from math import isfinite
+
+
+def http_retry_delay(status_code: int, retry_after: str | None) -> float:
+    """429のdelta-secondsまたはHTTP-dateを0〜30秒へ制限して返す。"""
+    if status_code != 429:
+        return 1.0
+    try:
+        seconds = float(retry_after) if retry_after is not None else 1.0
+    except ValueError:
+        try:
+            retry_at = (
+                parsedate_to_datetime(retry_after) if retry_after is not None else None
+            )
+        except (TypeError, ValueError, OverflowError):
+            return 1.0
+        if retry_at is None:
+            return 1.0
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=timezone.utc)
+        seconds = (retry_at - datetime.now(timezone.utc)).total_seconds()
+    if not isfinite(seconds):
+        return 1.0
+    return min(max(seconds, 0.0), 30.0)

--- a/src/video_selection/vision/ollama_vision_runtime.py
+++ b/src/video_selection/vision/ollama_vision_runtime.py
@@ -1,0 +1,640 @@
+"""Ollama structured outputsを使うVisionRuntime adapter。"""
+
+import base64
+import hashlib
+import json
+import re
+import time
+from collections.abc import Callable, Mapping
+from fractions import Fraction
+from typing import Literal, TypeVar, cast
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from ..models.candidate_annotation import (
+    BlogImageType,
+    CandidateAnnotation,
+    ContextCueRelevance,
+    ExplanationValue,
+    ScreenTextKind,
+    SpoilerRisk,
+)
+from ..models.candidate_annotation_request import CandidateAnnotationRequest
+from ..models.model_role import ModelRole
+from ..models.resolved_model import ResolvedModel
+from ..models.scene_catalog import SceneCatalog
+from ..models.scene_catalog_entry import SceneCatalogEntry, SceneSelectionRole
+from ..models.scene_catalog_request import SceneCatalogRequest
+from ..models.vision_inference_diagnostics import VisionInferenceDiagnostics
+from ..models.vision_runtime_error import VisionRuntimeError
+from ..models.vision_runtime_failure_reason import VisionRuntimeFailureReason
+from .vision_contract import (
+    CANDIDATE_ANNOTATION_PROMPT_VERSION,
+    CANDIDATE_ANNOTATION_SCHEMA,
+    CANDIDATE_ANNOTATION_SCHEMA_VERSION,
+    CANDIDATE_ANNOTATION_STAGE_CONTRACT_VERSION,
+    RETRY_POLICY_VERSION,
+    SCENE_CATALOG_PROMPT_VERSION,
+    SCENE_CATALOG_SCHEMA,
+    SCENE_CATALOG_SCHEMA_VERSION,
+    SCENE_CATALOG_STAGE_CONTRACT_VERSION,
+)
+
+JsonRequester = Callable[
+    [str, str, Mapping[str, object] | None, float],
+    object,
+]
+Sleeper = Callable[[float], None]
+InferenceValue = TypeVar("InferenceValue")
+InferenceParser = Callable[[Mapping[str, object]], InferenceValue]
+StageKind = Literal["scene_catalog", "candidate_annotation"]
+
+_SCENE_ENTRY_KEYS = {"slug", "display_name", "description", "selection_role"}
+_ANNOTATION_KEYS = {
+    "representative_frame_id",
+    "scene_slug",
+    "blog_image_type",
+    "explanation_value",
+    "annotation_summary",
+    "frame_choice_reason",
+    "screen_text_kind",
+    "context_relevance",
+    "supporting_context_cue_ids",
+    "spoiler_risk",
+    "spoiler_evidence",
+}
+_SCENE_SLUG_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+_RETRYABLE_REASONS = {
+    VisionRuntimeFailureReason.TRANSPORT_FAILURE,
+    VisionRuntimeFailureReason.RESPONSE_INVALID,
+    VisionRuntimeFailureReason.SCHEMA_INVALID,
+    VisionRuntimeFailureReason.DOMAIN_INVALID,
+}
+
+
+class OllamaVisionRuntime:
+    """Scene CatalogとCandidate Annotationの全推論規則を閉じ込める。"""
+
+    def __init__(
+        self,
+        host: str,
+        *,
+        timeout_seconds: float,
+        requester: JsonRequester | None = None,
+        sleeper: Sleeper = time.sleep,
+    ) -> None:
+        if not host.strip() or timeout_seconds <= 0:
+            raise ValueError("Ollama VisionRuntimeの接続設定が不正です")
+        self._host = host.rstrip("/")
+        self._timeout_seconds = timeout_seconds
+        self._requester = requester or _request_json
+        self._sleeper = sleeper
+
+    def create_scene_catalog(
+        self,
+        request: SceneCatalogRequest,
+        model: ResolvedModel,
+        *,
+        num_ctx: int,
+    ) -> tuple[SceneCatalog, VisionInferenceDiagnostics]:
+        """共有Scene Catalogをstrict schemaとdomain validationで生成する。"""
+        _require_model_role(model, ModelRole.SCENE_CATALOG, num_ctx)
+        semantic_input = _scene_catalog_semantic_input(request, model, num_ctx)
+        return self._infer(
+            stage_kind="scene_catalog",
+            request_fingerprint=_fingerprint(semantic_input),
+            payload=_scene_catalog_payload(request, model, num_ctx),
+            parser=_parse_scene_catalog,
+            model=model,
+            image_count=len(request.representatives),
+            context_cue_count=0,
+        )
+
+    def annotate_candidate(
+        self,
+        request: CandidateAnnotationRequest,
+        catalog: SceneCatalog,
+        model: ResolvedModel,
+        *,
+        num_ctx: int,
+    ) -> tuple[CandidateAnnotation, VisionInferenceDiagnostics]:
+        """一つのCandidate Momentをstrict schemaと所属検証で評価する。"""
+        _require_model_role(model, ModelRole.CANDIDATE_ANNOTATION, num_ctx)
+        semantic_input = _candidate_semantic_input(request, catalog, model, num_ctx)
+        return self._infer(
+            stage_kind="candidate_annotation",
+            request_fingerprint=_fingerprint(semantic_input),
+            payload=_candidate_payload(request, catalog, model, num_ctx),
+            parser=lambda value: _parse_candidate_annotation(value, request, catalog),
+            model=model,
+            image_count=len(request.frame_candidates),
+            context_cue_count=len(request.context_cues),
+        )
+
+    def _infer(
+        self,
+        *,
+        stage_kind: StageKind,
+        request_fingerprint: str,
+        payload: dict[str, object],
+        parser: InferenceParser[InferenceValue],
+        model: ResolvedModel,
+        image_count: int,
+        context_cue_count: int,
+    ) -> tuple[InferenceValue, VisionInferenceDiagnostics]:
+        """同じsemantic入力を最大2回実行しsafe diagnosticsを返す。"""
+        started_at = time.monotonic()
+        previous_validation_code: str | None = None
+        for attempt in (1, 2):
+            attempt_payload = _with_repair_code(payload, previous_validation_code)
+            try:
+                response = self._request(attempt_payload)
+                value = parser(_decode_content(response, stage_kind))
+            except VisionRuntimeError as error:
+                if attempt == 2 or error.reason not in _RETRYABLE_REASONS:
+                    raise VisionRuntimeError(
+                        error.reason,
+                        validation_code=error.validation_code,
+                        attempt_count=attempt,
+                    ) from None
+                previous_validation_code = error.validation_code
+                self._sleeper(error.retry_after_seconds)
+                continue
+            diagnostics = _diagnostics(
+                response=response,
+                stage_kind=stage_kind,
+                request_fingerprint=request_fingerprint,
+                model=model,
+                attempt_count=attempt,
+                validation_code=previous_validation_code,
+                image_count=image_count,
+                context_cue_count=context_cue_count,
+                duration_seconds=time.monotonic() - started_at,
+            )
+            return value, diagnostics
+        raise AssertionError("VisionRuntime retry loop did not terminate")
+
+    def _request(self, payload: Mapping[str, object]) -> Mapping[str, object]:
+        """transport detailをstable failureへ変換する。"""
+        try:
+            response = self._requester(
+                "POST",
+                f"{self._host}/api/chat",
+                payload,
+                self._timeout_seconds,
+            )
+        except HTTPError as error:
+            if error.code in {408, 429} or error.code >= 500:
+                raise VisionRuntimeError(
+                    VisionRuntimeFailureReason.TRANSPORT_FAILURE,
+                    validation_code="ollama_transport_failure",
+                    retry_after_seconds=_retry_delay(error),
+                ) from None
+            reason = (
+                VisionRuntimeFailureReason.MODEL_UNAVAILABLE
+                if error.code == 404
+                else VisionRuntimeFailureReason.INVALID_REQUEST
+            )
+            raise VisionRuntimeError(reason) from None
+        except Exception:
+            raise VisionRuntimeError(
+                VisionRuntimeFailureReason.TRANSPORT_FAILURE,
+                validation_code="ollama_transport_failure",
+            ) from None
+        if not isinstance(response, dict) or not all(
+            isinstance(key, str) for key in response
+        ):
+            raise VisionRuntimeError(
+                VisionRuntimeFailureReason.RESPONSE_INVALID,
+                validation_code="ollama_response_invalid",
+            )
+        return cast(dict[str, object], response)
+
+
+def _request_json(
+    method: str,
+    url: str,
+    payload: Mapping[str, object] | None,
+    timeout: float,
+) -> object:
+    body = None if payload is None else json.dumps(payload).encode()
+    request = Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method=method,
+    )
+    with urlopen(request, timeout=timeout) as response:
+        return json.load(response)
+
+
+def _scene_catalog_payload(
+    request: SceneCatalogRequest,
+    model: ResolvedModel,
+    num_ctx: int,
+) -> dict[str, object]:
+    hint = request.scene_hint or "なし"
+    content = (
+        "Video Set全体で共有するブログ画像用Scene Catalogを作成してください。"
+        "3〜8 sceneにotherを必ず1件含め、otherのselection_roleはordinaryにします。"
+        "画像品質、最終score、採否、推論過程は出力しません。\n"
+        f"Selection Intent: {request.selection_intent}\nScene Hint: {hint}"
+    )
+    return {
+        "model": model.configured_name,
+        "stream": False,
+        "think": False,
+        "format": SCENE_CATALOG_SCHEMA,
+        "options": {"temperature": 0, "num_ctx": num_ctx},
+        "messages": [
+            {
+                "role": "user",
+                "content": content,
+                "images": [
+                    base64.b64encode(item.image_bytes).decode()
+                    for item in request.representatives
+                ],
+            }
+        ],
+    }
+
+
+def _candidate_payload(
+    request: CandidateAnnotationRequest,
+    catalog: SceneCatalog,
+    model: ResolvedModel,
+    num_ctx: int,
+) -> dict[str, object]:
+    semantic_request = {
+        "candidate_moment_id": request.moment.identifier,
+        "frame_candidate_ids": [item.identifier for item in request.frame_candidates],
+        "scene_catalog": [_scene_value(item) for item in catalog.scenes],
+        "context_cues": [
+            {
+                "id": cue.identifier,
+                "start": _fraction_value(cue.start),
+                "end": _fraction_value(cue.end),
+                "text": cue.text,
+            }
+            for cue in request.context_cues
+        ],
+        "video_set_progress": _fraction_value(request.video_set_progress),
+        "selection_intent": request.selection_intent,
+    }
+    content = (
+        "入力された1〜3枚からブログ上の意味を最も表すframeを1枚選び、"
+        "共有Scene Catalogを使ってCandidate Annotationを返してください。"
+        "画像品質、confidence、final score、eligible、selected、逐語的画面文、"
+        "推論過程は出力しません。Context Cue本文をannotation summaryへ引用しません。\n"
+        + json.dumps(semantic_request, ensure_ascii=False, sort_keys=True)
+    )
+    return {
+        "model": model.configured_name,
+        "stream": False,
+        "think": False,
+        "format": CANDIDATE_ANNOTATION_SCHEMA,
+        "options": {"temperature": 0, "num_ctx": num_ctx},
+        "messages": [
+            {
+                "role": "user",
+                "content": content,
+                "images": [
+                    base64.b64encode(item.image_bytes).decode()
+                    for item in request.frame_candidates
+                ],
+            }
+        ],
+    }
+
+
+def _with_repair_code(
+    payload: dict[str, object], validation_code: str | None
+) -> dict[str, object]:
+    if validation_code is None:
+        return payload
+    copied = cast(dict[str, object], json.loads(json.dumps(payload)))
+    messages = cast(list[dict[str, object]], copied["messages"])
+    content = cast(str, messages[0]["content"])
+    messages[0]["content"] = (
+        f"{content}\n前回の出力を修正してください。validation_code={validation_code}"
+    )
+    return copied
+
+
+def _decode_content(
+    response: Mapping[str, object], stage_kind: StageKind
+) -> Mapping[str, object]:
+    if response.get("done") is not True:
+        raise VisionRuntimeError(
+            VisionRuntimeFailureReason.RESPONSE_INVALID,
+            validation_code=f"{stage_kind}_response_truncated",
+        )
+    message = response.get("message")
+    content = message.get("content") if isinstance(message, dict) else None
+    if not isinstance(content, str) or not content.strip():
+        raise VisionRuntimeError(
+            VisionRuntimeFailureReason.RESPONSE_INVALID,
+            validation_code=f"{stage_kind}_response_empty",
+        )
+    try:
+        parsed: object = json.loads(content)
+    except json.JSONDecodeError:
+        raise VisionRuntimeError(
+            VisionRuntimeFailureReason.SCHEMA_INVALID,
+            validation_code=f"{stage_kind}_schema_invalid",
+        ) from None
+    if not isinstance(parsed, dict) or not all(isinstance(key, str) for key in parsed):
+        raise VisionRuntimeError(
+            VisionRuntimeFailureReason.SCHEMA_INVALID,
+            validation_code=f"{stage_kind}_schema_invalid",
+        )
+    return cast(dict[str, object], parsed)
+
+
+def _parse_scene_catalog(value: Mapping[str, object]) -> SceneCatalog:
+    scenes = value.get("scenes")
+    if (
+        set(value) != {"scenes"}
+        or not isinstance(scenes, list)
+        or not 3 <= len(scenes) <= 8
+    ):
+        raise _schema_error("scene_catalog_schema_invalid")
+    entries: list[SceneCatalogEntry] = []
+    for raw_scene in scenes:
+        if not isinstance(raw_scene, dict) or set(raw_scene) != _SCENE_ENTRY_KEYS:
+            raise _schema_error("scene_catalog_schema_invalid")
+        slug = raw_scene.get("slug")
+        display_name = raw_scene.get("display_name")
+        description = raw_scene.get("description")
+        selection_role = raw_scene.get("selection_role")
+        if (
+            not isinstance(slug, str)
+            or _SCENE_SLUG_PATTERN.fullmatch(slug) is None
+            or not isinstance(display_name, str)
+            or not display_name.strip()
+            or not isinstance(description, str)
+            or not description.strip()
+            or selection_role not in {"ordinary", "cinematic", "recurring_gameplay"}
+        ):
+            raise _schema_error("scene_catalog_schema_invalid")
+        entries.append(
+            SceneCatalogEntry(
+                slug=slug,
+                display_name=display_name,
+                description=description,
+                selection_role=cast(SceneSelectionRole, selection_role),
+            )
+        )
+    try:
+        return SceneCatalog(tuple(entries))
+    except ValueError:
+        raise _domain_error("scene_catalog_domain_invalid") from None
+
+
+def _parse_candidate_annotation(
+    value: Mapping[str, object],
+    request: CandidateAnnotationRequest,
+    catalog: SceneCatalog,
+) -> CandidateAnnotation:
+    if set(value) != _ANNOTATION_KEYS:
+        raise _schema_error("candidate_annotation_schema_invalid")
+    representative_frame_id = value.get("representative_frame_id")
+    scene_slug = value.get("scene_slug")
+    blog_image_type = value.get("blog_image_type")
+    explanation_value = value.get("explanation_value")
+    annotation_summary = value.get("annotation_summary")
+    frame_choice_reason = value.get("frame_choice_reason")
+    screen_text_kind = value.get("screen_text_kind")
+    context_relevance = value.get("context_relevance")
+    cue_ids = value.get("supporting_context_cue_ids")
+    spoiler_risk = value.get("spoiler_risk")
+    spoiler_evidence = value.get("spoiler_evidence")
+    if (
+        not isinstance(representative_frame_id, str)
+        or not isinstance(scene_slug, str)
+        or blog_image_type not in {"normal_gameplay", "event", "menu", "title", "other"}
+        or explanation_value not in {"none", "low", "medium", "high"}
+        or not isinstance(annotation_summary, str)
+        or not annotation_summary.strip()
+        or not isinstance(frame_choice_reason, str)
+        or not frame_choice_reason.strip()
+        or screen_text_kind not in {"none", "dialogue", "menu", "title", "hud", "other"}
+        or context_relevance not in {"unavailable", "none", "weak", "strong"}
+        or not isinstance(cue_ids, list)
+        or not all(isinstance(item, str) for item in cue_ids)
+        or len(cue_ids) != len(set(cue_ids))
+        or spoiler_risk not in {"none", "low", "medium", "high"}
+        or not isinstance(spoiler_evidence, str)
+    ):
+        raise _schema_error("candidate_annotation_schema_invalid")
+    frames = {item.identifier: item for item in request.frame_candidates}
+    available_cue_ids = {item.identifier for item in request.context_cues}
+    if (
+        representative_frame_id not in frames
+        or scene_slug not in catalog.slugs
+        or not set(cue_ids).issubset(available_cue_ids)
+        or context_relevance in {"unavailable", "none"}
+        and cue_ids
+        or context_relevance in {"weak", "strong"}
+        and not cue_ids
+        or spoiler_risk == "none"
+        and spoiler_evidence
+        or spoiler_risk != "none"
+        and not spoiler_evidence.strip()
+    ):
+        raise _domain_error("candidate_annotation_domain_invalid")
+    try:
+        return CandidateAnnotation(
+            candidate=frames[representative_frame_id],
+            summary=annotation_summary,
+            candidate_moment_id=request.moment.identifier,
+            scene_slug=scene_slug,
+            blog_image_type=cast(BlogImageType, blog_image_type),
+            explanation_value=cast(ExplanationValue, explanation_value),
+            frame_choice_reason=frame_choice_reason,
+            screen_text_kind=cast(ScreenTextKind, screen_text_kind),
+            context_relevance=cast(ContextCueRelevance, context_relevance),
+            supporting_context_cue_ids=tuple(cast(list[str], cue_ids)),
+            spoiler_risk=cast(SpoilerRisk, spoiler_risk),
+            spoiler_evidence=spoiler_evidence,
+        )
+    except ValueError:
+        raise _domain_error("candidate_annotation_domain_invalid") from None
+
+
+def _schema_error(code: str) -> VisionRuntimeError:
+    return VisionRuntimeError(
+        VisionRuntimeFailureReason.SCHEMA_INVALID,
+        validation_code=code,
+    )
+
+
+def _domain_error(code: str) -> VisionRuntimeError:
+    return VisionRuntimeError(
+        VisionRuntimeFailureReason.DOMAIN_INVALID,
+        validation_code=code,
+    )
+
+
+def _scene_catalog_semantic_input(
+    request: SceneCatalogRequest,
+    model: ResolvedModel,
+    num_ctx: int,
+) -> dict[str, object]:
+    return {
+        "representatives": [
+            {
+                "id": item.identifier,
+                "image_sha256": hashlib.sha256(item.image_bytes).hexdigest(),
+            }
+            for item in request.representatives
+        ],
+        "selection_intent": request.selection_intent,
+        "scene_hint": request.scene_hint,
+        "model": {**model.semantic_input(), "num_ctx": num_ctx},
+        "generation_options": {"temperature": 0, "stream": False, "think": False},
+        "prompt_version": SCENE_CATALOG_PROMPT_VERSION,
+        "schema_version": SCENE_CATALOG_SCHEMA_VERSION,
+        "stage_contract_version": SCENE_CATALOG_STAGE_CONTRACT_VERSION,
+        "retry_policy_version": RETRY_POLICY_VERSION,
+    }
+
+
+def _candidate_semantic_input(
+    request: CandidateAnnotationRequest,
+    catalog: SceneCatalog,
+    model: ResolvedModel,
+    num_ctx: int,
+) -> dict[str, object]:
+    return {
+        "candidate_moment_id": request.moment.identifier,
+        "frame_candidates": [
+            {
+                "id": item.identifier,
+                "image_sha256": hashlib.sha256(item.image_bytes).hexdigest(),
+            }
+            for item in request.frame_candidates
+        ],
+        "context_cues": [
+            {
+                "id": cue.identifier,
+                "text_sha256": hashlib.sha256(cue.text.encode()).hexdigest(),
+                "start": _fraction_value(cue.start),
+                "end": _fraction_value(cue.end),
+            }
+            for cue in request.context_cues
+        ],
+        "cue_selection_policy_version": request.cue_selection_policy_version,
+        "scene_catalog": [_scene_value(item) for item in catalog.scenes],
+        "video_set_progress": _fraction_value(request.video_set_progress),
+        "selection_intent": request.selection_intent,
+        "model": {**model.semantic_input(), "num_ctx": num_ctx},
+        "generation_options": {"temperature": 0, "stream": False, "think": False},
+        "prompt_version": CANDIDATE_ANNOTATION_PROMPT_VERSION,
+        "schema_version": CANDIDATE_ANNOTATION_SCHEMA_VERSION,
+        "stage_contract_version": CANDIDATE_ANNOTATION_STAGE_CONTRACT_VERSION,
+        "retry_policy_version": RETRY_POLICY_VERSION,
+    }
+
+
+def _fingerprint(value: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _scene_value(scene: SceneCatalogEntry) -> dict[str, str]:
+    return {
+        "slug": scene.slug,
+        "display_name": scene.display_name,
+        "description": scene.description,
+        "selection_role": scene.selection_role,
+    }
+
+
+def _fraction_value(value: Fraction) -> dict[str, int]:
+    return {"numerator": value.numerator, "denominator": value.denominator}
+
+
+def _diagnostics(
+    *,
+    response: Mapping[str, object],
+    stage_kind: StageKind,
+    request_fingerprint: str,
+    model: ResolvedModel,
+    attempt_count: int,
+    validation_code: str | None,
+    image_count: int,
+    context_cue_count: int,
+    duration_seconds: float,
+) -> VisionInferenceDiagnostics:
+    prompt_version = (
+        SCENE_CATALOG_PROMPT_VERSION
+        if stage_kind == "scene_catalog"
+        else CANDIDATE_ANNOTATION_PROMPT_VERSION
+    )
+    schema_version = (
+        SCENE_CATALOG_SCHEMA_VERSION
+        if stage_kind == "scene_catalog"
+        else CANDIDATE_ANNOTATION_SCHEMA_VERSION
+    )
+    stage_contract_version = (
+        SCENE_CATALOG_STAGE_CONTRACT_VERSION
+        if stage_kind == "scene_catalog"
+        else CANDIDATE_ANNOTATION_STAGE_CONTRACT_VERSION
+    )
+    done_reason = response.get("done_reason")
+    return VisionInferenceDiagnostics(
+        request_fingerprint=request_fingerprint,
+        model_name=model.configured_name,
+        model_identity=model.execution_identity.identifier,
+        runtime_identity=model.runtime_identity.identifier,
+        prompt_version=prompt_version,
+        schema_version=schema_version,
+        stage_contract_version=stage_contract_version,
+        retry_policy_version=RETRY_POLICY_VERSION,
+        cache_hit=False,
+        attempt_count=attempt_count,
+        validation_code=validation_code,
+        image_count=image_count,
+        context_cue_count=context_cue_count,
+        duration_seconds=duration_seconds,
+        prompt_eval_count=_non_negative_int(response.get("prompt_eval_count")),
+        eval_count=_non_negative_int(response.get("eval_count")),
+        done_reason=(
+            done_reason
+            if isinstance(done_reason, str)
+            and re.fullmatch(r"[0-9A-Za-z][0-9A-Za-z._:+/-]{0,255}", done_reason)
+            else None
+        ),
+    )
+
+
+def _non_negative_int(value: object) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return None
+
+
+def _retry_delay(error: HTTPError) -> float:
+    if error.code != 429 or error.headers is None:
+        return 1.0
+    value = error.headers.get("Retry-After")
+    try:
+        seconds = float(value) if value is not None else 1.0
+    except ValueError:
+        return 1.0
+    return min(max(seconds, 0.0), 30.0)
+
+
+def _require_model_role(
+    model: ResolvedModel,
+    expected_role: ModelRole,
+    num_ctx: int,
+) -> None:
+    if model.role is not expected_role or num_ctx < 1:
+        raise VisionRuntimeError(VisionRuntimeFailureReason.INVALID_REQUEST)

--- a/src/video_selection/vision/ollama_vision_runtime.py
+++ b/src/video_selection/vision/ollama_vision_runtime.py
@@ -572,20 +572,8 @@ def _diagnostics(
     context_cue_count: int,
     duration_seconds: float,
 ) -> VisionInferenceDiagnostics:
-    prompt_version = (
-        SCENE_CATALOG_PROMPT_VERSION
-        if stage_kind == "scene_catalog"
-        else CANDIDATE_ANNOTATION_PROMPT_VERSION
-    )
-    schema_version = (
-        SCENE_CATALOG_SCHEMA_VERSION
-        if stage_kind == "scene_catalog"
-        else CANDIDATE_ANNOTATION_SCHEMA_VERSION
-    )
-    stage_contract_version = (
-        SCENE_CATALOG_STAGE_CONTRACT_VERSION
-        if stage_kind == "scene_catalog"
-        else CANDIDATE_ANNOTATION_STAGE_CONTRACT_VERSION
+    prompt_version, schema_version, stage_contract_version = _contract_versions(
+        stage_kind
     )
     done_reason = response.get("done_reason")
     return VisionInferenceDiagnostics(
@@ -611,6 +599,20 @@ def _diagnostics(
             and re.fullmatch(r"[0-9A-Za-z][0-9A-Za-z._:+/-]{0,255}", done_reason)
             else None
         ),
+    )
+
+
+def _contract_versions(stage_kind: StageKind) -> tuple[str, str, str]:
+    if stage_kind == "scene_catalog":
+        return (
+            SCENE_CATALOG_PROMPT_VERSION,
+            SCENE_CATALOG_SCHEMA_VERSION,
+            SCENE_CATALOG_STAGE_CONTRACT_VERSION,
+        )
+    return (
+        CANDIDATE_ANNOTATION_PROMPT_VERSION,
+        CANDIDATE_ANNOTATION_SCHEMA_VERSION,
+        CANDIDATE_ANNOTATION_STAGE_CONTRACT_VERSION,
     )
 
 

--- a/src/video_selection/vision/ollama_vision_runtime.py
+++ b/src/video_selection/vision/ollama_vision_runtime.py
@@ -12,18 +12,26 @@ from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 from ..models.candidate_annotation import (
-    BlogImageType,
+    BLOG_IMAGE_TYPES,
+    CONTEXT_CUE_RELEVANCES,
+    EXPLANATION_VALUES,
+    SCREEN_TEXT_KINDS,
+    SPOILER_RISKS,
     CandidateAnnotation,
-    ContextCueRelevance,
-    ExplanationValue,
-    ScreenTextKind,
-    SpoilerRisk,
+    candidate_annotation_context_is_valid,
+    candidate_annotation_free_text_is_safe,
+    candidate_annotation_relationships_are_valid,
 )
 from ..models.candidate_annotation_request import CandidateAnnotationRequest
 from ..models.model_role import ModelRole
 from ..models.resolved_model import ResolvedModel
 from ..models.scene_catalog import SceneCatalog
-from ..models.scene_catalog_entry import SceneCatalogEntry, SceneSelectionRole
+from ..models.scene_catalog_entry import (
+    SCENE_SELECTION_ROLES,
+    SceneCatalogEntry,
+    SceneSelectionRole,
+    is_valid_scene_slug,
+)
 from ..models.scene_catalog_request import SceneCatalogRequest
 from ..models.vision_inference_diagnostics import VisionInferenceDiagnostics
 from ..models.vision_runtime_error import VisionRuntimeError
@@ -63,9 +71,13 @@ _ANNOTATION_KEYS = {
     "spoiler_risk",
     "spoiler_evidence",
 }
-_SCENE_SLUG_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
 _RETRYABLE_REASONS = {
     VisionRuntimeFailureReason.TRANSPORT_FAILURE,
+    VisionRuntimeFailureReason.RESPONSE_INVALID,
+    VisionRuntimeFailureReason.SCHEMA_INVALID,
+    VisionRuntimeFailureReason.DOMAIN_INVALID,
+}
+_PROMPT_REPAIR_REASONS = {
     VisionRuntimeFailureReason.RESPONSE_INVALID,
     VisionRuntimeFailureReason.SCHEMA_INVALID,
     VisionRuntimeFailureReason.DOMAIN_INVALID,
@@ -145,8 +157,9 @@ class OllamaVisionRuntime:
         """同じsemantic入力を最大2回実行しsafe diagnosticsを返す。"""
         started_at = time.monotonic()
         previous_validation_code: str | None = None
+        repair_code: str | None = None
         for attempt in (1, 2):
-            attempt_payload = _with_repair_code(payload, previous_validation_code)
+            attempt_payload = _with_repair_code(payload, repair_code)
             try:
                 response = self._request(attempt_payload)
                 value = parser(_decode_content(response, stage_kind))
@@ -158,6 +171,11 @@ class OllamaVisionRuntime:
                         attempt_count=attempt,
                     ) from None
                 previous_validation_code = error.validation_code
+                repair_code = (
+                    error.validation_code
+                    if error.reason in _PROMPT_REPAIR_REASONS
+                    else None
+                )
                 self._sleeper(error.retry_after_seconds)
                 continue
             diagnostics = _diagnostics(
@@ -285,7 +303,8 @@ def _candidate_payload(
         "入力された1〜3枚からブログ上の意味を最も表すframeを1枚選び、"
         "共有Scene Catalogを使ってCandidate Annotationを返してください。"
         "画像品質、confidence、final score、eligible、selected、逐語的画面文、"
-        "推論過程は出力しません。Context Cue本文をannotation summaryへ引用しません。\n"
+        "推論過程は出力しません。Context Cue本文をannotation summary、"
+        "frame choice reason、spoiler evidenceへ引用しません。\n"
         + json.dumps(semantic_request, ensure_ascii=False, sort_keys=True)
     )
     return {
@@ -324,7 +343,8 @@ def _with_repair_code(
 def _decode_content(
     response: Mapping[str, object], stage_kind: StageKind
 ) -> Mapping[str, object]:
-    if response.get("done") is not True:
+    done_reason = response.get("done_reason")
+    if response.get("done") is not True or done_reason not in (None, "stop"):
         raise VisionRuntimeError(
             VisionRuntimeFailureReason.RESPONSE_INVALID,
             validation_code=f"{stage_kind}_response_truncated",
@@ -369,12 +389,12 @@ def _parse_scene_catalog(value: Mapping[str, object]) -> SceneCatalog:
         selection_role = raw_scene.get("selection_role")
         if (
             not isinstance(slug, str)
-            or _SCENE_SLUG_PATTERN.fullmatch(slug) is None
+            or not is_valid_scene_slug(slug)
             or not isinstance(display_name, str)
             or not display_name.strip()
             or not isinstance(description, str)
             or not description.strip()
-            or selection_role not in {"ordinary", "cinematic", "recurring_gameplay"}
+            or selection_role not in SCENE_SELECTION_ROLES
         ):
             raise _schema_error("scene_catalog_schema_invalid")
         entries.append(
@@ -412,35 +432,44 @@ def _parse_candidate_annotation(
     if (
         not isinstance(representative_frame_id, str)
         or not isinstance(scene_slug, str)
-        or blog_image_type not in {"normal_gameplay", "event", "menu", "title", "other"}
-        or explanation_value not in {"none", "low", "medium", "high"}
+        or blog_image_type not in BLOG_IMAGE_TYPES
+        or explanation_value not in EXPLANATION_VALUES
         or not isinstance(annotation_summary, str)
         or not annotation_summary.strip()
         or not isinstance(frame_choice_reason, str)
         or not frame_choice_reason.strip()
-        or screen_text_kind not in {"none", "dialogue", "menu", "title", "hud", "other"}
-        or context_relevance not in {"unavailable", "none", "weak", "strong"}
+        or screen_text_kind not in SCREEN_TEXT_KINDS
+        or context_relevance not in CONTEXT_CUE_RELEVANCES
         or not isinstance(cue_ids, list)
         or not all(isinstance(item, str) for item in cue_ids)
         or len(cue_ids) != len(set(cue_ids))
-        or spoiler_risk not in {"none", "low", "medium", "high"}
+        or spoiler_risk not in SPOILER_RISKS
         or not isinstance(spoiler_evidence, str)
     ):
         raise _schema_error("candidate_annotation_schema_invalid")
     frames = {item.identifier: item for item in request.frame_candidates}
-    available_cue_ids = {item.identifier for item in request.context_cues}
+    typed_context_relevance = context_relevance
+    typed_cue_ids = tuple(cast(list[str], cue_ids))
+    typed_spoiler_risk = spoiler_risk
+    available_cue_ids = tuple(item.identifier for item in request.context_cues)
     if (
         representative_frame_id not in frames
         or scene_slug not in catalog.slugs
-        or not set(cue_ids).issubset(available_cue_ids)
-        or context_relevance in {"unavailable", "none"}
-        and cue_ids
-        or context_relevance in {"weak", "strong"}
-        and not cue_ids
-        or spoiler_risk == "none"
-        and spoiler_evidence
-        or spoiler_risk != "none"
-        and not spoiler_evidence.strip()
+        or not candidate_annotation_relationships_are_valid(
+            typed_context_relevance,
+            typed_cue_ids,
+            typed_spoiler_risk,
+            spoiler_evidence,
+        )
+        or not candidate_annotation_context_is_valid(
+            typed_context_relevance,
+            typed_cue_ids,
+            available_cue_ids,
+        )
+        or not candidate_annotation_free_text_is_safe(
+            (annotation_summary, frame_choice_reason, spoiler_evidence),
+            tuple(item.text for item in request.context_cues),
+        )
     ):
         raise _domain_error("candidate_annotation_domain_invalid")
     try:
@@ -449,13 +478,13 @@ def _parse_candidate_annotation(
             summary=annotation_summary,
             candidate_moment_id=request.moment.identifier,
             scene_slug=scene_slug,
-            blog_image_type=cast(BlogImageType, blog_image_type),
-            explanation_value=cast(ExplanationValue, explanation_value),
+            blog_image_type=blog_image_type,
+            explanation_value=explanation_value,
             frame_choice_reason=frame_choice_reason,
-            screen_text_kind=cast(ScreenTextKind, screen_text_kind),
-            context_relevance=cast(ContextCueRelevance, context_relevance),
-            supporting_context_cue_ids=tuple(cast(list[str], cue_ids)),
-            spoiler_risk=cast(SpoilerRisk, spoiler_risk),
+            screen_text_kind=screen_text_kind,
+            context_relevance=typed_context_relevance,
+            supporting_context_cue_ids=typed_cue_ids,
+            spoiler_risk=typed_spoiler_risk,
             spoiler_evidence=spoiler_evidence,
         )
     except ValueError:

--- a/src/video_selection/vision/ollama_vision_runtime.py
+++ b/src/video_selection/vision/ollama_vision_runtime.py
@@ -11,6 +11,7 @@ from typing import Literal, TypeVar, cast
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
+from ..model_runtime.ollama_model_store import OllamaModelStore
 from ..models.candidate_annotation import (
     BLOG_IMAGE_TYPES,
     CONTEXT_CUE_RELEVANCES,
@@ -23,7 +24,11 @@ from ..models.candidate_annotation import (
     candidate_annotation_relationships_are_valid,
 )
 from ..models.candidate_annotation_request import CandidateAnnotationRequest
+from ..models.model_artifact_invalid_error import ModelArtifactInvalidError
 from ..models.model_role import ModelRole
+from ..models.model_store_http_error import ModelStoreHttpError
+from ..models.model_store_kind import ModelStoreKind
+from ..models.model_store_unavailable_error import ModelStoreUnavailableError
 from ..models.resolved_model import ResolvedModel
 from ..models.scene_catalog import SceneCatalog
 from ..models.scene_catalog_entry import (
@@ -36,6 +41,7 @@ from ..models.scene_catalog_request import SceneCatalogRequest
 from ..models.vision_inference_diagnostics import VisionInferenceDiagnostics
 from ..models.vision_runtime_error import VisionRuntimeError
 from ..models.vision_runtime_failure_reason import VisionRuntimeFailureReason
+from ..utils.http_retry_delay import http_retry_delay
 from .vision_contract import (
     CANDIDATE_ANNOTATION_PROMPT_VERSION,
     CANDIDATE_ANNOTATION_SCHEMA,
@@ -53,6 +59,7 @@ JsonRequester = Callable[
     object,
 ]
 Sleeper = Callable[[float], None]
+ModelIdentityResolver = Callable[[ResolvedModel], str]
 InferenceValue = TypeVar("InferenceValue")
 InferenceParser = Callable[[Mapping[str, object]], InferenceValue]
 StageKind = Literal["scene_catalog", "candidate_annotation"]
@@ -94,6 +101,7 @@ class OllamaVisionRuntime:
         timeout_seconds: float,
         requester: JsonRequester | None = None,
         sleeper: Sleeper = time.sleep,
+        model_identity_resolver: ModelIdentityResolver | None = None,
     ) -> None:
         if not host.strip() or timeout_seconds <= 0:
             raise ValueError("Ollama VisionRuntimeの接続設定が不正です")
@@ -101,6 +109,14 @@ class OllamaVisionRuntime:
         self._timeout_seconds = timeout_seconds
         self._requester = requester or _request_json
         self._sleeper = sleeper
+        self._model_store = OllamaModelStore(
+            self._host,
+            timeout_seconds=self._timeout_seconds,
+            requester=self._requester,
+        )
+        self._model_identity_resolver = (
+            model_identity_resolver or self._resolve_current_model_identity
+        )
 
     def create_scene_catalog(
         self,
@@ -161,6 +177,7 @@ class OllamaVisionRuntime:
         for attempt in (1, 2):
             attempt_payload = _with_repair_code(payload, repair_code)
             try:
+                self._require_frozen_model_identity(model)
                 response = self._request(attempt_payload)
                 value = parser(_decode_content(response, stage_kind))
             except VisionRuntimeError as error:
@@ -171,11 +188,7 @@ class OllamaVisionRuntime:
                         attempt_count=attempt,
                     ) from None
                 previous_validation_code = error.validation_code
-                repair_code = (
-                    error.validation_code
-                    if error.reason in _PROMPT_REPAIR_REASONS
-                    else None
-                )
+                repair_code = _repair_validation_code(error)
                 self._sleeper(error.retry_after_seconds)
                 continue
             diagnostics = _diagnostics(
@@ -192,6 +205,49 @@ class OllamaVisionRuntime:
             return value, diagnostics
         raise AssertionError("VisionRuntime retry loop did not terminate")
 
+    def _require_frozen_model_identity(self, model: ResolvedModel) -> None:
+        """推論直前のmutable tagがfreeze済みdigestを指すことを要求する。"""
+        try:
+            current_identity = self._model_identity_resolver(model)
+        except VisionRuntimeError:
+            raise
+        except Exception:
+            raise VisionRuntimeError(
+                VisionRuntimeFailureReason.TRANSPORT_FAILURE,
+                validation_code="ollama_transport_failure",
+            ) from None
+        if current_identity != model.execution_identity.identifier:
+            raise VisionRuntimeError(
+                VisionRuntimeFailureReason.MODEL_UNAVAILABLE,
+                validation_code="ollama_model_identity_changed",
+            )
+
+    def _resolve_current_model_identity(self, model: ResolvedModel) -> str:
+        """Model Storeの確認portをVision failureへ変換する。"""
+        try:
+            identity = self._model_store.resolve_current_identity(model.configured_name)
+        except ModelArtifactInvalidError:
+            raise VisionRuntimeError(
+                VisionRuntimeFailureReason.RESPONSE_INVALID,
+                validation_code="ollama_model_identity_response_invalid",
+            ) from None
+        except ModelStoreHttpError as error:
+            raise _http_failure(
+                error.status_code,
+                error.retry_after_seconds,
+            ) from None
+        except ModelStoreUnavailableError:
+            raise VisionRuntimeError(
+                VisionRuntimeFailureReason.TRANSPORT_FAILURE,
+                validation_code="ollama_transport_failure",
+            ) from None
+        if identity is None:
+            raise VisionRuntimeError(
+                VisionRuntimeFailureReason.MODEL_UNAVAILABLE,
+                validation_code="ollama_model_identity_unavailable",
+            )
+        return identity.identifier
+
     def _request(self, payload: Mapping[str, object]) -> Mapping[str, object]:
         """transport detailをstable failureへ変換する。"""
         try:
@@ -202,18 +258,13 @@ class OllamaVisionRuntime:
                 self._timeout_seconds,
             )
         except HTTPError as error:
-            if error.code in {408, 429} or error.code >= 500:
-                raise VisionRuntimeError(
-                    VisionRuntimeFailureReason.TRANSPORT_FAILURE,
-                    validation_code="ollama_transport_failure",
-                    retry_after_seconds=_retry_delay(error),
-                ) from None
-            reason = (
-                VisionRuntimeFailureReason.MODEL_UNAVAILABLE
-                if error.code == 404
-                else VisionRuntimeFailureReason.INVALID_REQUEST
+            retry_after = (
+                error.headers.get("Retry-After") if error.headers is not None else None
             )
-            raise VisionRuntimeError(reason) from None
+            raise _http_failure(
+                error.code,
+                http_retry_delay(error.code, retry_after),
+            ) from None
         except Exception:
             raise VisionRuntimeError(
                 VisionRuntimeFailureReason.TRANSPORT_FAILURE,
@@ -651,15 +702,32 @@ def _non_negative_int(value: object) -> int | None:
     return None
 
 
-def _retry_delay(error: HTTPError) -> float:
-    if error.code != 429 or error.headers is None:
-        return 1.0
-    value = error.headers.get("Retry-After")
-    try:
-        seconds = float(value) if value is not None else 1.0
-    except ValueError:
-        return 1.0
-    return min(max(seconds, 0.0), 30.0)
+def _http_failure(
+    status_code: int,
+    retry_after_seconds: float,
+) -> VisionRuntimeError:
+    if status_code in {408, 429} or status_code >= 500:
+        return VisionRuntimeError(
+            VisionRuntimeFailureReason.TRANSPORT_FAILURE,
+            validation_code="ollama_transport_failure",
+            retry_after_seconds=retry_after_seconds,
+        )
+    reason = (
+        VisionRuntimeFailureReason.MODEL_UNAVAILABLE
+        if status_code == 404
+        else VisionRuntimeFailureReason.INVALID_REQUEST
+    )
+    return VisionRuntimeError(reason)
+
+
+def _repair_validation_code(error: VisionRuntimeError) -> str | None:
+    """model出力を検証できたfailureだけをprompt修復指示へ変換する。"""
+    if (
+        error.reason not in _PROMPT_REPAIR_REASONS
+        or error.validation_code == "ollama_model_identity_response_invalid"
+    ):
+        return None
+    return error.validation_code
 
 
 def _require_model_role(
@@ -667,5 +735,9 @@ def _require_model_role(
     expected_role: ModelRole,
     num_ctx: int,
 ) -> None:
-    if model.role is not expected_role or num_ctx < 1:
+    if (
+        model.role is not expected_role
+        or model.execution_identity.store_kind is not ModelStoreKind.OLLAMA
+        or num_ctx < 1
+    ):
         raise VisionRuntimeError(VisionRuntimeFailureReason.INVALID_REQUEST)

--- a/src/video_selection/vision/ollama_vision_runtime.py
+++ b/src/video_selection/vision/ollama_vision_runtime.py
@@ -24,6 +24,7 @@ from ..models.candidate_annotation import (
     candidate_annotation_relationships_are_valid,
 )
 from ..models.candidate_annotation_request import CandidateAnnotationRequest
+from ..models.model_artifact import ModelArtifact
 from ..models.model_artifact_invalid_error import ModelArtifactInvalidError
 from ..models.model_role import ModelRole
 from ..models.model_store_http_error import ModelStoreHttpError
@@ -59,7 +60,7 @@ JsonRequester = Callable[
     object,
 ]
 Sleeper = Callable[[float], None]
-ModelIdentityResolver = Callable[[ResolvedModel], str]
+ModelStateResolver = Callable[[ResolvedModel], ModelArtifact]
 InferenceValue = TypeVar("InferenceValue")
 InferenceParser = Callable[[Mapping[str, object]], InferenceValue]
 StageKind = Literal["scene_catalog", "candidate_annotation"]
@@ -101,7 +102,7 @@ class OllamaVisionRuntime:
         timeout_seconds: float,
         requester: JsonRequester | None = None,
         sleeper: Sleeper = time.sleep,
-        model_identity_resolver: ModelIdentityResolver | None = None,
+        model_state_resolver: ModelStateResolver | None = None,
     ) -> None:
         if not host.strip() or timeout_seconds <= 0:
             raise ValueError("Ollama VisionRuntimeの接続設定が不正です")
@@ -114,8 +115,8 @@ class OllamaVisionRuntime:
             timeout_seconds=self._timeout_seconds,
             requester=self._requester,
         )
-        self._model_identity_resolver = (
-            model_identity_resolver or self._resolve_current_model_identity
+        self._model_state_resolver = (
+            model_state_resolver or self._resolve_current_model_state
         )
 
     def create_scene_catalog(
@@ -177,8 +178,9 @@ class OllamaVisionRuntime:
         for attempt in (1, 2):
             attempt_payload = _with_repair_code(payload, repair_code)
             try:
-                self._require_frozen_model_identity(model)
+                self._require_frozen_model_state(model)
                 response = self._request(attempt_payload)
+                self._require_frozen_model_state(model)
                 value = parser(_decode_content(response, stage_kind))
             except VisionRuntimeError as error:
                 if attempt == 2 or error.reason not in _RETRYABLE_REASONS:
@@ -205,10 +207,10 @@ class OllamaVisionRuntime:
             return value, diagnostics
         raise AssertionError("VisionRuntime retry loop did not terminate")
 
-    def _require_frozen_model_identity(self, model: ResolvedModel) -> None:
-        """推論直前のmutable tagがfreeze済みdigestを指すことを要求する。"""
+    def _require_frozen_model_state(self, model: ResolvedModel) -> None:
+        """推論前後のmodel artifactがfreeze済みstateと一致することを要求する。"""
         try:
-            current_identity = self._model_identity_resolver(model)
+            current = self._model_state_resolver(model)
         except VisionRuntimeError:
             raise
         except Exception:
@@ -216,16 +218,21 @@ class OllamaVisionRuntime:
                 VisionRuntimeFailureReason.TRANSPORT_FAILURE,
                 validation_code="ollama_transport_failure",
             ) from None
-        if current_identity != model.execution_identity.identifier:
+        if current.identity != model.execution_identity:
             raise VisionRuntimeError(
                 VisionRuntimeFailureReason.MODEL_UNAVAILABLE,
                 validation_code="ollama_model_identity_changed",
             )
+        if current.runtime_identity != model.runtime_identity:
+            raise VisionRuntimeError(
+                VisionRuntimeFailureReason.MODEL_UNAVAILABLE,
+                validation_code="ollama_runtime_identity_changed",
+            )
 
-    def _resolve_current_model_identity(self, model: ResolvedModel) -> str:
-        """Model Storeの確認portをVision failureへ変換する。"""
+    def _resolve_current_model_state(self, model: ResolvedModel) -> ModelArtifact:
+        """Model Storeのartifact確認portをVision failureへ変換する。"""
         try:
-            identity = self._model_store.resolve_current_identity(model.configured_name)
+            artifact = self._model_store.resolve_current_artifact(model.configured_name)
         except ModelArtifactInvalidError:
             raise VisionRuntimeError(
                 VisionRuntimeFailureReason.RESPONSE_INVALID,
@@ -241,12 +248,12 @@ class OllamaVisionRuntime:
                 VisionRuntimeFailureReason.TRANSPORT_FAILURE,
                 validation_code="ollama_transport_failure",
             ) from None
-        if identity is None:
+        if artifact is None:
             raise VisionRuntimeError(
                 VisionRuntimeFailureReason.MODEL_UNAVAILABLE,
                 validation_code="ollama_model_identity_unavailable",
             )
-        return identity.identifier
+        return artifact
 
     def _request(self, payload: Mapping[str, object]) -> Mapping[str, object]:
         """transport detailをstable failureへ変換する。"""

--- a/src/video_selection/vision/vision_contract.py
+++ b/src/video_selection/vision/vision_contract.py
@@ -1,5 +1,14 @@
 """VisionRuntime v1のschemaとversion定数。"""
 
+from ..models.candidate_annotation import (
+    BLOG_IMAGE_TYPES,
+    CONTEXT_CUE_RELEVANCES,
+    EXPLANATION_VALUES,
+    SCREEN_TEXT_KINDS,
+    SPOILER_RISKS,
+)
+from ..models.scene_catalog_entry import SCENE_SELECTION_ROLES
+
 SCENE_CATALOG_PROMPT_VERSION = "scene-catalog-prompt-v1"
 SCENE_CATALOG_SCHEMA_VERSION = "scene-catalog-schema-v1"
 SCENE_CATALOG_STAGE_CONTRACT_VERSION = "scene-catalog-stage-v1"
@@ -28,7 +37,7 @@ SCENE_CATALOG_SCHEMA: dict[str, object] = {
                     "description": {"type": "string", "minLength": 1},
                     "selection_role": {
                         "type": "string",
-                        "enum": ["ordinary", "cinematic", "recurring_gameplay"],
+                        "enum": list(SCENE_SELECTION_ROLES),
                     },
                 },
                 "required": [
@@ -51,21 +60,21 @@ CANDIDATE_ANNOTATION_SCHEMA: dict[str, object] = {
         "scene_slug": {"type": "string"},
         "blog_image_type": {
             "type": "string",
-            "enum": ["normal_gameplay", "event", "menu", "title", "other"],
+            "enum": list(BLOG_IMAGE_TYPES),
         },
         "explanation_value": {
             "type": "string",
-            "enum": ["none", "low", "medium", "high"],
+            "enum": list(EXPLANATION_VALUES),
         },
         "annotation_summary": {"type": "string", "minLength": 1},
         "frame_choice_reason": {"type": "string", "minLength": 1},
         "screen_text_kind": {
             "type": "string",
-            "enum": ["none", "dialogue", "menu", "title", "hud", "other"],
+            "enum": list(SCREEN_TEXT_KINDS),
         },
         "context_relevance": {
             "type": "string",
-            "enum": ["unavailable", "none", "weak", "strong"],
+            "enum": list(CONTEXT_CUE_RELEVANCES),
         },
         "supporting_context_cue_ids": {
             "type": "array",
@@ -74,7 +83,7 @@ CANDIDATE_ANNOTATION_SCHEMA: dict[str, object] = {
         },
         "spoiler_risk": {
             "type": "string",
-            "enum": ["none", "low", "medium", "high"],
+            "enum": list(SPOILER_RISKS),
         },
         "spoiler_evidence": {"type": "string"},
     },

--- a/src/video_selection/vision/vision_contract.py
+++ b/src/video_selection/vision/vision_contract.py
@@ -1,0 +1,94 @@
+"""VisionRuntime v1のschemaとversion定数。"""
+
+SCENE_CATALOG_PROMPT_VERSION = "scene-catalog-prompt-v1"
+SCENE_CATALOG_SCHEMA_VERSION = "scene-catalog-schema-v1"
+SCENE_CATALOG_STAGE_CONTRACT_VERSION = "scene-catalog-stage-v1"
+CANDIDATE_ANNOTATION_PROMPT_VERSION = "candidate-annotation-prompt-v1"
+CANDIDATE_ANNOTATION_SCHEMA_VERSION = "candidate-annotation-schema-v1"
+CANDIDATE_ANNOTATION_STAGE_CONTRACT_VERSION = "candidate-annotation-stage-v1"
+RETRY_POLICY_VERSION = "ollama-retry-v1"
+
+SCENE_CATALOG_SCHEMA: dict[str, object] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "scenes": {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 8,
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "slug": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+                    },
+                    "display_name": {"type": "string", "minLength": 1},
+                    "description": {"type": "string", "minLength": 1},
+                    "selection_role": {
+                        "type": "string",
+                        "enum": ["ordinary", "cinematic", "recurring_gameplay"],
+                    },
+                },
+                "required": [
+                    "slug",
+                    "display_name",
+                    "description",
+                    "selection_role",
+                ],
+            },
+        }
+    },
+    "required": ["scenes"],
+}
+
+CANDIDATE_ANNOTATION_SCHEMA: dict[str, object] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "representative_frame_id": {"type": "string"},
+        "scene_slug": {"type": "string"},
+        "blog_image_type": {
+            "type": "string",
+            "enum": ["normal_gameplay", "event", "menu", "title", "other"],
+        },
+        "explanation_value": {
+            "type": "string",
+            "enum": ["none", "low", "medium", "high"],
+        },
+        "annotation_summary": {"type": "string", "minLength": 1},
+        "frame_choice_reason": {"type": "string", "minLength": 1},
+        "screen_text_kind": {
+            "type": "string",
+            "enum": ["none", "dialogue", "menu", "title", "hud", "other"],
+        },
+        "context_relevance": {
+            "type": "string",
+            "enum": ["unavailable", "none", "weak", "strong"],
+        },
+        "supporting_context_cue_ids": {
+            "type": "array",
+            "items": {"type": "string"},
+            "uniqueItems": True,
+        },
+        "spoiler_risk": {
+            "type": "string",
+            "enum": ["none", "low", "medium", "high"],
+        },
+        "spoiler_evidence": {"type": "string"},
+    },
+    "required": [
+        "representative_frame_id",
+        "scene_slug",
+        "blog_image_type",
+        "explanation_value",
+        "annotation_summary",
+        "frame_choice_reason",
+        "screen_text_kind",
+        "context_relevance",
+        "supporting_context_cue_ids",
+        "spoiler_risk",
+        "spoiler_evidence",
+    ],
+}

--- a/tests/video_selection/fakes/fake_structured_vision_runtime.py
+++ b/tests/video_selection/fakes/fake_structured_vision_runtime.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+from threading import Event
 
 from src.video_selection.models.candidate_annotation import CandidateAnnotation
 from src.video_selection.models.candidate_annotation_request import (
@@ -22,6 +23,8 @@ class FakeStructuredVisionRuntime:
         *,
         failure_moment_id: str | None = None,
         reject_all_calls: bool = False,
+        scene_catalog_call_started: Event | None = None,
+        release_scene_catalog_call: Event | None = None,
     ) -> None:
         self._catalog = catalog
         self._annotations = {
@@ -29,6 +32,8 @@ class FakeStructuredVisionRuntime:
         }
         self._failure_moment_id = failure_moment_id
         self._reject_all_calls = reject_all_calls
+        self._scene_catalog_call_started = scene_catalog_call_started
+        self._release_scene_catalog_call = release_scene_catalog_call
         self.scene_catalog_calls: list[SceneCatalogRequest] = []
         self.candidate_annotation_calls: list[CandidateAnnotationRequest] = []
 
@@ -43,7 +48,15 @@ class FakeStructuredVisionRuntime:
         del num_ctx
         if self._reject_all_calls:
             raise AssertionError("Scene Catalogが再生成されました")
+        is_first_call = not self.scene_catalog_calls
         self.scene_catalog_calls.append(request)
+        if is_first_call and self._scene_catalog_call_started is not None:
+            self._scene_catalog_call_started.set()
+            if (
+                self._release_scene_catalog_call is not None
+                and not self._release_scene_catalog_call.wait(timeout=5)
+            ):
+                raise TimeoutError("Scene Catalog callが解放されませんでした")
         return self._catalog, _diagnostics(model, len(request.representatives), 0)
 
     def annotate_candidate(

--- a/tests/video_selection/fakes/fake_structured_vision_runtime.py
+++ b/tests/video_selection/fakes/fake_structured_vision_runtime.py
@@ -1,0 +1,98 @@
+from dataclasses import replace
+
+from src.video_selection.models.candidate_annotation import CandidateAnnotation
+from src.video_selection.models.candidate_annotation_request import (
+    CandidateAnnotationRequest,
+)
+from src.video_selection.models.resolved_model import ResolvedModel
+from src.video_selection.models.scene_catalog import SceneCatalog
+from src.video_selection.models.scene_catalog_request import SceneCatalogRequest
+from src.video_selection.models.vision_inference_diagnostics import (
+    VisionInferenceDiagnostics,
+)
+
+
+class FakeStructuredVisionRuntime:
+    """固定CatalogとMoment別Annotationを返す記録用fake。"""
+
+    def __init__(
+        self,
+        catalog: SceneCatalog,
+        annotations: tuple[CandidateAnnotation, ...],
+        *,
+        failure_moment_id: str | None = None,
+        reject_all_calls: bool = False,
+    ) -> None:
+        self._catalog = catalog
+        self._annotations = {
+            annotation.candidate_moment_id: annotation for annotation in annotations
+        }
+        self._failure_moment_id = failure_moment_id
+        self._reject_all_calls = reject_all_calls
+        self.scene_catalog_calls: list[SceneCatalogRequest] = []
+        self.candidate_annotation_calls: list[CandidateAnnotationRequest] = []
+
+    def create_scene_catalog(
+        self,
+        request: SceneCatalogRequest,
+        model: ResolvedModel,
+        *,
+        num_ctx: int,
+    ) -> tuple[SceneCatalog, VisionInferenceDiagnostics]:
+        """固定Catalogと診断を返す。"""
+        del num_ctx
+        if self._reject_all_calls:
+            raise AssertionError("Scene Catalogが再生成されました")
+        self.scene_catalog_calls.append(request)
+        return self._catalog, _diagnostics(model, len(request.representatives), 0)
+
+    def annotate_candidate(
+        self,
+        request: CandidateAnnotationRequest,
+        catalog: SceneCatalog,
+        model: ResolvedModel,
+        *,
+        num_ctx: int,
+    ) -> tuple[CandidateAnnotation, VisionInferenceDiagnostics]:
+        """Moment IDに対応する固定Annotationと診断を返す。"""
+        del catalog, num_ctx
+        if self._reject_all_calls:
+            raise AssertionError("Candidate Annotationが再生成されました")
+        self.candidate_annotation_calls.append(request)
+        if request.moment.identifier == self._failure_moment_id:
+            raise RuntimeError("fake raw response: chain of thought")
+        annotation = self._annotations[request.moment.identifier]
+        return annotation, replace(
+            _diagnostics(
+                model,
+                len(request.frame_candidates),
+                len(request.context_cues),
+            ),
+            request_fingerprint=request.moment.identifier[4:],
+        )
+
+
+def _diagnostics(
+    model: ResolvedModel,
+    image_count: int,
+    context_cue_count: int,
+) -> VisionInferenceDiagnostics:
+    return VisionInferenceDiagnostics(
+        request_fingerprint="a" * 64,
+        model_name=model.configured_name,
+        model_identity=model.execution_identity.identifier,
+        runtime_identity=model.runtime_identity.identifier,
+        prompt_version="fake-prompt-v1",
+        schema_version="fake-schema-v1",
+        stage_contract_version="fake-stage-v1",
+        retry_policy_version="fake-retry-v1",
+        cache_hit=False,
+        attempt_count=1,
+        validation_code=None,
+        image_count=image_count,
+        context_cue_count=context_cue_count,
+        duration_seconds=0.25,
+        prompt_eval_count=100,
+        eval_count=20,
+        done_reason="stop",
+    )

--- a/tests/video_selection/models/test_candidate_annotation.py
+++ b/tests/video_selection/models/test_candidate_annotation.py
@@ -1,0 +1,40 @@
+from src.video_selection.models.candidate_annotation import CandidateAnnotation
+from src.video_selection.models.frame_candidate import FrameCandidate
+
+
+def test_major_spoiler_requires_safe_evidence_summary() -> None:
+    """high Spoiler Riskに引用ではないevidence summaryが要求されること。
+
+    Arrange:
+        - high riskと短い意味証拠を持つCandidate Annotationが用意される
+    Act:
+        - Candidate Annotationが構築される
+    Assert:
+        - riskとevidenceが分離して保持されること
+    """
+    # Arrange
+    candidate = FrameCandidate(identifier="frame-1", image_bytes=b"image")
+
+    # Act
+    annotation = CandidateAnnotation(
+        candidate=candidate,
+        summary="終盤の対決場面",
+        candidate_moment_id="mom_" + "a" * 64,
+        scene_slug="climax",
+        blog_image_type="event",
+        explanation_value="high",
+        frame_choice_reason="対決する人物が明確に写る",
+        screen_text_kind="dialogue",
+        context_relevance="strong",
+        supporting_context_cue_ids=("cue-1",),
+        spoiler_risk="high",
+        spoiler_evidence="主要人物の正体が明示される",
+    )
+
+    # Assert
+    assert annotation.candidate is candidate
+    assert annotation.spoiler_risk == "high"
+    assert annotation.spoiler_evidence == "主要人物の正体が明示される"
+    assert not hasattr(annotation, "quality_score")
+    assert not hasattr(annotation, "final_score")
+    assert not hasattr(annotation, "selected")

--- a/tests/video_selection/models/test_scene_catalog.py
+++ b/tests/video_selection/models/test_scene_catalog.py
@@ -1,0 +1,63 @@
+import pytest
+
+from src.video_selection.models.scene_catalog import SceneCatalog
+from src.video_selection.models.scene_catalog_entry import SceneCatalogEntry
+
+
+def test_catalog_requires_unique_scenes_and_ordinary_other() -> None:
+    """共有Scene Catalogが3〜8件と通常扱いのotherを要求すること。
+
+    Arrange:
+        - 重複しない3件のsceneとordinary roleのotherが用意される
+    Act:
+        - Scene Catalogが構築される
+    Assert:
+        - scene順とslug lookupが保持されること
+    """
+    # Arrange
+    scenes = (
+        SceneCatalogEntry("exploration", "探索", "フィールド探索", "ordinary"),
+        SceneCatalogEntry("battle", "戦闘", "通常戦闘", "recurring_gameplay"),
+        SceneCatalogEntry("other", "その他", "分類不能", "ordinary"),
+    )
+
+    # Act
+    catalog = SceneCatalog(scenes)
+
+    # Assert
+    assert catalog.slugs == ("exploration", "battle", "other")
+    assert catalog.for_slug("battle").display_name == "戦闘"
+
+
+@pytest.mark.parametrize(
+    "scenes",
+    [
+        (
+            SceneCatalogEntry("battle", "戦闘", "通常戦闘", "ordinary"),
+            SceneCatalogEntry("battle", "戦闘2", "別の戦闘", "cinematic"),
+            SceneCatalogEntry("other", "その他", "分類不能", "ordinary"),
+        ),
+        (
+            SceneCatalogEntry("exploration", "探索", "フィールド探索", "ordinary"),
+            SceneCatalogEntry("battle", "戦闘", "通常戦闘", "ordinary"),
+            SceneCatalogEntry("other", "その他", "分類不能", "cinematic"),
+        ),
+    ],
+)
+def test_invalid_catalog_domain_is_rejected(
+    scenes: tuple[SceneCatalogEntry, ...],
+) -> None:
+    """slug重複またはordinaryでないotherが拒否されること。
+
+    Arrange:
+        - domain contractに違反するscene列が用意される
+    Act:
+        - Scene Catalogの構築が試行される
+    Assert:
+        - domain validation errorが返されること
+    """
+    # Arrange
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="Scene Catalog"):
+        SceneCatalog(scenes)

--- a/tests/video_selection/models/test_vision_inference_diagnostics.py
+++ b/tests/video_selection/models/test_vision_inference_diagnostics.py
@@ -1,0 +1,103 @@
+import pytest
+
+from src.video_selection.models.vision_inference_diagnostics import (
+    VisionInferenceDiagnostics,
+)
+
+
+def test_canonical_ollama_diagnostics_is_accepted() -> None:
+    """canonicalなOllama identityを持つ診断が受理されること。
+
+    Arrange:
+        - 完全model digestと安全なruntime versionが用意される
+    Act:
+        - Vision推論診断が構築される
+    Assert:
+        - identityが変更されず保持されること
+    """
+    # Arrange
+    model_identity = "ollama:sha256:" + "a" * 64
+    runtime_identity = "ollama:0.31.2"
+
+    # Act
+    diagnostics = _diagnostics(model_identity, runtime_identity)
+
+    # Assert
+    assert diagnostics.model_identity == model_identity
+    assert diagnostics.runtime_identity == runtime_identity
+
+
+def test_canonical_hugging_face_diagnostics_is_accepted() -> None:
+    """canonicalなHugging Face identityを持つ診断が受理されること。
+
+    Arrange:
+        - 完全commit SHAと安全なruntime versionが用意される
+    Act:
+        - Vision推論診断が構築される
+    Assert:
+        - identityが変更されず保持されること
+    """
+    # Arrange
+    model_identity = "hf:" + "b" * 40
+    runtime_identity = "huggingface-hub:0.30.0"
+
+    # Act
+    diagnostics = _diagnostics(model_identity, runtime_identity)
+
+    # Assert
+    assert diagnostics.model_identity == model_identity
+    assert diagnostics.runtime_identity == runtime_identity
+
+
+@pytest.mark.parametrize(
+    ("model_identity", "runtime_identity"),
+    (
+        ("/private/model", "ollama:0.31.2"),
+        ("ollama:sha256:" + "a" * 64, "/private/ollama"),
+        ("hf:" + "b" * 40, "ollama:0.31.2"),
+    ),
+)
+def test_noncanonical_or_mismatched_diagnostic_identity_is_rejected(
+    model_identity: str,
+    runtime_identity: str,
+) -> None:
+    """非canonicalまたはstore不一致のdiagnostic identityが拒否されること。
+
+    Arrange:
+        - pathまたは異なるstoreを含むmodel/runtime identityが用意される
+    Act:
+        - Vision推論診断が構築される
+    Assert:
+        - privacy-safeなcanonical identityではないため拒否されること
+    """
+    # Arrange
+
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="Vision inference diagnostics"):
+        _diagnostics(model_identity, runtime_identity)
+
+
+def _diagnostics(
+    model_identity: str,
+    runtime_identity: str,
+) -> VisionInferenceDiagnostics:
+    return VisionInferenceDiagnostics(
+        request_fingerprint="c" * 64,
+        model_name="qwen3-vl:8b-instruct",
+        model_identity=model_identity,
+        runtime_identity=runtime_identity,
+        prompt_version="prompt-v1",
+        schema_version="schema-v1",
+        stage_contract_version="stage-v1",
+        retry_policy_version="retry-v1",
+        cache_hit=False,
+        attempt_count=1,
+        validation_code=None,
+        image_count=1,
+        context_cue_count=0,
+        duration_seconds=0.1,
+        prompt_eval_count=10,
+        eval_count=5,
+        done_reason="stop",
+    )

--- a/tests/video_selection/services/test_video_set_vision_processor.py
+++ b/tests/video_selection/services/test_video_set_vision_processor.py
@@ -1,3 +1,4 @@
+import threading
 from fractions import Fraction
 from pathlib import Path
 
@@ -105,6 +106,85 @@ def test_matching_fingerprints_reuse_catalog_and_each_annotation(
     assert '"reasoning"' not in cache_text
 
 
+def test_same_catalog_fingerprint_runs_inference_once_under_lock(
+    tmp_path: Path,
+) -> None:
+    """同じCatalog fingerprintの並行処理でmodel推論が一度だけ実行されること。
+
+    Arrange:
+        - 最初のCatalog推論を一時停止するfake runtimeが用意される
+        - 同じVideo Setとsemantic入力を処理する2つのthreadが用意される
+    Act:
+        - 最初の推論中に2つ目の処理が開始される
+    Assert:
+        - 2つ目が同じ推論を開始せず最初のCompleted Stageを再利用すること
+    """
+    # Arrange
+    video_set, configuration = _video_set_and_configuration(tmp_path)
+    requests = _requests()
+    request = requests[0]
+    annotation = _annotations(requests)[0]
+    first_call_started = threading.Event()
+    release_first_call = threading.Event()
+    second_process_started = threading.Event()
+    runtime = FakeStructuredVisionRuntime(
+        _catalog(),
+        (annotation,),
+        scene_catalog_call_started=first_call_started,
+        release_scene_catalog_call=release_first_call,
+    )
+    models = FakeModelRuntime("vision-model").resolve_models(configuration)
+    errors: list[BaseException] = []
+    results: list[object] = []
+
+    def process(second: bool = False) -> None:
+        try:
+            if second:
+                second_process_started.set()
+            results.append(
+                VideoSetVisionProcessor(runtime, RecordingRunObserver()).process(
+                    video_set=video_set,
+                    representatives=request.frame_candidates,
+                    representative_source_fingerprints=(StageFingerprint("c" * 64),),
+                    annotation_requests=(request,),
+                    configuration=configuration,
+                    resolved_models=models,
+                )
+            )
+        except BaseException as error:
+            errors.append(error)
+
+    first_thread = threading.Thread(target=process, name="first-vision-processor")
+    second_thread = threading.Thread(
+        target=process,
+        args=(True,),
+        name="second-vision-processor",
+    )
+
+    # Act
+    first_thread.start()
+    assert first_call_started.wait(timeout=5)
+    second_thread.start()
+    assert second_process_started.wait(timeout=5)
+    try:
+        second_thread.join(timeout=0.2)
+        second_finished_early = not second_thread.is_alive()
+        inference_count_while_locked = len(runtime.scene_catalog_calls)
+    finally:
+        release_first_call.set()
+        first_thread.join(timeout=5)
+        second_thread.join(timeout=5)
+
+    # Assert
+    assert second_finished_early is False
+    assert inference_count_while_locked == 1
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert errors == []
+    assert len(results) == 2
+    assert len(runtime.scene_catalog_calls) == 1
+
+
 def test_completed_annotations_survive_a_later_annotation_failure(
     tmp_path: Path,
 ) -> None:
@@ -162,6 +242,57 @@ def test_completed_annotations_survive_a_later_annotation_failure(
     ] == [requests[1].moment.identifier]
     assert result.annotations == annotations
     assert [item.cache_hit for item in result.annotation_diagnostics] == [True, False]
+
+
+def test_verbatim_context_cue_is_rejected_before_annotation_cache(
+    tmp_path: Path,
+) -> None:
+    """Context Cue本文を含むAnnotationがcache保存前に拒否されること。
+
+    Arrange:
+        - Context Cue本文をsummaryへ逐語再出力するfake runtimeが用意される
+    Act:
+        - 一つのCandidate Annotationが処理される
+    Assert:
+        - runtime境界で失敗しraw Context Cue本文がcacheへ保存されないこと
+    """
+    # Arrange
+    video_set, configuration = _video_set_and_configuration(tmp_path)
+    request = _requests()[1]
+    raw_context_text = request.context_cues[0].text
+    unsafe_annotation = CandidateAnnotation(
+        candidate=request.frame_candidates[0],
+        summary=raw_context_text,
+        candidate_moment_id=request.moment.identifier,
+        scene_slug="climax",
+        blog_image_type="event",
+        explanation_value="high",
+        frame_choice_reason="対決する人物が明確に写る",
+        screen_text_kind="dialogue",
+        context_relevance="strong",
+        supporting_context_cue_ids=("cue-b",),
+        spoiler_risk="high",
+        spoiler_evidence="主要人物の正体が画面で明示される",
+    )
+    runtime = FakeStructuredVisionRuntime(_catalog(), (unsafe_annotation,))
+    models = FakeModelRuntime("vision-model").resolve_models(configuration)
+
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="Candidate Annotation"):
+        VideoSetVisionProcessor(runtime, RecordingRunObserver()).process(
+            video_set=video_set,
+            representatives=request.frame_candidates,
+            representative_source_fingerprints=(StageFingerprint("c" * 64),),
+            annotation_requests=(request,),
+            configuration=configuration,
+            resolved_models=models,
+        )
+    cache_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in configuration.processing_cache_folder.rglob("*.json")
+    )
+    assert raw_context_text not in cache_text
 
 
 def _video_set_and_configuration(

--- a/tests/video_selection/services/test_video_set_vision_processor.py
+++ b/tests/video_selection/services/test_video_set_vision_processor.py
@@ -295,6 +295,53 @@ def test_verbatim_context_cue_is_rejected_before_annotation_cache(
     assert raw_context_text not in cache_text
 
 
+def test_foreign_frame_payload_is_rejected_before_annotation_cache(
+    tmp_path: Path,
+) -> None:
+    """同じIDで異なるpayloadを持つFrame Candidateがcache前に拒否されること。
+
+    Arrange:
+        - request frameと同じIDに異なる画像bytesを持つAnnotationが用意される
+    Act:
+        - 一つのCandidate Annotationが処理される
+    Assert:
+        - runtime境界で失敗しforeign frameがcold resultへ返されないこと
+    """
+    # Arrange
+    video_set, configuration = _video_set_and_configuration(tmp_path)
+    request = _requests()[0]
+    foreign_frame = FrameCandidate(
+        request.frame_candidates[0].identifier,
+        b"foreign-image",
+    )
+    foreign_annotation = CandidateAnnotation(
+        candidate=foreign_frame,
+        summary="フィールドを探索する場面",
+        candidate_moment_id=request.moment.identifier,
+        scene_slug="exploration",
+        blog_image_type="normal_gameplay",
+        explanation_value="medium",
+        frame_choice_reason="探索場所が明確に写る",
+        screen_text_kind="hud",
+        context_relevance="unavailable",
+        spoiler_risk="none",
+    )
+    runtime = FakeStructuredVisionRuntime(_catalog(), (foreign_annotation,))
+    models = FakeModelRuntime("vision-model").resolve_models(configuration)
+
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="Candidate Annotation"):
+        VideoSetVisionProcessor(runtime, RecordingRunObserver()).process(
+            video_set=video_set,
+            representatives=request.frame_candidates,
+            representative_source_fingerprints=(StageFingerprint("c" * 64),),
+            annotation_requests=(request,),
+            configuration=configuration,
+            resolved_models=models,
+        )
+
+
 def _video_set_and_configuration(
     tmp_path: Path,
 ) -> tuple[VideoSet, EffectiveConfiguration]:

--- a/tests/video_selection/services/test_video_set_vision_processor.py
+++ b/tests/video_selection/services/test_video_set_vision_processor.py
@@ -1,0 +1,264 @@
+from fractions import Fraction
+from pathlib import Path
+
+import pytest
+
+from src.video_selection.models.candidate_annotation import CandidateAnnotation
+from src.video_selection.models.candidate_annotation_request import (
+    CandidateAnnotationRequest,
+)
+from src.video_selection.models.candidate_moment import CandidateMoment
+from src.video_selection.models.context_cue import ContextCue
+from src.video_selection.models.effective_configuration import EffectiveConfiguration
+from src.video_selection.models.frame_candidate import FrameCandidate
+from src.video_selection.models.scene_catalog import SceneCatalog
+from src.video_selection.models.scene_catalog_entry import SceneCatalogEntry
+from src.video_selection.models.stage_fingerprint import StageFingerprint
+from src.video_selection.models.video_set import VideoSet
+from src.video_selection.services.discover_video_set import discover_video_set
+from src.video_selection.services.video_set_vision_processor import (
+    VideoSetVisionProcessor,
+)
+from tests.video_selection.fakes.fake_model_runtime import FakeModelRuntime
+from tests.video_selection.fakes.fake_structured_vision_runtime import (
+    FakeStructuredVisionRuntime,
+)
+from tests.video_selection.fakes.recording_run_observer import RecordingRunObserver
+
+
+def test_matching_fingerprints_reuse_catalog_and_each_annotation(
+    tmp_path: Path,
+) -> None:
+    """一致するStage Fingerprintでmodel contentが再生成されないこと。
+
+    Arrange:
+        - Scene Catalogと2件のCandidate Annotationを返すfakeが用意される
+        - 初回と選択枚数・spoiler感度・outputだけ異なる2回目が用意される
+    Act:
+        - 同じVision Stage semantic入力が2回処理される
+    Assert:
+        - 2回目はCatalogとAnnotationをすべて独立cacheから復元すること
+        - raw Context Cue、prompt body、raw response、reasoningがcacheされないこと
+    """
+    # Arrange
+    video_set, configuration = _video_set_and_configuration(tmp_path)
+    requests = _requests()
+    catalog = _catalog()
+    annotations = _annotations(requests)
+    cold_runtime = FakeStructuredVisionRuntime(catalog, annotations)
+    cold_processor = VideoSetVisionProcessor(
+        cold_runtime,
+        RecordingRunObserver(),
+    )
+    models = FakeModelRuntime("vision-model").resolve_models(configuration)
+
+    # Act
+    cold_result = cold_processor.process(
+        video_set=video_set,
+        representatives=tuple(request.frame_candidates[0] for request in requests),
+        representative_source_fingerprints=(StageFingerprint("c" * 64),),
+        annotation_requests=requests,
+        configuration=configuration,
+        resolved_models=models,
+    )
+    warm_runtime = FakeStructuredVisionRuntime(
+        catalog,
+        annotations,
+        reject_all_calls=True,
+    )
+    warm_result = VideoSetVisionProcessor(
+        warm_runtime,
+        RecordingRunObserver(),
+    ).process(
+        video_set=video_set,
+        representatives=tuple(request.frame_candidates[0] for request in requests),
+        representative_source_fingerprints=(StageFingerprint("c" * 64),),
+        annotation_requests=requests,
+        configuration=EffectiveConfiguration(
+            video_input_folder=configuration.video_input_folder,
+            output_folder=tmp_path / "different-output",
+            image_count=999,
+            spoiler_sensitivity="high",
+        ),
+        resolved_models=models,
+    )
+
+    # Assert
+    assert len(cold_runtime.scene_catalog_calls) == 1
+    assert len(cold_runtime.candidate_annotation_calls) == 2
+    assert warm_runtime.scene_catalog_calls == []
+    assert warm_runtime.candidate_annotation_calls == []
+    assert warm_result.catalog == cold_result.catalog
+    assert warm_result.annotations == cold_result.annotations
+    assert cold_result.catalog_diagnostics.cache_hit is False
+    assert all(not item.cache_hit for item in cold_result.annotation_diagnostics)
+    assert warm_result.catalog_diagnostics.cache_hit is True
+    assert all(item.cache_hit for item in warm_result.annotation_diagnostics)
+    assert len(warm_result.completed_stages) == 3
+    cache_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in configuration.processing_cache_folder.rglob("*.json")
+    )
+    assert "正体を明かす秘密の台詞" not in cache_text
+    assert '"messages"' not in cache_text
+    assert '"raw_response"' not in cache_text
+    assert '"reasoning"' not in cache_text
+
+
+def test_completed_annotations_survive_a_later_annotation_failure(
+    tmp_path: Path,
+) -> None:
+    """後続Annotation失敗後も先に完了したMomentが再利用されること。
+
+    Arrange:
+        - 2件目だけ失敗するfake VisionRuntimeが用意される
+    Act:
+        - 失敗runの後に同じ入力が再実行される
+    Assert:
+        - Scene Catalogと1件目は再実行されず2件目だけ生成されること
+        - 最初の失敗runで全Annotation完了結果が返されないこと
+    """
+    # Arrange
+    video_set, configuration = _video_set_and_configuration(tmp_path)
+    requests = _requests()
+    catalog = _catalog()
+    annotations = _annotations(requests)
+    first_runtime = FakeStructuredVisionRuntime(
+        catalog,
+        annotations,
+        failure_moment_id=requests[1].moment.identifier,
+    )
+    models = FakeModelRuntime("vision-model").resolve_models(configuration)
+
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match="fake raw response"):
+        VideoSetVisionProcessor(
+            first_runtime,
+            RecordingRunObserver(),
+        ).process(
+            video_set=video_set,
+            representatives=tuple(request.frame_candidates[0] for request in requests),
+            representative_source_fingerprints=(StageFingerprint("c" * 64),),
+            annotation_requests=requests,
+            configuration=configuration,
+            resolved_models=models,
+        )
+    retry_runtime = FakeStructuredVisionRuntime(catalog, annotations)
+    result = VideoSetVisionProcessor(
+        retry_runtime,
+        RecordingRunObserver(),
+    ).process(
+        video_set=video_set,
+        representatives=tuple(request.frame_candidates[0] for request in requests),
+        representative_source_fingerprints=(StageFingerprint("c" * 64),),
+        annotation_requests=requests,
+        configuration=configuration,
+        resolved_models=models,
+    )
+    assert retry_runtime.scene_catalog_calls == []
+    assert [
+        item.moment.identifier for item in retry_runtime.candidate_annotation_calls
+    ] == [requests[1].moment.identifier]
+    assert result.annotations == annotations
+    assert [item.cache_hit for item in result.annotation_diagnostics] == [True, False]
+
+
+def _video_set_and_configuration(
+    tmp_path: Path,
+) -> tuple[VideoSet, EffectiveConfiguration]:
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    (input_folder / "video.mp4").write_bytes(b"video-content")
+    return (
+        discover_video_set(input_folder),
+        EffectiveConfiguration(
+            video_input_folder=input_folder,
+            output_folder=tmp_path / "output",
+        ),
+    )
+
+
+def _requests() -> tuple[CandidateAnnotationRequest, ...]:
+    first_frame = FrameCandidate("frame-a", b"image-a")
+    second_frame = FrameCandidate("frame-b", b"image-b")
+    return (
+        CandidateAnnotationRequest(
+            moment=_moment("a", first_frame.identifier, Fraction(10)),
+            frame_candidates=(first_frame,),
+            context_cues=(),
+            video_set_progress=Fraction(1, 4),
+            selection_intent="ブログ本文を説明できる画像を選ぶ",
+            cue_selection_policy_version="nearby-context-v1",
+        ),
+        CandidateAnnotationRequest(
+            moment=_moment("b", second_frame.identifier, Fraction(20)),
+            frame_candidates=(second_frame,),
+            context_cues=(
+                ContextCue(
+                    identifier="cue-b",
+                    start=Fraction(19),
+                    end=Fraction(21),
+                    text="正体を明かす秘密の台詞",
+                ),
+            ),
+            video_set_progress=Fraction(3, 4),
+            selection_intent="ブログ本文を説明できる画像を選ぶ",
+            cue_selection_policy_version="nearby-context-v1",
+        ),
+    )
+
+
+def _moment(seed: str, frame_id: str, time: Fraction) -> CandidateMoment:
+    return CandidateMoment(
+        identifier="mom_" + seed * 64,
+        source_pts=int(time),
+        anchor_time=time,
+        timeline_segment_id="seg_" + seed * 64,
+        evidence=("scene",),
+        proxy_quality_score=0.9,
+        frame_candidate_ids=(frame_id,),
+    )
+
+
+def _catalog() -> SceneCatalog:
+    return SceneCatalog(
+        (
+            SceneCatalogEntry("exploration", "探索", "フィールド探索", "ordinary"),
+            SceneCatalogEntry("climax", "終盤", "重要な対決", "cinematic"),
+            SceneCatalogEntry("other", "その他", "分類不能", "ordinary"),
+        )
+    )
+
+
+def _annotations(
+    requests: tuple[CandidateAnnotationRequest, ...],
+) -> tuple[CandidateAnnotation, ...]:
+    return (
+        CandidateAnnotation(
+            candidate=requests[0].frame_candidates[0],
+            summary="フィールドを探索する場面",
+            candidate_moment_id=requests[0].moment.identifier,
+            scene_slug="exploration",
+            blog_image_type="normal_gameplay",
+            explanation_value="medium",
+            frame_choice_reason="探索場所が明確に写る",
+            screen_text_kind="hud",
+            context_relevance="unavailable",
+            spoiler_risk="none",
+        ),
+        CandidateAnnotation(
+            candidate=requests[1].frame_candidates[0],
+            summary="終盤の重要な対決",
+            candidate_moment_id=requests[1].moment.identifier,
+            scene_slug="climax",
+            blog_image_type="event",
+            explanation_value="high",
+            frame_choice_reason="対決する人物が明確に写る",
+            screen_text_kind="dialogue",
+            context_relevance="strong",
+            supporting_context_cue_ids=("cue-b",),
+            spoiler_risk="high",
+            spoiler_evidence="主要人物の正体が画面で明示される",
+        ),
+    )

--- a/tests/video_selection/vision/test_ollama_vision_runtime.py
+++ b/tests/video_selection/vision/test_ollama_vision_runtime.py
@@ -1,6 +1,8 @@
 import json
 from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
 from email.message import Message
+from email.utils import format_datetime
 from fractions import Fraction
 from typing import cast
 from urllib.error import HTTPError
@@ -45,10 +47,19 @@ def test_scene_catalog_uses_strict_documented_ollama_request() -> None:
 
     def requester(
         _method: str,
-        _url: str,
+        url: str,
         payload: Mapping[str, object] | None,
         _timeout: float,
     ) -> object:
+        if url.endswith("/api/tags"):
+            return {
+                "models": [
+                    {
+                        "name": "qwen3-vl:8b-instruct",
+                        "digest": "a" * 64,
+                    }
+                ]
+            }
         assert payload is not None
         requests.append(payload)
         return _response(_catalog_payload())
@@ -131,6 +142,7 @@ def test_schema_failure_is_retried_once_with_stable_code() -> None:
         timeout_seconds=60.0,
         requester=requester,
         sleeper=sleeps.append,
+        model_identity_resolver=_resolved_identity,
     )
     request = SceneCatalogRequest(
         representatives=(FrameCandidate("frame-a", b"image-a"),),
@@ -189,6 +201,7 @@ def test_truncated_response_is_retried_before_success() -> None:
         timeout_seconds=60.0,
         requester=requester,
         sleeper=lambda _seconds: None,
+        model_identity_resolver=_resolved_identity,
     )
 
     # Act
@@ -241,6 +254,7 @@ def test_repeated_truncated_response_fails_after_one_retry() -> None:
         timeout_seconds=60.0,
         requester=requester,
         sleeper=lambda _seconds: None,
+        model_identity_resolver=_resolved_identity,
     )
 
     # Act
@@ -289,6 +303,7 @@ def test_candidate_domain_failure_stops_without_other_fallback() -> None:
         timeout_seconds=60.0,
         requester=requester,
         sleeper=lambda _seconds: None,
+        model_identity_resolver=_resolved_identity,
     )
 
     # Act
@@ -304,6 +319,250 @@ def test_candidate_domain_failure_stops_without_other_fallback() -> None:
     assert captured.value.reason is VisionRuntimeFailureReason.DOMAIN_INVALID
     assert captured.value.validation_code == "candidate_annotation_domain_invalid"
     assert "foreign-frame" not in str(captured.value)
+
+
+def test_changed_ollama_tag_is_rejected_before_inference() -> None:
+    """freeze後にOllama tagのdigestが変わった場合に推論前に停止されること。
+
+    Arrange:
+        - freeze済みidentityと異なるdigestを返すlocal model一覧が用意される
+    Act:
+        - Scene Catalog推論が実行される
+    Assert:
+        - chat requestが送られずmodel identity changedで失敗すること
+    """
+    # Arrange
+    chat_calls = 0
+
+    def requester(
+        _method: str,
+        url: str,
+        _payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        nonlocal chat_calls
+        if url.endswith("/api/tags"):
+            return {
+                "models": [
+                    {
+                        "name": "qwen3-vl:8b-instruct",
+                        "digest": "b" * 64,
+                    }
+                ]
+            }
+        chat_calls += 1
+        return _response(_catalog_payload())
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    # Assert
+    with pytest.raises(VisionRuntimeError) as captured:
+        runtime.create_scene_catalog(
+            SceneCatalogRequest(
+                representatives=(FrameCandidate("frame-a", b"image-a"),),
+                selection_intent="ブログ画像を分類する",
+            ),
+            _resolved_model(ModelRole.SCENE_CATALOG),
+            num_ctx=32768,
+        )
+    assert chat_calls == 0
+    assert captured.value.reason is VisionRuntimeFailureReason.MODEL_UNAVAILABLE
+    assert captured.value.validation_code == "ollama_model_identity_changed"
+
+
+def test_tag_preflight_http_429_honors_http_date_retry_after() -> None:
+    """推論前tag確認のHTTP 429でもHTTP-date待機が尊重されること。
+
+    Arrange:
+        - 初回tag確認に45秒後のHTTP-dateを返す429が用意される
+        - 再試行時にfreeze済みdigestとvalid responseが用意される
+    Act:
+        - Scene Catalog推論が実行される
+    Assert:
+        - 待機が30秒へ制限され推論前tag確認から再試行されること
+    """
+    # Arrange
+    tag_calls = 0
+    sleeps: list[float] = []
+
+    def requester(
+        _method: str,
+        url: str,
+        _payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        nonlocal tag_calls
+        if url.endswith("/api/tags"):
+            tag_calls += 1
+            if tag_calls == 1:
+                headers = Message()
+                retry_at = datetime.now(timezone.utc) + timedelta(seconds=45)
+                headers["Retry-After"] = format_datetime(retry_at, usegmt=True)
+                raise HTTPError(url, 429, "rate limited", headers, None)
+            return {
+                "models": [
+                    {
+                        "name": "qwen3-vl:8b-instruct",
+                        "digest": "a" * 64,
+                    }
+                ]
+            }
+        return _response(_catalog_payload())
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=sleeps.append,
+    )
+
+    # Act
+    catalog, diagnostics = runtime.create_scene_catalog(
+        SceneCatalogRequest(
+            representatives=(FrameCandidate("frame-a", b"image-a"),),
+            selection_intent="ブログ画像を分類する",
+        ),
+        _resolved_model(ModelRole.SCENE_CATALOG),
+        num_ctx=32768,
+    )
+
+    # Assert
+    assert catalog.slugs[-1] == "other"
+    assert diagnostics.attempt_count == 2
+    assert tag_calls == 2
+    assert sleeps == [30.0]
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_reason"),
+    (
+        (400, VisionRuntimeFailureReason.INVALID_REQUEST),
+        (401, VisionRuntimeFailureReason.INVALID_REQUEST),
+        (404, VisionRuntimeFailureReason.MODEL_UNAVAILABLE),
+    ),
+)
+def test_tag_preflight_non_retryable_http_4xx_fails_immediately(
+    status_code: int,
+    expected_reason: VisionRuntimeFailureReason,
+) -> None:
+    """推論前tag確認の非retryable HTTP 4xxが即時fatalになること。
+
+    Arrange:
+        - 外部detailを含む非retryable HTTP 4xxがtag確認へ用意される
+    Act:
+        - Scene Catalog推論が実行される
+    Assert:
+        - 再試行されずstatusに対応する安全なfatal errorになること
+    """
+    # Arrange
+    calls = 0
+
+    def requester(
+        _method: str,
+        url: str,
+        _payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        nonlocal calls
+        calls += 1
+        raise HTTPError(
+            url,
+            status_code,
+            "token-secret /private/model",
+            hdrs=Message(),
+            fp=None,
+        )
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    # Assert
+    with pytest.raises(VisionRuntimeError) as captured:
+        runtime.create_scene_catalog(
+            SceneCatalogRequest(
+                representatives=(FrameCandidate("frame-a", b"image-a"),),
+                selection_intent="ブログ画像を分類する",
+            ),
+            _resolved_model(ModelRole.SCENE_CATALOG),
+            num_ctx=32768,
+        )
+    assert calls == 1
+    assert captured.value.reason is expected_reason
+    assert "token-secret" not in str(captured.value)
+    assert "/private/model" not in str(captured.value)
+
+
+def test_invalid_tag_preflight_retries_without_repairing_prompt() -> None:
+    """不正なtag応答後の再試行でmodel promptが変更されないこと。
+
+    Arrange:
+        - 初回だけ不正なlocal model一覧を返すAPIが用意される
+        - 再試行時にfreeze済みdigestとvalid responseが用意される
+    Act:
+        - Scene Catalog推論が実行される
+    Assert:
+        - 診断codeは保持され、未実行modelのpromptへ修復指示が入らないこと
+    """
+    # Arrange
+    tag_calls = 0
+    chat_payloads: list[Mapping[str, object]] = []
+
+    def requester(
+        _method: str,
+        url: str,
+        payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        nonlocal tag_calls
+        if url.endswith("/api/tags"):
+            tag_calls += 1
+            if tag_calls == 1:
+                return {"models": "invalid"}
+            return {
+                "models": [
+                    {
+                        "name": "qwen3-vl:8b-instruct",
+                        "digest": "a" * 64,
+                    }
+                ]
+            }
+        assert payload is not None
+        chat_payloads.append(payload)
+        return _response(_catalog_payload())
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    _, diagnostics = runtime.create_scene_catalog(
+        SceneCatalogRequest(
+            representatives=(FrameCandidate("frame-a", b"image-a"),),
+            selection_intent="ブログ画像を分類する",
+        ),
+        _resolved_model(ModelRole.SCENE_CATALOG),
+        num_ctx=32768,
+    )
+
+    # Assert
+    assert diagnostics.attempt_count == 2
+    assert diagnostics.validation_code == "ollama_model_identity_response_invalid"
+    assert len(chat_payloads) == 1
+    assert "validation_code" not in str(_first_message(chat_payloads[0])["content"])
 
 
 def test_candidate_without_context_is_explicitly_unavailable() -> None:
@@ -336,6 +595,7 @@ def test_candidate_without_context_is_explicitly_unavailable() -> None:
         timeout_seconds=60.0,
         requester=lambda _method, _url, _payload, _timeout: _response(response),
         sleeper=lambda _seconds: None,
+        model_identity_resolver=_resolved_identity,
     )
 
     # Act
@@ -382,6 +642,7 @@ def test_candidate_without_context_rejects_none_relevance() -> None:
         timeout_seconds=60.0,
         requester=lambda _method, _url, _payload, _timeout: _response(response),
         sleeper=lambda _seconds: None,
+        model_identity_resolver=_resolved_identity,
     )
 
     # Act
@@ -416,6 +677,7 @@ def test_candidate_with_context_rejects_unavailable_relevance() -> None:
         timeout_seconds=60.0,
         requester=lambda _method, _url, _payload, _timeout: _response(response),
         sleeper=lambda _seconds: None,
+        model_identity_resolver=_resolved_identity,
     )
 
     # Act
@@ -456,6 +718,7 @@ def test_candidate_rejects_verbatim_context_cue_in_free_text(
         timeout_seconds=60.0,
         requester=lambda _method, _url, _payload, _timeout: _response(response),
         sleeper=lambda _seconds: None,
+        model_identity_resolver=_resolved_identity,
     )
 
     # Act
@@ -474,6 +737,7 @@ def test_candidate_rejects_verbatim_context_cue_in_free_text(
 @pytest.mark.parametrize(
     ("cue_text", "leaked_text"),
     (
+        ("犯人A", "犯人Aが判明"),
         ("「正体は王だ」", "正体は王だ"),
         ("王都は陥落した。次の目的地は北の塔だ。", "次の目的地は北の塔だ"),
     ),
@@ -501,6 +765,7 @@ def test_candidate_rejects_normalized_or_partial_context_cue_quote(
         timeout_seconds=60.0,
         requester=lambda _method, _url, _payload, _timeout: _response(response),
         sleeper=lambda _seconds: None,
+        model_identity_resolver=_resolved_identity,
     )
 
     # Act
@@ -546,6 +811,7 @@ def test_retryable_transport_failure_is_retried_with_same_semantic_input() -> No
         timeout_seconds=60.0,
         requester=requester,
         sleeper=lambda _seconds: None,
+        model_identity_resolver=_resolved_identity,
     )
 
     # Act
@@ -603,6 +869,7 @@ def test_non_retryable_http_4xx_fails_immediately_without_external_detail() -> N
         timeout_seconds=60.0,
         requester=requester,
         sleeper=lambda _seconds: None,
+        model_identity_resolver=_resolved_identity,
     )
 
     # Act
@@ -655,6 +922,61 @@ def test_http_429_honors_capped_retry_after() -> None:
         timeout_seconds=60.0,
         requester=requester,
         sleeper=sleeps.append,
+        model_identity_resolver=_resolved_identity,
+    )
+
+    # Act
+    catalog, diagnostics = runtime.create_scene_catalog(
+        SceneCatalogRequest(
+            representatives=(FrameCandidate("frame-a", b"image-a"),),
+            selection_intent="ブログ画像を分類する",
+        ),
+        _resolved_model(ModelRole.SCENE_CATALOG),
+        num_ctx=32768,
+    )
+
+    # Assert
+    assert catalog.slugs[-1] == "other"
+    assert diagnostics.attempt_count == 2
+    assert calls == 2
+    assert sleeps == [30.0]
+
+
+def test_http_429_honors_http_date_retry_after() -> None:
+    """HTTP-date形式のRetry-Afterが最大30秒まで尊重されること。
+
+    Arrange:
+        - 初回に45秒後のHTTP-dateを返す429、2回目にvalid responseが用意される
+    Act:
+        - Scene Catalog推論が実行される
+    Assert:
+        - HTTP-dateの差分が解釈され待機が30秒へ制限されること
+    """
+    # Arrange
+    calls = 0
+    sleeps: list[float] = []
+
+    def requester(
+        _method: str,
+        url: str,
+        _payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            headers = Message()
+            retry_at = datetime.now(timezone.utc) + timedelta(seconds=45)
+            headers["Retry-After"] = format_datetime(retry_at, usegmt=True)
+            raise HTTPError(url, 429, "rate limited", headers, None)
+        return _response(_catalog_payload())
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=sleeps.append,
+        model_identity_resolver=_resolved_identity,
     )
 
     # Act
@@ -799,6 +1121,10 @@ def _resolved_model(role: ModelRole) -> ResolvedModel:
         runtime_identity=ModelRuntimeIdentity(ModelStoreKind.OLLAMA, "0.31.2"),
         artifact_location=None,
     )
+
+
+def _resolved_identity(model: ResolvedModel) -> str:
+    return model.execution_identity.identifier
 
 
 def _first_message(payload: Mapping[str, object]) -> Mapping[str, object]:

--- a/tests/video_selection/vision/test_ollama_vision_runtime.py
+++ b/tests/video_selection/vision/test_ollama_vision_runtime.py
@@ -974,6 +974,50 @@ def test_candidate_rejects_normalized_or_partial_context_cue_quote(
     assert captured.value.validation_code == "candidate_annotation_domain_invalid"
 
 
+@pytest.mark.parametrize(
+    ("cue_text", "annotation_summary"),
+    (
+        ("はい", "人物がはいと返事する場面"),
+        ("OK", "画面にOK表示が示される場面"),
+    ),
+)
+def test_candidate_allows_ambiguous_one_or_two_character_cue_occurrence(
+    cue_text: str,
+    annotation_summary: str,
+) -> None:
+    """一般的な1〜2文字Cueの出現が逐語引用と判定されないこと。
+
+    Arrange:
+        - 一般的な1〜2文字Cueと、その文字列を含む要約が用意される
+    Act:
+        - Candidate Annotation推論が実行される
+    Assert:
+        - 独立生成との区別がつかない短い一致が受理されること
+    """
+    # Arrange
+    request = _annotation_request_with_context_text(cue_text)
+    response = _annotation_payload()
+    response["annotation_summary"] = annotation_summary
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=lambda _method, _url, _payload, _timeout: _response(response),
+        sleeper=lambda _seconds: None,
+        model_state_resolver=_resolved_artifact,
+    )
+
+    # Act
+    annotation, _ = runtime.annotate_candidate(
+        request,
+        _catalog(),
+        _resolved_model(ModelRole.CANDIDATE_ANNOTATION),
+        num_ctx=32768,
+    )
+
+    # Assert
+    assert annotation.summary == annotation_summary
+
+
 def test_retryable_transport_failure_is_retried_with_same_semantic_input() -> None:
     """一時transport failureが同じsemantic入力で一度だけ再試行されること。
 

--- a/tests/video_selection/vision/test_ollama_vision_runtime.py
+++ b/tests/video_selection/vision/test_ollama_vision_runtime.py
@@ -1,0 +1,521 @@
+import json
+from collections.abc import Mapping
+from email.message import Message
+from fractions import Fraction
+from typing import cast
+from urllib.error import HTTPError
+
+import pytest
+
+from src.video_selection.models.candidate_annotation_request import (
+    CandidateAnnotationRequest,
+)
+from src.video_selection.models.candidate_moment import CandidateMoment
+from src.video_selection.models.context_cue import ContextCue
+from src.video_selection.models.frame_candidate import FrameCandidate
+from src.video_selection.models.model_role import ModelRole
+from src.video_selection.models.model_runtime_identity import ModelRuntimeIdentity
+from src.video_selection.models.model_store_kind import ModelStoreKind
+from src.video_selection.models.model_update_status import ModelUpdateStatus
+from src.video_selection.models.resolved_model import ResolvedModel
+from src.video_selection.models.resolved_model_identity import ResolvedModelIdentity
+from src.video_selection.models.scene_catalog import SceneCatalog
+from src.video_selection.models.scene_catalog_entry import SceneCatalogEntry
+from src.video_selection.models.scene_catalog_request import SceneCatalogRequest
+from src.video_selection.models.vision_runtime_error import VisionRuntimeError
+from src.video_selection.models.vision_runtime_failure_reason import (
+    VisionRuntimeFailureReason,
+)
+from src.video_selection.vision.ollama_vision_runtime import OllamaVisionRuntime
+
+
+def test_scene_catalog_uses_strict_documented_ollama_request() -> None:
+    """Scene Catalogが画像付きstrict schema requestから生成されること。
+
+    Arrange:
+        - 3件のsceneを返すfake Ollama APIと2枚の代表画像が用意される
+    Act:
+        - Scene Catalog推論が実行される
+    Assert:
+        - JSON Schema object、temperature 0、stream/think falseが送られること
+        - token/runtime診断とdomain検証済みCatalogが返されること
+    """
+    # Arrange
+    requests: list[Mapping[str, object]] = []
+
+    def requester(
+        _method: str,
+        _url: str,
+        payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        assert payload is not None
+        requests.append(payload)
+        return _response(_catalog_payload())
+
+    runtime = OllamaVisionRuntime(
+        "http://ollama.example:11434/",
+        timeout_seconds=45.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+    )
+    request = SceneCatalogRequest(
+        representatives=(
+            FrameCandidate(identifier="frame-a", image_bytes=b"image-a"),
+            FrameCandidate(identifier="frame-b", image_bytes=b"image-b"),
+        ),
+        selection_intent="ブログ本文を説明できる画像を分類する",
+        scene_hint="RPGの探索と戦闘",
+    )
+
+    # Act
+    catalog, diagnostics = runtime.create_scene_catalog(
+        request,
+        _resolved_model(ModelRole.SCENE_CATALOG),
+        num_ctx=32768,
+    )
+
+    # Assert
+    assert catalog.slugs == ("exploration", "battle", "other")
+    assert diagnostics.attempt_count == 1
+    assert diagnostics.prompt_eval_count == 123
+    assert diagnostics.eval_count == 45
+    assert diagnostics.done_reason == "stop"
+    assert len(diagnostics.request_fingerprint) == 64
+    assert len(requests) == 1
+    payload = requests[0]
+    assert payload["model"] == "qwen3-vl:8b-instruct"
+    assert payload["stream"] is False
+    assert payload["think"] is False
+    assert payload["options"] == {"temperature": 0, "num_ctx": 32768}
+    schema = payload["format"]
+    assert isinstance(schema, dict)
+    assert schema["additionalProperties"] is False
+    assert "quality_score" not in json.dumps(schema)
+    assert "final_score" not in json.dumps(schema)
+    assert "selected" not in json.dumps(schema)
+    messages = payload["messages"]
+    assert isinstance(messages, list)
+    assert messages[0]["images"] == ["aW1hZ2UtYQ==", "aW1hZ2UtYg=="]
+
+
+def test_schema_failure_is_retried_once_with_stable_code() -> None:
+    """schema invalidがraw responseを戻さず一度だけ修復再試行されること。
+
+    Arrange:
+        - 初回だけ未知fieldを含み2回目はvalidなresponseが用意される
+    Act:
+        - Scene Catalog推論が実行される
+    Assert:
+        - 同じ画像で2回だけrequestされstable codeだけが追加されること
+    """
+    # Arrange
+    payloads: list[Mapping[str, object]] = []
+    sleeps: list[float] = []
+
+    def requester(
+        _method: str,
+        _url: str,
+        payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        assert payload is not None
+        payloads.append(payload)
+        response = _catalog_payload()
+        if len(payloads) == 1:
+            response["raw_reasoning"] = "secret chain of thought"
+        return _response(response)
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=sleeps.append,
+    )
+    request = SceneCatalogRequest(
+        representatives=(FrameCandidate("frame-a", b"image-a"),),
+        selection_intent="ブログ画像を分類する",
+    )
+
+    # Act
+    catalog, diagnostics = runtime.create_scene_catalog(
+        request,
+        _resolved_model(ModelRole.SCENE_CATALOG),
+        num_ctx=32768,
+    )
+
+    # Assert
+    assert catalog.slugs[-1] == "other"
+    assert diagnostics.attempt_count == 2
+    assert diagnostics.validation_code == "scene_catalog_schema_invalid"
+    assert sleeps == [1.0]
+    assert (
+        _first_message(payloads[0])["images"] == _first_message(payloads[1])["images"]
+    )
+    second_prompt = _first_message(payloads[1])["content"]
+    assert isinstance(second_prompt, str)
+    assert "scene_catalog_schema_invalid" in second_prompt
+    assert "secret chain of thought" not in second_prompt
+
+
+def test_candidate_domain_failure_stops_without_other_fallback() -> None:
+    """Candidate Annotation domain failureが2回後にrun停止へ変換されること。
+
+    Arrange:
+        - 入力にないRepresentative Frameを2回返すAPIが用意される
+    Act:
+        - Candidate Annotation推論が実行される
+    Assert:
+        - domain_invalidで失敗しother fallbackが生成されないこと
+    """
+    # Arrange
+    calls = 0
+
+    def requester(
+        _method: str,
+        _url: str,
+        _payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        nonlocal calls
+        calls += 1
+        response = _annotation_payload()
+        response["representative_frame_id"] = "foreign-frame"
+        return _response(response)
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    # Assert
+    with pytest.raises(VisionRuntimeError) as captured:
+        runtime.annotate_candidate(
+            _annotation_request(),
+            _catalog(),
+            _resolved_model(ModelRole.CANDIDATE_ANNOTATION),
+            num_ctx=32768,
+        )
+    assert calls == 2
+    assert captured.value.reason is VisionRuntimeFailureReason.DOMAIN_INVALID
+    assert captured.value.validation_code == "candidate_annotation_domain_invalid"
+    assert "foreign-frame" not in str(captured.value)
+
+
+def test_candidate_without_context_is_explicitly_unavailable() -> None:
+    """Context CueなしのCandidateがunavailableとして評価されること。
+
+    Arrange:
+        - Context Cueを持たないCandidate Momentとunavailable responseが用意される
+    Act:
+        - Candidate Annotation推論が実行される
+    Assert:
+        - supporting Cueなしのunavailableが正常なannotationになること
+    """
+    # Arrange
+    request = _annotation_request()
+    request_without_context = CandidateAnnotationRequest(
+        moment=request.moment,
+        frame_candidates=request.frame_candidates,
+        context_cues=(),
+        video_set_progress=request.video_set_progress,
+        selection_intent=request.selection_intent,
+        cue_selection_policy_version=request.cue_selection_policy_version,
+    )
+    response = _annotation_payload()
+    response["context_relevance"] = "unavailable"
+    response["supporting_context_cue_ids"] = []
+    response["spoiler_risk"] = "none"
+    response["spoiler_evidence"] = ""
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=lambda _method, _url, _payload, _timeout: _response(response),
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    annotation, diagnostics = runtime.annotate_candidate(
+        request_without_context,
+        _catalog(),
+        _resolved_model(ModelRole.CANDIDATE_ANNOTATION),
+        num_ctx=32768,
+    )
+
+    # Assert
+    assert annotation.context_relevance == "unavailable"
+    assert annotation.supporting_context_cue_ids == ()
+    assert diagnostics.context_cue_count == 0
+
+
+def test_retryable_transport_failure_is_retried_with_same_semantic_input() -> None:
+    """一時transport failureが同じsemantic入力で一度だけ再試行されること。
+
+    Arrange:
+        - 初回timeout後にhigh Spoiler Riskを返すAPIが用意される
+    Act:
+        - Candidate Annotation推論が実行される
+    Assert:
+        - 2回目が成功しmajor spoiler evidenceが保持されること
+    """
+    # Arrange
+    payloads: list[Mapping[str, object]] = []
+
+    def requester(
+        _method: str,
+        _url: str,
+        payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        assert payload is not None
+        payloads.append(payload)
+        if len(payloads) == 1:
+            raise TimeoutError("token-secret /private/path")
+        return _response(_annotation_payload())
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    annotation, diagnostics = runtime.annotate_candidate(
+        _annotation_request(),
+        _catalog(),
+        _resolved_model(ModelRole.CANDIDATE_ANNOTATION),
+        num_ctx=32768,
+    )
+
+    # Assert
+    assert diagnostics.attempt_count == 2
+    assert annotation.spoiler_risk == "high"
+    assert annotation.spoiler_evidence == "最終ボスの正体が画面で明示される"
+    assert (
+        _first_message(payloads[0])["images"] == _first_message(payloads[1])["images"]
+    )
+
+
+def test_non_retryable_http_4xx_fails_immediately_without_external_detail() -> None:
+    """408/429以外のHTTP 4xxが安全なfatal errorになること。
+
+    Arrange:
+        - credentialを含むHTTP 400 responseが用意される
+    Act:
+        - Scene Catalog推論が実行される
+    Assert:
+        - 再試行されず外部detailがerrorへ出ないこと
+    """
+    # Arrange
+    calls = 0
+
+    def requester(
+        _method: str,
+        url: str,
+        _payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        nonlocal calls
+        calls += 1
+        raise HTTPError(
+            url,
+            400,
+            "token-secret /private/model",
+            hdrs=Message(),
+            fp=None,
+        )
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    # Assert
+    with pytest.raises(VisionRuntimeError) as captured:
+        runtime.create_scene_catalog(
+            SceneCatalogRequest(
+                representatives=(FrameCandidate("frame-a", b"image-a"),),
+                selection_intent="ブログ画像を分類する",
+            ),
+            _resolved_model(ModelRole.SCENE_CATALOG),
+            num_ctx=32768,
+        )
+    assert calls == 1
+    assert captured.value.reason is VisionRuntimeFailureReason.INVALID_REQUEST
+    assert "token-secret" not in str(captured.value)
+    assert "/private/model" not in str(captured.value)
+
+
+def test_http_429_honors_capped_retry_after() -> None:
+    """HTTP 429のRetry-Afterが最大30秒まで尊重されること。
+
+    Arrange:
+        - 初回にRetry-After 45秒の429、2回目にvalid responseが用意される
+    Act:
+        - Scene Catalog推論が実行される
+    Assert:
+        - 待機が30秒へ制限され同じrequestが一度だけ再試行されること
+    """
+    # Arrange
+    calls = 0
+    sleeps: list[float] = []
+
+    def requester(
+        _method: str,
+        url: str,
+        _payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            headers = Message()
+            headers["Retry-After"] = "45"
+            raise HTTPError(url, 429, "rate limited", headers, None)
+        return _response(_catalog_payload())
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=sleeps.append,
+    )
+
+    # Act
+    catalog, diagnostics = runtime.create_scene_catalog(
+        SceneCatalogRequest(
+            representatives=(FrameCandidate("frame-a", b"image-a"),),
+            selection_intent="ブログ画像を分類する",
+        ),
+        _resolved_model(ModelRole.SCENE_CATALOG),
+        num_ctx=32768,
+    )
+
+    # Assert
+    assert catalog.slugs[-1] == "other"
+    assert diagnostics.attempt_count == 2
+    assert calls == 2
+    assert sleeps == [30.0]
+
+
+def _catalog_payload() -> dict[str, object]:
+    return {
+        "scenes": [
+            {
+                "slug": "exploration",
+                "display_name": "探索",
+                "description": "フィールド探索",
+                "selection_role": "ordinary",
+            },
+            {
+                "slug": "battle",
+                "display_name": "戦闘",
+                "description": "繰り返される通常戦闘",
+                "selection_role": "recurring_gameplay",
+            },
+            {
+                "slug": "other",
+                "display_name": "その他",
+                "description": "分類不能",
+                "selection_role": "ordinary",
+            },
+        ]
+    }
+
+
+def _annotation_payload() -> dict[str, object]:
+    return {
+        "representative_frame_id": "frame-a",
+        "scene_slug": "battle",
+        "blog_image_type": "event",
+        "explanation_value": "high",
+        "annotation_summary": "終盤の重要な対決",
+        "frame_choice_reason": "対決する人物が明確に写る",
+        "screen_text_kind": "dialogue",
+        "context_relevance": "strong",
+        "supporting_context_cue_ids": ["cue-a"],
+        "spoiler_risk": "high",
+        "spoiler_evidence": "最終ボスの正体が画面で明示される",
+    }
+
+
+def _response(content: dict[str, object]) -> dict[str, object]:
+    return {
+        "message": {"content": json.dumps(content, ensure_ascii=False)},
+        "done": True,
+        "done_reason": "stop",
+        "prompt_eval_count": 123,
+        "eval_count": 45,
+    }
+
+
+def _catalog() -> SceneCatalog:
+    return SceneCatalog(
+        (
+            SceneCatalogEntry("exploration", "探索", "フィールド探索", "ordinary"),
+            SceneCatalogEntry(
+                "battle",
+                "戦闘",
+                "繰り返される通常戦闘",
+                "recurring_gameplay",
+            ),
+            SceneCatalogEntry("other", "その他", "分類不能", "ordinary"),
+        )
+    )
+
+
+def _annotation_request() -> CandidateAnnotationRequest:
+    frame = FrameCandidate("frame-a", b"image-a")
+    moment = CandidateMoment(
+        identifier="mom_" + "a" * 64,
+        source_pts=100,
+        anchor_time=Fraction(10),
+        timeline_segment_id="seg_" + "b" * 64,
+        evidence=("scene",),
+        proxy_quality_score=0.9,
+        frame_candidate_ids=(frame.identifier,),
+    )
+    cue = ContextCue(
+        identifier="cue-a",
+        start=Fraction(9),
+        end=Fraction(11),
+        text="正体を明かす台詞",
+    )
+    return CandidateAnnotationRequest(
+        moment=moment,
+        frame_candidates=(frame,),
+        context_cues=(cue,),
+        video_set_progress=Fraction(1, 2),
+        selection_intent="ブログ本文を説明できる画像を選ぶ",
+        cue_selection_policy_version="nearby-context-v1",
+    )
+
+
+def _resolved_model(role: ModelRole) -> ResolvedModel:
+    identity = ResolvedModelIdentity(ModelStoreKind.OLLAMA, "sha256:" + "a" * 64)
+    return ResolvedModel(
+        role=role,
+        configured_name="qwen3-vl:8b-instruct",
+        canonical_name="qwen3-vl:8b-instruct",
+        local_identity_before_update=identity,
+        update_status=ModelUpdateStatus.UNCHANGED,
+        execution_identity=identity,
+        runtime_identity=ModelRuntimeIdentity(ModelStoreKind.OLLAMA, "0.31.2"),
+        artifact_location=None,
+    )
+
+
+def _first_message(payload: Mapping[str, object]) -> Mapping[str, object]:
+    messages = payload.get("messages")
+    assert isinstance(messages, list)
+    assert messages
+    message = messages[0]
+    assert isinstance(message, dict)
+    return cast(dict[str, object], message)

--- a/tests/video_selection/vision/test_ollama_vision_runtime.py
+++ b/tests/video_selection/vision/test_ollama_vision_runtime.py
@@ -15,6 +15,7 @@ from src.video_selection.models.candidate_annotation_request import (
 from src.video_selection.models.candidate_moment import CandidateMoment
 from src.video_selection.models.context_cue import ContextCue
 from src.video_selection.models.frame_candidate import FrameCandidate
+from src.video_selection.models.model_artifact import ModelArtifact
 from src.video_selection.models.model_role import ModelRole
 from src.video_selection.models.model_runtime_identity import ModelRuntimeIdentity
 from src.video_selection.models.model_store_kind import ModelStoreKind
@@ -51,6 +52,8 @@ def test_scene_catalog_uses_strict_documented_ollama_request() -> None:
         payload: Mapping[str, object] | None,
         _timeout: float,
     ) -> object:
+        if url.endswith("/api/version"):
+            return {"version": "0.31.2"}
         if url.endswith("/api/tags"):
             return {
                 "models": [
@@ -142,7 +145,7 @@ def test_schema_failure_is_retried_once_with_stable_code() -> None:
         timeout_seconds=60.0,
         requester=requester,
         sleeper=sleeps.append,
-        model_identity_resolver=_resolved_identity,
+        model_state_resolver=_resolved_artifact,
     )
     request = SceneCatalogRequest(
         representatives=(FrameCandidate("frame-a", b"image-a"),),
@@ -201,7 +204,7 @@ def test_truncated_response_is_retried_before_success() -> None:
         timeout_seconds=60.0,
         requester=requester,
         sleeper=lambda _seconds: None,
-        model_identity_resolver=_resolved_identity,
+        model_state_resolver=_resolved_artifact,
     )
 
     # Act
@@ -254,7 +257,7 @@ def test_repeated_truncated_response_fails_after_one_retry() -> None:
         timeout_seconds=60.0,
         requester=requester,
         sleeper=lambda _seconds: None,
-        model_identity_resolver=_resolved_identity,
+        model_state_resolver=_resolved_artifact,
     )
 
     # Act
@@ -303,7 +306,7 @@ def test_candidate_domain_failure_stops_without_other_fallback() -> None:
         timeout_seconds=60.0,
         requester=requester,
         sleeper=lambda _seconds: None,
-        model_identity_resolver=_resolved_identity,
+        model_state_resolver=_resolved_artifact,
     )
 
     # Act
@@ -341,6 +344,8 @@ def test_changed_ollama_tag_is_rejected_before_inference() -> None:
         _timeout: float,
     ) -> object:
         nonlocal chat_calls
+        if url.endswith("/api/version"):
+            return {"version": "0.31.2"}
         if url.endswith("/api/tags"):
             return {
                 "models": [
@@ -376,6 +381,187 @@ def test_changed_ollama_tag_is_rejected_before_inference() -> None:
     assert captured.value.validation_code == "ollama_model_identity_changed"
 
 
+def test_changed_ollama_runtime_is_rejected_before_inference() -> None:
+    """freeze後にOllama runtime versionが変わった場合に推論前に停止されること。
+
+    Arrange:
+        - freeze済みruntimeと異なるserver versionが用意される
+        - freeze済みdigestを指すlocal model一覧が用意される
+    Act:
+        - Scene Catalog推論が実行される
+    Assert:
+        - chat requestが送られずruntime identity changedで失敗すること
+    """
+    # Arrange
+    chat_calls = 0
+
+    def requester(
+        _method: str,
+        url: str,
+        _payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        nonlocal chat_calls
+        if url.endswith("/api/version"):
+            return {"version": "0.31.3"}
+        if url.endswith("/api/tags"):
+            return {
+                "models": [
+                    {
+                        "name": "qwen3-vl:8b-instruct",
+                        "digest": "a" * 64,
+                    }
+                ]
+            }
+        chat_calls += 1
+        return _response(_catalog_payload())
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    # Assert
+    with pytest.raises(VisionRuntimeError) as captured:
+        runtime.create_scene_catalog(
+            SceneCatalogRequest(
+                representatives=(FrameCandidate("frame-a", b"image-a"),),
+                selection_intent="ブログ画像を分類する",
+            ),
+            _resolved_model(ModelRole.SCENE_CATALOG),
+            num_ctx=32768,
+        )
+    assert chat_calls == 0
+    assert captured.value.reason is VisionRuntimeFailureReason.MODEL_UNAVAILABLE
+    assert captured.value.validation_code == "ollama_runtime_identity_changed"
+
+
+def test_changed_ollama_tag_is_rejected_after_inference() -> None:
+    """推論中にOllama tagのdigestが変わった場合に応答が破棄されること。
+
+    Arrange:
+        - 推論前はfreeze済みdigest、推論後は異なるdigestが用意される
+    Act:
+        - Scene Catalog推論が実行される
+    Assert:
+        - chat応答が返ってもmodel identity changedで失敗すること
+    """
+    # Arrange
+    tag_calls = 0
+    chat_calls = 0
+
+    def requester(
+        _method: str,
+        url: str,
+        _payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        nonlocal tag_calls, chat_calls
+        if url.endswith("/api/version"):
+            return {"version": "0.31.2"}
+        if url.endswith("/api/tags"):
+            tag_calls += 1
+            fill = "a" if tag_calls == 1 else "b"
+            return {
+                "models": [
+                    {
+                        "name": "qwen3-vl:8b-instruct",
+                        "digest": fill * 64,
+                    }
+                ]
+            }
+        chat_calls += 1
+        return _response(_catalog_payload())
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    # Assert
+    with pytest.raises(VisionRuntimeError) as captured:
+        runtime.create_scene_catalog(
+            SceneCatalogRequest(
+                representatives=(FrameCandidate("frame-a", b"image-a"),),
+                selection_intent="ブログ画像を分類する",
+            ),
+            _resolved_model(ModelRole.SCENE_CATALOG),
+            num_ctx=32768,
+        )
+    assert tag_calls == 2
+    assert chat_calls == 1
+    assert captured.value.reason is VisionRuntimeFailureReason.MODEL_UNAVAILABLE
+    assert captured.value.validation_code == "ollama_model_identity_changed"
+
+
+def test_changed_ollama_runtime_is_rejected_after_inference() -> None:
+    """推論中にOllama runtime versionが変わった場合に応答が破棄されること。
+
+    Arrange:
+        - 推論前はfreeze済みversion、推論後は異なるversionが用意される
+        - 両確認でfreeze済みdigestを指すlocal model一覧が用意される
+    Act:
+        - Scene Catalog推論が実行される
+    Assert:
+        - chat応答が返ってもruntime identity changedで失敗すること
+    """
+    # Arrange
+    version_calls = 0
+    chat_calls = 0
+
+    def requester(
+        _method: str,
+        url: str,
+        _payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        nonlocal version_calls, chat_calls
+        if url.endswith("/api/version"):
+            version_calls += 1
+            version = "0.31.2" if version_calls == 1 else "0.31.3"
+            return {"version": version}
+        if url.endswith("/api/tags"):
+            return {
+                "models": [
+                    {
+                        "name": "qwen3-vl:8b-instruct",
+                        "digest": "a" * 64,
+                    }
+                ]
+            }
+        chat_calls += 1
+        return _response(_catalog_payload())
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    # Assert
+    with pytest.raises(VisionRuntimeError) as captured:
+        runtime.create_scene_catalog(
+            SceneCatalogRequest(
+                representatives=(FrameCandidate("frame-a", b"image-a"),),
+                selection_intent="ブログ画像を分類する",
+            ),
+            _resolved_model(ModelRole.SCENE_CATALOG),
+            num_ctx=32768,
+        )
+    assert version_calls == 2
+    assert chat_calls == 1
+    assert captured.value.reason is VisionRuntimeFailureReason.MODEL_UNAVAILABLE
+    assert captured.value.validation_code == "ollama_runtime_identity_changed"
+
+
 def test_tag_preflight_http_429_honors_http_date_retry_after() -> None:
     """推論前tag確認のHTTP 429でもHTTP-date待機が尊重されること。
 
@@ -398,6 +584,8 @@ def test_tag_preflight_http_429_honors_http_date_retry_after() -> None:
         _timeout: float,
     ) -> object:
         nonlocal tag_calls
+        if url.endswith("/api/version"):
+            return {"version": "0.31.2"}
         if url.endswith("/api/tags"):
             tag_calls += 1
             if tag_calls == 1:
@@ -435,7 +623,7 @@ def test_tag_preflight_http_429_honors_http_date_retry_after() -> None:
     # Assert
     assert catalog.slugs[-1] == "other"
     assert diagnostics.attempt_count == 2
-    assert tag_calls == 2
+    assert tag_calls == 3
     assert sleeps == [30.0]
 
 
@@ -461,7 +649,7 @@ def test_tag_preflight_non_retryable_http_4xx_fails_immediately(
         - 再試行されずstatusに対応する安全なfatal errorになること
     """
     # Arrange
-    calls = 0
+    tag_calls = 0
 
     def requester(
         _method: str,
@@ -469,8 +657,10 @@ def test_tag_preflight_non_retryable_http_4xx_fails_immediately(
         _payload: Mapping[str, object] | None,
         _timeout: float,
     ) -> object:
-        nonlocal calls
-        calls += 1
+        nonlocal tag_calls
+        if url.endswith("/api/version"):
+            return {"version": "0.31.2"}
+        tag_calls += 1
         raise HTTPError(
             url,
             status_code,
@@ -497,7 +687,7 @@ def test_tag_preflight_non_retryable_http_4xx_fails_immediately(
             _resolved_model(ModelRole.SCENE_CATALOG),
             num_ctx=32768,
         )
-    assert calls == 1
+    assert tag_calls == 1
     assert captured.value.reason is expected_reason
     assert "token-secret" not in str(captured.value)
     assert "/private/model" not in str(captured.value)
@@ -525,6 +715,8 @@ def test_invalid_tag_preflight_retries_without_repairing_prompt() -> None:
         _timeout: float,
     ) -> object:
         nonlocal tag_calls
+        if url.endswith("/api/version"):
+            return {"version": "0.31.2"}
         if url.endswith("/api/tags"):
             tag_calls += 1
             if tag_calls == 1:
@@ -561,6 +753,7 @@ def test_invalid_tag_preflight_retries_without_repairing_prompt() -> None:
     # Assert
     assert diagnostics.attempt_count == 2
     assert diagnostics.validation_code == "ollama_model_identity_response_invalid"
+    assert tag_calls == 3
     assert len(chat_payloads) == 1
     assert "validation_code" not in str(_first_message(chat_payloads[0])["content"])
 
@@ -595,7 +788,7 @@ def test_candidate_without_context_is_explicitly_unavailable() -> None:
         timeout_seconds=60.0,
         requester=lambda _method, _url, _payload, _timeout: _response(response),
         sleeper=lambda _seconds: None,
-        model_identity_resolver=_resolved_identity,
+        model_state_resolver=_resolved_artifact,
     )
 
     # Act
@@ -642,7 +835,7 @@ def test_candidate_without_context_rejects_none_relevance() -> None:
         timeout_seconds=60.0,
         requester=lambda _method, _url, _payload, _timeout: _response(response),
         sleeper=lambda _seconds: None,
-        model_identity_resolver=_resolved_identity,
+        model_state_resolver=_resolved_artifact,
     )
 
     # Act
@@ -677,7 +870,7 @@ def test_candidate_with_context_rejects_unavailable_relevance() -> None:
         timeout_seconds=60.0,
         requester=lambda _method, _url, _payload, _timeout: _response(response),
         sleeper=lambda _seconds: None,
-        model_identity_resolver=_resolved_identity,
+        model_state_resolver=_resolved_artifact,
     )
 
     # Act
@@ -718,7 +911,7 @@ def test_candidate_rejects_verbatim_context_cue_in_free_text(
         timeout_seconds=60.0,
         requester=lambda _method, _url, _payload, _timeout: _response(response),
         sleeper=lambda _seconds: None,
-        model_identity_resolver=_resolved_identity,
+        model_state_resolver=_resolved_artifact,
     )
 
     # Act
@@ -765,7 +958,7 @@ def test_candidate_rejects_normalized_or_partial_context_cue_quote(
         timeout_seconds=60.0,
         requester=lambda _method, _url, _payload, _timeout: _response(response),
         sleeper=lambda _seconds: None,
-        model_identity_resolver=_resolved_identity,
+        model_state_resolver=_resolved_artifact,
     )
 
     # Act
@@ -811,7 +1004,7 @@ def test_retryable_transport_failure_is_retried_with_same_semantic_input() -> No
         timeout_seconds=60.0,
         requester=requester,
         sleeper=lambda _seconds: None,
-        model_identity_resolver=_resolved_identity,
+        model_state_resolver=_resolved_artifact,
     )
 
     # Act
@@ -869,7 +1062,7 @@ def test_non_retryable_http_4xx_fails_immediately_without_external_detail() -> N
         timeout_seconds=60.0,
         requester=requester,
         sleeper=lambda _seconds: None,
-        model_identity_resolver=_resolved_identity,
+        model_state_resolver=_resolved_artifact,
     )
 
     # Act
@@ -922,7 +1115,7 @@ def test_http_429_honors_capped_retry_after() -> None:
         timeout_seconds=60.0,
         requester=requester,
         sleeper=sleeps.append,
-        model_identity_resolver=_resolved_identity,
+        model_state_resolver=_resolved_artifact,
     )
 
     # Act
@@ -976,7 +1169,7 @@ def test_http_429_honors_http_date_retry_after() -> None:
         timeout_seconds=60.0,
         requester=requester,
         sleeper=sleeps.append,
-        model_identity_resolver=_resolved_identity,
+        model_state_resolver=_resolved_artifact,
     )
 
     # Act
@@ -1123,8 +1316,13 @@ def _resolved_model(role: ModelRole) -> ResolvedModel:
     )
 
 
-def _resolved_identity(model: ResolvedModel) -> str:
-    return model.execution_identity.identifier
+def _resolved_artifact(model: ResolvedModel) -> ModelArtifact:
+    return ModelArtifact(
+        identity=model.execution_identity,
+        canonical_name=model.canonical_name,
+        runtime_identity=model.runtime_identity,
+        location=None,
+    )
 
 
 def _first_message(payload: Mapping[str, object]) -> Mapping[str, object]:

--- a/tests/video_selection/vision/test_ollama_vision_runtime.py
+++ b/tests/video_selection/vision/test_ollama_vision_runtime.py
@@ -158,6 +158,107 @@ def test_schema_failure_is_retried_once_with_stable_code() -> None:
     assert "secret chain of thought" not in second_prompt
 
 
+def test_truncated_response_is_retried_before_success() -> None:
+    """token上限で打ち切られた応答が一度だけ再試行されること。
+
+    Arrange:
+        - 初回だけdone reasonがlengthとなるschema-valid responseが用意される
+    Act:
+        - Scene Catalog推論が実行される
+    Assert:
+        - 打ち切り応答が採用されずstable code付きで再試行されること
+    """
+    # Arrange
+    payloads: list[Mapping[str, object]] = []
+
+    def requester(
+        _method: str,
+        _url: str,
+        payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        assert payload is not None
+        payloads.append(payload)
+        response = _response(_catalog_payload())
+        if len(payloads) == 1:
+            response["done_reason"] = "length"
+        return response
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    catalog, diagnostics = runtime.create_scene_catalog(
+        SceneCatalogRequest(
+            representatives=(FrameCandidate("frame-a", b"image-a"),),
+            selection_intent="ブログ画像を分類する",
+        ),
+        _resolved_model(ModelRole.SCENE_CATALOG),
+        num_ctx=32768,
+    )
+
+    # Assert
+    assert catalog.slugs[-1] == "other"
+    assert diagnostics.attempt_count == 2
+    assert diagnostics.validation_code == "scene_catalog_response_truncated"
+    assert len(payloads) == 2
+    second_prompt = _first_message(payloads[1])["content"]
+    assert isinstance(second_prompt, str)
+    assert "scene_catalog_response_truncated" in second_prompt
+
+
+def test_repeated_truncated_response_fails_after_one_retry() -> None:
+    """打ち切り応答が2回続いた場合にrunが停止されること。
+
+    Arrange:
+        - done reasonがlengthとなるschema-valid responseが用意される
+    Act:
+        - Scene Catalog推論が実行される
+    Assert:
+        - 2回だけrequestされresponse_truncatedで失敗すること
+    """
+    # Arrange
+    calls = 0
+
+    def requester(
+        _method: str,
+        _url: str,
+        _payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        nonlocal calls
+        calls += 1
+        response = _response(_catalog_payload())
+        response["done_reason"] = "length"
+        return response
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    # Assert
+    with pytest.raises(VisionRuntimeError) as captured:
+        runtime.create_scene_catalog(
+            SceneCatalogRequest(
+                representatives=(FrameCandidate("frame-a", b"image-a"),),
+                selection_intent="ブログ画像を分類する",
+            ),
+            _resolved_model(ModelRole.SCENE_CATALOG),
+            num_ctx=32768,
+        )
+    assert calls == 2
+    assert captured.value.reason is VisionRuntimeFailureReason.RESPONSE_INVALID
+    assert captured.value.validation_code == "scene_catalog_response_truncated"
+
+
 def test_candidate_domain_failure_stops_without_other_fallback() -> None:
     """Candidate Annotation domain failureが2回後にrun停止へ変換されること。
 
@@ -251,6 +352,170 @@ def test_candidate_without_context_is_explicitly_unavailable() -> None:
     assert diagnostics.context_cue_count == 0
 
 
+def test_candidate_without_context_rejects_none_relevance() -> None:
+    """Context Cueなしでnone relevanceが返された場合に拒否されること。
+
+    Arrange:
+        - Context CueなしのCandidateとnone responseが用意される
+    Act:
+        - Candidate Annotation推論が実行される
+    Assert:
+        - unavailable以外がdomain invalidとして拒否されること
+    """
+    # Arrange
+    request = _annotation_request()
+    request_without_context = CandidateAnnotationRequest(
+        moment=request.moment,
+        frame_candidates=request.frame_candidates,
+        context_cues=(),
+        video_set_progress=request.video_set_progress,
+        selection_intent=request.selection_intent,
+        cue_selection_policy_version=request.cue_selection_policy_version,
+    )
+    response = _annotation_payload()
+    response["context_relevance"] = "none"
+    response["supporting_context_cue_ids"] = []
+    response["spoiler_risk"] = "none"
+    response["spoiler_evidence"] = ""
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=lambda _method, _url, _payload, _timeout: _response(response),
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    # Assert
+    with pytest.raises(VisionRuntimeError) as captured:
+        runtime.annotate_candidate(
+            request_without_context,
+            _catalog(),
+            _resolved_model(ModelRole.CANDIDATE_ANNOTATION),
+            num_ctx=32768,
+        )
+    assert captured.value.reason is VisionRuntimeFailureReason.DOMAIN_INVALID
+    assert captured.value.validation_code == "candidate_annotation_domain_invalid"
+
+
+def test_candidate_with_context_rejects_unavailable_relevance() -> None:
+    """Context Cueありでunavailable relevanceが返された場合に拒否されること。
+
+    Arrange:
+        - Context CueありのCandidateとunavailable responseが用意される
+    Act:
+        - Candidate Annotation推論が実行される
+    Assert:
+        - Context Cueを評価しない応答がdomain invalidとして拒否されること
+    """
+    # Arrange
+    response = _annotation_payload()
+    response["context_relevance"] = "unavailable"
+    response["supporting_context_cue_ids"] = []
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=lambda _method, _url, _payload, _timeout: _response(response),
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    # Assert
+    with pytest.raises(VisionRuntimeError) as captured:
+        runtime.annotate_candidate(
+            _annotation_request(),
+            _catalog(),
+            _resolved_model(ModelRole.CANDIDATE_ANNOTATION),
+            num_ctx=32768,
+        )
+    assert captured.value.reason is VisionRuntimeFailureReason.DOMAIN_INVALID
+    assert captured.value.validation_code == "candidate_annotation_domain_invalid"
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ("annotation_summary", "frame_choice_reason", "spoiler_evidence"),
+)
+def test_candidate_rejects_verbatim_context_cue_in_free_text(
+    field_name: str,
+) -> None:
+    """Context Cue本文が自由文fieldへ逐語再出力された場合に拒否されること。
+
+    Arrange:
+        - Context Cue本文を一つの自由文fieldへそのまま返すresponseが用意される
+    Act:
+        - Candidate Annotation推論が実行される
+    Assert:
+        - raw textを含む応答がdomain invalidとして拒否されること
+    """
+    # Arrange
+    request = _annotation_request()
+    response = _annotation_payload()
+    response[field_name] = request.context_cues[0].text
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=lambda _method, _url, _payload, _timeout: _response(response),
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    # Assert
+    with pytest.raises(VisionRuntimeError) as captured:
+        runtime.annotate_candidate(
+            request,
+            _catalog(),
+            _resolved_model(ModelRole.CANDIDATE_ANNOTATION),
+            num_ctx=32768,
+        )
+    assert captured.value.reason is VisionRuntimeFailureReason.DOMAIN_INVALID
+    assert captured.value.validation_code == "candidate_annotation_domain_invalid"
+
+
+@pytest.mark.parametrize(
+    ("cue_text", "leaked_text"),
+    (
+        ("「正体は王だ」", "正体は王だ"),
+        ("王都は陥落した。次の目的地は北の塔だ。", "次の目的地は北の塔だ"),
+    ),
+)
+def test_candidate_rejects_normalized_or_partial_context_cue_quote(
+    cue_text: str,
+    leaked_text: str,
+) -> None:
+    """Context Cueの引用符除去または一部引用が拒否されること。
+
+    Arrange:
+        - 引用符付きまたは複数文のContext Cueが用意される
+        - Cueの正規化後全文または一文だけを返すresponseが用意される
+    Act:
+        - Candidate Annotation推論が実行される
+    Assert:
+        - 十分長い逐語spanを含む応答がdomain invalidとして拒否されること
+    """
+    # Arrange
+    request = _annotation_request_with_context_text(cue_text)
+    response = _annotation_payload()
+    response["annotation_summary"] = leaked_text
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=lambda _method, _url, _payload, _timeout: _response(response),
+        sleeper=lambda _seconds: None,
+    )
+
+    # Act
+    # Assert
+    with pytest.raises(VisionRuntimeError) as captured:
+        runtime.annotate_candidate(
+            request,
+            _catalog(),
+            _resolved_model(ModelRole.CANDIDATE_ANNOTATION),
+            num_ctx=32768,
+        )
+    assert captured.value.reason is VisionRuntimeFailureReason.DOMAIN_INVALID
+    assert captured.value.validation_code == "candidate_annotation_domain_invalid"
+
+
 def test_retryable_transport_failure_is_retried_with_same_semantic_input() -> None:
     """一時transport failureが同じsemantic入力で一度だけ再試行されること。
 
@@ -298,6 +563,10 @@ def test_retryable_transport_failure_is_retried_with_same_semantic_input() -> No
     assert (
         _first_message(payloads[0])["images"] == _first_message(payloads[1])["images"]
     )
+    assert (
+        _first_message(payloads[0])["content"] == _first_message(payloads[1])["content"]
+    )
+    assert "ollama_transport_failure" not in str(_first_message(payloads[1])["content"])
 
 
 def test_non_retryable_http_4xx_fails_immediately_without_external_detail() -> None:
@@ -495,6 +764,26 @@ def _annotation_request() -> CandidateAnnotationRequest:
         video_set_progress=Fraction(1, 2),
         selection_intent="ブログ本文を説明できる画像を選ぶ",
         cue_selection_policy_version="nearby-context-v1",
+    )
+
+
+def _annotation_request_with_context_text(text: str) -> CandidateAnnotationRequest:
+    request = _annotation_request()
+    cue = request.context_cues[0]
+    return CandidateAnnotationRequest(
+        moment=request.moment,
+        frame_candidates=request.frame_candidates,
+        context_cues=(
+            ContextCue(
+                identifier=cue.identifier,
+                start=cue.start,
+                end=cue.end,
+                text=text,
+            ),
+        ),
+        video_set_progress=request.video_set_progress,
+        selection_intent=request.selection_intent,
+        cue_selection_policy_version=request.cue_selection_policy_version,
     )
 
 


### PR DESCRIPTION
## 概要

- 最大24画像を受け取るVideo Set共有Scene Catalogと、Moment単位Candidate Annotationのdomain contractを追加
- Ollama /api/chatのJSON Schema structured outputs、stream=false、think=false、temperature=0を実装
- schema検証後のFrame Candidate、Scene Slug、Context Cue所属・有無・Relevance検証を追加
- transport・空応答・打ち切り・schema・domain failureを初回と1回のretryへ限定
- transport retryは元のpromptを維持し、response/schema/domain retryだけstable validation codeで修復
- 推論前後にconfigured Ollama tagのdigestとserver runtimeを再確認し、freeze済みstateから変化した応答を破棄
- Scene CatalogはVideo Set単位、Candidate AnnotationはMoment単位のatomic Completed Stageとしてcache・再開
- 同一Stage Fingerprintの推論をlock内で一度だけ実行し、並行workerは確定artifactを復元
- canonical形式を検証済みのmodel identity、runtime、attempt、token、durationをprivacy-safeな診断として保存
- READMEとVideo Set Vision Stageの運用文書を更新

## 主な仕様判断

- modelはscene、Blog Image Type、Explanation Value、Screen Text Kind、Context Cue Relevance、Spoiler Riskだけを判断する
- Quality Score、confidence、final score、soft coverage、eligible・selected flagはmodel schemaへ含めない
- failure時にother fallback、画像・Cue削減、失敗Candidateのsilent exclusionを行わない
- prompt body、raw response、chain of thought、Context Cue本文、absolute path、credentialをcache artifactへ保存しない
- 自由文へ逐語再出力されたContext Cue本文は正規化・部分span照合でdomain invalidとして拒否する
- 要求画像枚数、spoiler sensitivity、soft coverage、output pathはmodel contentのfingerprintへ含めない
- Representative Setの上流Frame Candidate Extraction fingerprintはScene Catalog fingerprintへ含める
- PR baseがintegration branchのためpublic CLIとpackage versionは変更しない

## 検証

- uv run task test: 456 passed
- Ruff format・Ruff check・strict mypy成功
- fake VisionRuntime goldenで推論前後のmodel/runtime identity変更、schema/domain/transport failure、空・打ち切り応答、retry成功・失敗、秒数／HTTP-dateのRetry-Afterを検証
- 推論前tag確認の429および非retryable 4xx、Context Cue有無・3文字以上の逐語拒否・1〜2文字の誤検知回避、canonical diagnostic identityを検証
- runtime返却Frame CandidateのID・画像・metadata一致、warm cache、同一fingerprintの並行処理、途中失敗後のMoment単位再開、private text非保存を検証

## Follow-up

- deterministic Video Set selectorとSelection Shortlist拡張は#186で実装
- real Ollama最大24画像・target性能受け入れは#189で実施

関連: #185
