### PR TITLE
feat: 決定的なVideo Set最終selectorを実装

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -400,6 +400,10 @@ _Avoid_: Spoiler Risk, story progress, hard reject
 Spoiler SensitivityとSpoiler Riskの組み合わせから、0から1の選定utilityに適用する決定的な減点。`low`ではriskが`medium`、`high`のとき0.02、0.05、`medium`では`low`、`medium`、`high`のとき0.01、0.04、0.10、`high`では0.02、0.08、0.18とし、riskが`none`なら常に0とする。
 _Avoid_: hard reject, late-video penalty, model confidence
 
+**Spoiler Monotonicity Guard**:
+同じBlog Candidate集合でSpoiler Sensitivityを上げたとき、Major Spoiler Signalを持つ選択画像数が増えないようにする最終選定の件数境界。`medium`は`low`、`high`は`medium`の選択件数を上限としてgreedy選定を再実行し、個々の候補をriskだけで常時除外するhard cutoffとは区別する。
+_Avoid_: per-candidate spoiler rejection, late-video cutoff, model safety filter
+
 **Quality Score**:
 blog candidate がブログ画像としてどれだけ使いやすいかを表す評価値。scene の種類やゲームジャンルの指示ではなく、画像そのものの見やすさを表す。
 _Avoid_: scene hint, user-facing mode, selection profile
@@ -423,6 +427,14 @@ _Avoid_: all Candidate Moments, annotated Blog Candidate, selected output
 **Selection Shortfall**:
 有効な未注釈Candidate Momentを決定的なshortlist順で追加し、許可された視覚類似度緩和をすべて適用しても、適格なBlog Candidateが要求枚数に満たない状態。選べた画像とshortfall理由をreportへ出してwarning付きで正常終了し、Ollama Stage Failureとは区別する。
 _Avoid_: Candidate Annotation failure, silent omission, fabricated output, invalid-frame fallback
+
+**Selection Rejection Reason**:
+未採用Blog Candidateの主因を表すstable enum。`title_limit`、`visual_near_duplicate`、`similarity_ceiling`、`spoiler_monotonicity_guard`、`lower_marginal_utility`を持ち、model自由文や例外messageから推測しない。
+_Avoid_: free-text rejection, Content Reject Reason, Ollama Stage Failure
+
+**Counterfactual Selection Score**:
+未採用Blog Candidateが選定中に持ち得た最も高いMarginal Selection Utilityと、そのBase、coverage、spoiler、temporal、similarity passの内訳。採用を妨げた制約を説明するnear-miss診断であり、制約を無視して実際に選び直した結果ではない。
+_Avoid_: final selected score, model confidence, regenerated explanation
 
 **Neutral Image Analysis**:
 sceneやSelection Intent、modelに依存せず、Frame Candidateそのものから得られる画質metrics、Quality Score、正規化済みHSV・輝度・edge視覚特徴。画像の内容分類ではなく、blog candidate判定や動画横断のcosine similarity判定の土台になる。明確な無効frameには絶対条件、暗いgameなど入力特性にはRefinement Window Group内の分布、Transition Frameには同一streamとtime baseでdurationどおりに連続するnative frameだけの前後関係を使う。CLIPやHugging Face model identityをVideo Stageへ持ち込まない。

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## 動画入力版の設計と内部実装（公開前）
 
-複数のゲーム録画を一つのVideo Setとして扱う次期interfaceは、次の一つのcommandへ置き換える設計です。探索・content identity・Input Lock・Completed Stage cache、system FFmpeg/ffprobeを閉じ込めるMediaRuntimeに加え、動画単位のscan、exact timeline、Candidate Moment、native frame refinement、model-free Neutral Image Analysis、embedded subtitle/audio STTからのContext Cue収集、Ollama/Hugging Faceのmodel lifecycleとrun単位のidentity freeze、共有Scene CatalogとMoment単位のCandidate Annotationまで内部実装済みです。決定的な最終selector、public CLIの接続と切り替えは後続Issueで行うため、このcommandはまだ実行できません。
+複数のゲーム録画を一つのVideo Setとして扱う次期interfaceは、次の一つのcommandへ置き換える設計です。探索・content identity・Input Lock・Completed Stage cache、system FFmpeg/ffprobeを閉じ込めるMediaRuntimeに加え、動画単位のscan、exact timeline、Candidate Moment、native frame refinement、model-free Neutral Image Analysis、embedded subtitle/audio STTからのContext Cue収集、Ollama/Hugging Faceのmodel lifecycleとrun単位のidentity freeze、共有Scene Catalog、Moment単位のCandidate Annotation、soft coverage・spoiler・動画横断diversityを扱う決定的な最終selectorまで内部実装済みです。canonical reportとpublic CLIの接続・切り替えは後続Issueで行うため、このcommandはまだ実行できません。
 
 ```bash
 game-screen-pick \
@@ -18,6 +18,7 @@ game-screen-pick \
 - [動画入力とCLI](docs/video-input.md)
 - [動画単位のscan、timeline、Frame Candidate、Context Cue cache](docs/video-stage.md)
 - [共有Scene CatalogとCandidate Annotation Stage](docs/vision-stage.md)
+- [決定的なVideo Set最終選定Stage](docs/selection-stage.md)
 - [TOML、優先順位、model更新](docs/configuration.md)
 - [runtime、cache、進捗、エラー、WSL2運用](docs/operations.md)
 - [選択画像とreport](docs/report.md)

--- a/docs/adr/0004-select-video-set-blog-images-deterministically.md
+++ b/docs/adr/0004-select-video-set-blog-images-deterministically.md
@@ -49,7 +49,13 @@ Spoiler Sensitivity is a run setting with `low`, `medium`, and `high`; the defau
 | `medium` | 0.02 | 0.04 | 0.08 |
 | `high` | 0.05 | 0.10 | 0.18 |
 
-All values are soft penalties. No sensitivity level rejects a candidate.
+All table values are soft penalties; no table entry is a per-candidate hard
+rejection. Because greedy coverage and diversity interactions can otherwise make
+a higher sensitivity select more major spoilers, the selector also applies a
+deterministic monotonicity guard: `medium` may select no more `high`-risk
+candidates than the same pool selected at `low`, and `high` may select no more
+than `medium`. Each guarded profile is recomputed from an empty selected set
+under its own penalty values and the immediately lower profile's count limit.
 
 Risk boundaries are:
 
@@ -92,6 +98,7 @@ Visual similarity is an eligibility rule rather than another numeric penalty:
 
 - Normal selection begins at the configured similarity ceiling, whose default is 0.72.
 - If the current annotated pool cannot fill the request, the ceiling is relaxed through deterministic configured steps and ends at 0.98.
+- The built-in relaxation deltas are `+0.03`, `+0.06`, `+0.10`, and `+0.15`; duplicate capped values are removed and a terminal `0.98` pass is always appended.
 - A `recurring_gameplay` scene may use a ceiling of 0.98 after eligible Variant Groups have each had their first opportunity, allowing state variants without immediately expanding one group.
 - A pair with cosine similarity greater than 0.995 is a Visual Near-Duplicate and can never be selected together.
 
@@ -152,6 +159,6 @@ If seven gameplay and one event image have already been selected for `N=10`, a g
 
 Changing requested count, Spoiler Sensitivity, penalty weights, or coverage targets can reuse Candidate Annotation because these inputs affect only deterministic final selection. The selection-policy version must still be part of the final selection stage fingerprint.
 
-The report must retain enough diagnostic data to reproduce each decision: utility components, type targets and actuals, spoiler setting and penalty, progress distance and temporal penalty, visual threshold/pass, nearest selected similarity, Variant Group behavior, tie-break use, and Selection Shortfall reasons. The exact public report schema is decided with the CLI/config/report contract.
+The report must retain enough diagnostic data to reproduce each decision: utility components, type targets and actuals, spoiler setting and penalty, the monotonicity count limit, progress distance and temporal penalty, visual threshold/pass, nearest selected similarity, Variant Group behavior, tie-break use, and Selection Shortfall reasons. Unselected candidates retain their best observed counterfactual utility and one stable rejection code. The exact public report schema is decided with the CLI/config/report contract.
 
 Greedy selection is intentionally preferred over a global optimizer: it is deterministic, incremental, and reportable, while still allowing coverage and temporal effects to react after each selected image.

--- a/docs/selection-stage.md
+++ b/docs/selection-stage.md
@@ -68,4 +68,4 @@ Video Orderや後半位置そのものへの加点・減点、動画ごとの最
 - `spoiler_monotonicity_guard`
 - `lower_marginal_utility`
 
-選定policyのStage versionは`video-set-selection-v1`です。
+現行アプリケーションはまだ旧first-N selectorを実行するため、`select-images`のStage versionは`walking-skeleton-0`を維持します。決定的selectorを実行経路へ接続するIssue #189で、Stage versionも同時に更新します。

--- a/docs/selection-stage.md
+++ b/docs/selection-stage.md
@@ -1,0 +1,71 @@
+# Video Set最終選定Stage
+
+この文書は、公開前の動画入力selectorが注釈済みBlog Candidateから要求枚数を決定的に選ぶ内部契約を説明します。installed public CLIはIssue #190までscreenshot入力のままです。
+
+## Module seam
+
+`select_video_set_images`は、Candidate AnnotationとNeutral Image Analysisを結合したBlog Candidate集合を受け取り、次を一つの結果として返します。
+
+- 選択順付きのBlog Candidate
+- Base、coverage、spoiler、temporal、marginal utility
+- 選択時のsimilarity passと最も近い選択画像とのcosine similarity
+- Variant Group、stable reason code、tie-break使用有無
+- Blog Image Typeの目標と実績
+- 未採用候補のstable rejection、blocking ID、Counterfactual Selection Score
+- Selection Shortfall、最終similarity ceiling、Major Spoiler件数境界
+
+Candidate Annotationのsummary、spoiler evidence、Context Cue本文は採点式に使いません。Quality ScoreはNeutral Image Analysis、Explanation Value・Context Cue Relevance・Spoiler RiskはCandidate Annotationから取得し、modelに最終scoreや採否を問い合わせません。
+
+## Utilityとcoverage
+
+Selection Base Utilityは次の固定式です。
+
+```text
+0.70 * Quality Score
++ 0.25 * Explanation Value
++ 0.05 * Context Cue Relevance
+```
+
+Explanation Valueは`none=0`、`low=1/3`、`medium=2/3`、`high=1`、Context Cue Relevanceは`unavailable/none=0`、`weak=0.5`、`strong=1`へ変換します。
+
+要求枚数に対する`normal_gameplay=70%`、`event=25%`、`menu=5%`の目標は最大剰余法で丸めます。同率はこのtype順です。目標未達候補へ`+0.10`、最初のtitleへ`+0.05`を加えますが、超過を減点せず、候補が偏っていてもhard quotaにしません。titleだけは最大1枚です。
+
+## Spoilerと単調性
+
+ADR 0004の表に従うSpoiler Penaltyは候補単体へのsoft penaltyです。greedyなcoverage・diversityの相互作用によって高い感度のMajor Spoiler件数が逆に増えないよう、次の順で同じ候補集合を再選定します。
+
+1. `low`を件数上限なしで選ぶ。
+2. `medium`を`low`のMajor Spoiler選択数以下で選ぶ。
+3. `high`を`medium`のMajor Spoiler選択数以下で選ぶ。
+
+このguardで未採用になった候補は`spoiler_monotonicity_guard`として説明します。Video Set ProgressだけでSpoiler Riskを変更しません。
+
+## 視覚・時間的多様性
+
+通常のsimilarity ceilingは設定値から開始し、`+0.03`、`+0.06`、`+0.10`、`+0.15`の決定的passを適用して、必ず終端`0.98`へ進みます。上限で同じ値になるpassは重複させません。cosine similarityが`0.995`を超える組はVisual Near-Duplicateとして、shortfall時にも同時採用しません。
+
+同じsceneでsimilarityが`0.95`以上の連結成分を安定したVariant Groupにします。`recurring_gameplay`で同じGroupの2枚目を選ぶ前に、そのpassで適格な未代表Groupへ一度ずつ機会を与えます。全Groupの代表後はVisual Near-Duplicateを除き`0.98`までvariantを広げます。旧Cinematic Soft Capは適用しません。
+
+Temporal Diversity Penaltyは、要求枚数`N`と最も近い選択済みVideo Set Progress距離`d`から次の式で求めます。
+
+```text
+0.08 * max(0, 1 - d / (1 / N))
+```
+
+Video Orderや後半位置そのものへの加点・減点、動画ごとの最低枠はありません。
+
+## 決定性、Shortlist拡張、shortfall
+
+各greedy stepはMarginal Selection Utility、低いSpoiler Penalty、高いQuality Score、低い最大visual similarity、Video Order、Video Time、Frame Candidate IDの順で比較します。入力tupleの列挙順は結果へ影響しません。
+
+`select_from_shortlist_batches`は初期注釈batchでshortfallになった場合だけ次の決定的batchを受け取り、拡張済みpoolを空の選択状態から再計算します。以前の緩和passで選んだ候補を固定しません。batchの生成、Candidate Annotation、batch sizeの性能上限は呼び出し側とIssue #189が所有します。
+
+全Candidate Momentを使い切っても不足する場合は、選べた画像だけを正常結果として返します。2枚目のtitle、Visual Near-Duplicate、不適格frame、未完了Annotationでは穴埋めしません。未採用候補はCounterfactual Selection Scoreの降順と同じstable tie-breakで返し、主因を次のenumで示します。
+
+- `title_limit`
+- `visual_near_duplicate`
+- `similarity_ceiling`
+- `spoiler_monotonicity_guard`
+- `lower_marginal_utility`
+
+選定policyのStage versionは`video-set-selection-v1`です。

--- a/docs/selection-stage.md
+++ b/docs/selection-stage.md
@@ -38,7 +38,7 @@ ADR 0004の表に従うSpoiler Penaltyは候補単体へのsoft penaltyです。
 2. `medium`を`low`のMajor Spoiler選択数以下で選ぶ。
 3. `high`を`medium`のMajor Spoiler選択数以下で選ぶ。
 
-このguardで未採用になった候補は`spoiler_monotonicity_guard`として説明します。Video Set ProgressだけでSpoiler Riskを変更しません。
+このguardで未採用になった候補は`spoiler_monotonicity_guard`として説明します。guardで採用不能な候補はrecurring gameplayの未代表Variant Groupへ機会を与える判定から除外します。Video Set ProgressだけでSpoiler Riskを変更しません。
 
 ## 視覚・時間的多様性
 
@@ -60,7 +60,7 @@ Video Orderや後半位置そのものへの加点・減点、動画ごとの最
 
 `select_from_shortlist_batches`は初期注釈batchでshortfallになった場合だけ次の決定的batchを受け取り、拡張済みpoolを空の選択状態から再計算します。以前の緩和passで選んだ候補を固定しません。batchの生成、Candidate Annotation、batch sizeの性能上限は呼び出し側とIssue #189が所有します。
 
-全Candidate Momentを使い切っても不足する場合は、選べた画像だけを正常結果として返します。2枚目のtitle、Visual Near-Duplicate、不適格frame、未完了Annotationでは穴埋めしません。未採用候補はCounterfactual Selection Scoreの降順と同じstable tie-breakで返し、主因を次のenumで示します。
+全Candidate Momentを使い切っても不足する場合は、選べた画像だけを正常結果として返します。2枚目のtitle、Visual Near-Duplicate、不適格frame、未完了Annotationでは穴埋めしません。未採用候補のSimilarity Ceilingは要求数を満たした時点、またはshortfallで最後まで到達した実際の最終passを基準にします。未採用候補はCounterfactual Selection Scoreの降順と同じstable tie-breakで返し、主因を次のenumで示します。
 
 - `title_limit`
 - `visual_near_duplicate`

--- a/docs/vision-stage.md
+++ b/docs/vision-stage.md
@@ -35,7 +35,7 @@ Candidate Annotation v1は次の意味情報だけを返します。
 - Spoiler Riskと引用を含まないevidence summary
 - annotation summaryとRepresentative Frameの選択理由
 
-Quality Score、model confidence、final score、soft coverage、eligible/selected flag、生成した逐語的画面テキスト、reasoning traceはschemaに含めません。最終採否は[`video-set-selection-v1`](selection-stage.md)の決定的selectorが所有します。
+Quality Score、model confidence、final score、soft coverage、eligible/selected flag、生成した逐語的画面テキスト、reasoning traceはschemaに含めません。最終採否は[Video Set最終選定Stage](selection-stage.md)の決定的selectorが所有します。
 
 ## Retryとfailure
 

--- a/docs/vision-stage.md
+++ b/docs/vision-stage.md
@@ -12,7 +12,7 @@
 - 決定的なlocal順を持つSelection ShortlistのCandidate Annotation request
 - Effective Configurationとrun中にfreeze済みのResolved Models
 
-Scene Catalog Representative Setは要求画像枚数から独立します。Selection Shortlistの初期sizeと不足時の拡張は、決定的selectorとcapacity acceptanceを実装する後続Issue #186・#189が所有します。Candidate Annotation requestには1〜3件のFrame Candidate、versioned policyで選ばれた近傍Context Cue、Video Set Progress、Selection Intentを明示し、VisionRuntimeが暗黙に候補やCueを削りません。
+Scene Catalog Representative Setは要求画像枚数から独立します。Selection Shortlistは決定的selectorが不足時に追加batchを受けて拡張し、batch sizeと実model capacityの受け入れはIssue #189が所有します。Candidate Annotation requestには1〜3件のFrame Candidate、versioned policyで選ばれた近傍Context Cue、Video Set Progress、Selection Intentを明示し、VisionRuntimeが暗黙に候補やCueを削りません。
 
 ## Ollama operation
 
@@ -35,7 +35,7 @@ Candidate Annotation v1は次の意味情報だけを返します。
 - Spoiler Riskと引用を含まないevidence summary
 - annotation summaryとRepresentative Frameの選択理由
 
-Quality Score、model confidence、final score、soft coverage、eligible/selected flag、生成した逐語的画面テキスト、reasoning traceはschemaに含めません。最終採否はIssue #186の決定的selectorが所有します。
+Quality Score、model confidence、final score、soft coverage、eligible/selected flag、生成した逐語的画面テキスト、reasoning traceはschemaに含めません。最終採否は[`video-set-selection-v1`](selection-stage.md)の決定的selectorが所有します。
 
 ## Retryとfailure
 

--- a/src/video_selection/models/blog_candidate.py
+++ b/src/video_selection/models/blog_candidate.py
@@ -1,0 +1,60 @@
+"""最終選定へ渡す注釈済みBlog Candidate。"""
+
+import math
+from dataclasses import dataclass
+from fractions import Fraction
+
+from .candidate_annotation import CandidateAnnotation
+from .scene_catalog_entry import SCENE_SELECTION_ROLES, SceneSelectionRole
+
+
+@dataclass(frozen=True)
+class BlogCandidate:
+    """Annotationと決定的selectorに必要なlocal値を保持する。"""
+
+    annotation: CandidateAnnotation
+    scene_selection_role: SceneSelectionRole
+    video_order: int
+    video_set_progress: Fraction
+    shortlist_rank: int
+
+    def __post_init__(self) -> None:
+        """有効なRepresentative Frameと安定した順序値だけを受理する。"""
+        frame = self.annotation.candidate
+        analysis = frame.analysis
+        if (
+            analysis is None
+            or not analysis.eligible
+            or frame.video_time is None
+            or self.scene_selection_role not in SCENE_SELECTION_ROLES
+            or self.video_order < 0
+            or not 0 <= self.video_set_progress < 1
+            or self.shortlist_rank < 0
+            or not 0 <= analysis.quality_score <= 1
+            or not math.isfinite(analysis.quality_score)
+            or not analysis.visual_feature
+            or any(not math.isfinite(value) for value in analysis.visual_feature)
+        ):
+            msg = "Blog Candidateには有効なframe、進行位置、local順が必要です"
+            raise ValueError(msg)
+
+    @property
+    def identifier(self) -> str:
+        """Representative Frameの安定IDを返す。"""
+        return self.annotation.candidate.identifier
+
+    @property
+    def quality_score(self) -> float:
+        """Neutral Image AnalysisのQuality Scoreを返す。"""
+        analysis = self.annotation.candidate.analysis
+        if analysis is None:  # pragma: no cover - __post_init__で保証される
+            raise AssertionError
+        return analysis.quality_score
+
+    @property
+    def visual_feature(self) -> tuple[float, ...]:
+        """Neutral Image Analysisの視覚特徴を返す。"""
+        analysis = self.annotation.candidate.analysis
+        if analysis is None:  # pragma: no cover - __post_init__で保証される
+            raise AssertionError
+        return analysis.visual_feature

--- a/src/video_selection/models/rejected_blog_candidate.py
+++ b/src/video_selection/models/rejected_blog_candidate.py
@@ -1,0 +1,20 @@
+"""Video Set selectorが採用しなかったBlog Candidate。"""
+
+from dataclasses import dataclass
+
+from .blog_candidate import BlogCandidate
+from .selection_rejection_reason import SelectionRejectionReason
+from .selection_score import SelectionScore
+
+
+@dataclass(frozen=True)
+class RejectedBlogCandidate:
+    """stable reasonと採用を妨げた選択画像を保持する。"""
+
+    candidate: BlogCandidate
+    reason_code: SelectionRejectionReason
+    counterfactual_score: SelectionScore
+    blocked_by_image_id: str | None
+    nearest_selected_image_id: str | None
+    similarity: float | None
+    variant_group_id: str

--- a/src/video_selection/models/selected_blog_image.py
+++ b/src/video_selection/models/selected_blog_image.py
@@ -1,0 +1,18 @@
+"""決定的selectorが選んだ一つのBlog Candidate。"""
+
+from dataclasses import dataclass
+
+from .blog_candidate import BlogCandidate
+from .selection_score import SelectionScore
+
+
+@dataclass(frozen=True)
+class SelectedBlogImage:
+    """選択順、数値内訳、stable reason codeを保持する。"""
+
+    candidate: BlogCandidate
+    selection_index: int
+    score: SelectionScore
+    reason_codes: tuple[str, ...]
+    variant_group_id: str
+    tie_break_applied: bool

--- a/src/video_selection/models/selection_rejection_reason.py
+++ b/src/video_selection/models/selection_rejection_reason.py
@@ -1,0 +1,13 @@
+"""Video Set selectorのstable rejection reason。"""
+
+from enum import StrEnum
+
+
+class SelectionRejectionReason(StrEnum):
+    """未採用Blog Candidateの排他的な主理由。"""
+
+    TITLE_LIMIT = "title_limit"
+    VISUAL_NEAR_DUPLICATE = "visual_near_duplicate"
+    SIMILARITY_CEILING = "similarity_ceiling"
+    SPOILER_MONOTONICITY_GUARD = "spoiler_monotonicity_guard"
+    LOWER_MARGINAL_UTILITY = "lower_marginal_utility"

--- a/src/video_selection/models/selection_score.py
+++ b/src/video_selection/models/selection_score.py
@@ -1,0 +1,16 @@
+"""一回のgreedy選択時点におけるutility内訳。"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SelectionScore:
+    """selector判断を再現する数値componentを保持する。"""
+
+    base_utility: float
+    spoiler_penalty: float
+    coverage_bonus: float
+    temporal_diversity_penalty: float
+    marginal_utility: float
+    similarity_pass: float
+    nearest_selected_similarity: float | None

--- a/src/video_selection/models/video_set_selection_result.py
+++ b/src/video_selection/models/video_set_selection_result.py
@@ -1,0 +1,42 @@
+"""Video Set最終選定の結果。"""
+
+from dataclasses import dataclass
+
+from .rejected_blog_candidate import RejectedBlogCandidate
+from .selected_blog_image import SelectedBlogImage
+
+
+@dataclass(frozen=True)
+class VideoSetSelectionResult:
+    """選択画像と選定時のcoverage・similarity状態を保持する。"""
+
+    selected: tuple[SelectedBlogImage, ...]
+    rejected: tuple[RejectedBlogCandidate, ...]
+    requested_count: int
+    blog_image_type_targets: dict[str, int]
+    blog_image_type_actuals: dict[str, int]
+    final_similarity_ceiling: float
+    major_spoiler_limit: int | None
+    annotated_candidate_count: int
+    shortlist_expansion_count: int
+    all_candidate_moments_exhausted: bool
+
+    @property
+    def shortfall(self) -> bool:
+        """要求枚数へ到達しなかったかを返す。"""
+        return len(self.selected) < self.requested_count
+
+    @property
+    def major_spoiler_selected_count(self) -> int:
+        """Major Spoiler Signalを持つ選択画像数を返す。"""
+        return sum(
+            item.candidate.annotation.spoiler_risk == "high" for item in self.selected
+        )
+
+    @property
+    def rejection_counts(self) -> dict[str, int]:
+        """未採用候補をstable reason code別に集計する。"""
+        counts: dict[str, int] = {}
+        for item in self.rejected:
+            counts[item.reason_code.value] = counts.get(item.reason_code.value, 0) + 1
+        return counts

--- a/src/video_selection/services/select_video_set_images.py
+++ b/src/video_selection/services/select_video_set_images.py
@@ -34,12 +34,23 @@ _SPOILER_PENALTIES: Mapping[SpoilerSensitivity, Mapping[str, float]] = {
     "medium": {"none": 0.0, "low": 0.01, "medium": 0.04, "high": 0.10},
     "high": {"none": 0.0, "low": 0.02, "medium": 0.08, "high": 0.18},
 }
+_SPOILER_SENSITIVITY_ORDER: tuple[SpoilerSensitivity, ...] = (
+    "low",
+    "medium",
+    "high",
+)
 _COVERAGE_TYPES = ("normal_gameplay", "event", "menu")
 _COVERAGE_PERCENTAGES = (70, 25, 5)
 _SIMILARITY_RELAXATION_DELTAS = (0.03, 0.06, 0.10, 0.15)
 _MAX_SIMILARITY_CEILING = 0.98
 _VISUAL_NEAR_DUPLICATE_THRESHOLD = 0.995
 _VARIANT_GROUP_SIMILARITY_THRESHOLD = 0.95
+_SIMILARITY_REJECTION_REASONS = frozenset(
+    {
+        SelectionRejectionReason.VISUAL_NEAR_DUPLICATE,
+        SelectionRejectionReason.SIMILARITY_CEILING,
+    }
+)
 
 
 def select_from_shortlist_batches(
@@ -99,37 +110,19 @@ def select_video_set_images(
         spoiler_sensitivity,
         similarity_threshold,
     )
-    if spoiler_sensitivity == "low":
-        return _select_with_major_spoiler_limit(
+    major_spoiler_limit: int | None = None
+    for current_sensitivity in _SPOILER_SENSITIVITY_ORDER:
+        result = _select_with_major_spoiler_limit(
             candidates,
             requested_count=requested_count,
-            spoiler_sensitivity="low",
+            spoiler_sensitivity=current_sensitivity,
             similarity_threshold=similarity_threshold,
-            major_spoiler_limit=None,
+            major_spoiler_limit=major_spoiler_limit,
         )
-    low_result = _select_with_major_spoiler_limit(
-        candidates,
-        requested_count=requested_count,
-        spoiler_sensitivity="low",
-        similarity_threshold=similarity_threshold,
-        major_spoiler_limit=None,
-    )
-    medium_result = _select_with_major_spoiler_limit(
-        candidates,
-        requested_count=requested_count,
-        spoiler_sensitivity="medium",
-        similarity_threshold=similarity_threshold,
-        major_spoiler_limit=low_result.major_spoiler_selected_count,
-    )
-    if spoiler_sensitivity == "medium":
-        return medium_result
-    return _select_with_major_spoiler_limit(
-        candidates,
-        requested_count=requested_count,
-        spoiler_sensitivity="high",
-        similarity_threshold=similarity_threshold,
-        major_spoiler_limit=medium_result.major_spoiler_selected_count,
-    )
+        if current_sensitivity == spoiler_sensitivity:
+            return result
+        major_spoiler_limit = result.major_spoiler_selected_count
+    raise AssertionError("検証済みSpoiler Sensitivityを選定できません")
 
 
 def _select_with_major_spoiler_limit(
@@ -559,22 +552,11 @@ def _rejection(
         ),
         nearest_selected_image_id=(
             nearest_selected.candidate.identifier
-            if reason
-            in {
-                SelectionRejectionReason.VISUAL_NEAR_DUPLICATE,
-                SelectionRejectionReason.SIMILARITY_CEILING,
-            }
-            and nearest_selected is not None
+            if reason in _SIMILARITY_REJECTION_REASONS and nearest_selected is not None
             else None
         ),
         similarity=(
-            nearest_similarity
-            if reason
-            in {
-                SelectionRejectionReason.VISUAL_NEAR_DUPLICATE,
-                SelectionRejectionReason.SIMILARITY_CEILING,
-            }
-            else None
+            nearest_similarity if reason in _SIMILARITY_REJECTION_REASONS else None
         ),
         variant_group_id=variant_group_id,
     )

--- a/src/video_selection/services/select_video_set_images.py
+++ b/src/video_selection/services/select_video_set_images.py
@@ -176,6 +176,7 @@ def _select_with_major_spoiler_limit(
                     actuals,
                     similarity_pass,
                     variant_groups,
+                    major_spoiler_limit,
                 )
                 and not (
                     candidate.annotation.blog_image_type == "title"
@@ -235,6 +236,7 @@ def _select_with_major_spoiler_limit(
             variant_groups[candidate.identifier],
             counterfactual_scores[candidate.identifier],
             major_spoiler_limit,
+            final_similarity_ceiling,
         )
         for candidate in remaining
     ]
@@ -384,6 +386,7 @@ def _is_visually_eligible(
     actuals: Mapping[str, int],
     similarity_threshold: float,
     variant_groups: Mapping[str, str],
+    major_spoiler_limit: int | None,
 ) -> bool:
     nearest = _nearest_selected_similarity(candidate, selected)
     if nearest is not None and nearest > similarity_threshold:
@@ -405,6 +408,7 @@ def _is_visually_eligible(
             similarity_threshold,
             variant_groups,
             selected_groups,
+            major_spoiler_limit,
         )
     )
 
@@ -417,6 +421,7 @@ def _has_unrepresented_eligible_variant_group(
     similarity_threshold: float,
     variant_groups: Mapping[str, str],
     selected_groups: set[str],
+    major_spoiler_limit: int | None,
 ) -> bool:
     for alternative in remaining:
         if (
@@ -425,6 +430,11 @@ def _has_unrepresented_eligible_variant_group(
             or (
                 alternative.annotation.blog_image_type == "title"
                 and actuals["title"] >= 1
+            )
+            or _major_spoiler_limit_reached(
+                alternative,
+                selected,
+                major_spoiler_limit,
             )
         ):
             continue
@@ -510,6 +520,7 @@ def _rejection(
     variant_group_id: str,
     counterfactual_score: SelectionScore,
     major_spoiler_limit: int | None,
+    final_similarity_ceiling: float,
 ) -> RejectedBlogCandidate:
     nearest_similarity = _nearest_selected_similarity(candidate, selected)
     nearest_selected = _nearest_selected(candidate, selected)
@@ -529,7 +540,7 @@ def _rejection(
     ):
         reason = SelectionRejectionReason.VISUAL_NEAR_DUPLICATE
     elif (
-        nearest_similarity is not None and nearest_similarity > _MAX_SIMILARITY_CEILING
+        nearest_similarity is not None and nearest_similarity > final_similarity_ceiling
     ):
         reason = SelectionRejectionReason.SIMILARITY_CEILING
     elif _major_spoiler_limit_reached(

--- a/src/video_selection/services/select_video_set_images.py
+++ b/src/video_selection/services/select_video_set_images.py
@@ -1,0 +1,646 @@
+"""注釈済みBlog Candidateから画像を決定的に選ぶ。"""
+
+import hashlib
+import math
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from dataclasses import replace
+from fractions import Fraction
+from typing import Literal
+
+from ..models.blog_candidate import BlogCandidate
+from ..models.rejected_blog_candidate import RejectedBlogCandidate
+from ..models.selected_blog_image import SelectedBlogImage
+from ..models.selection_rejection_reason import SelectionRejectionReason
+from ..models.selection_score import SelectionScore
+from ..models.video_set_selection_result import VideoSetSelectionResult
+
+SpoilerSensitivity = Literal["low", "medium", "high"]
+
+_EXPLANATION_VALUES = {
+    "none": 0.0,
+    "low": 1 / 3,
+    "medium": 2 / 3,
+    "high": 1.0,
+}
+_CONTEXT_VALUES = {
+    "unavailable": 0.0,
+    "none": 0.0,
+    "weak": 0.5,
+    "strong": 1.0,
+}
+_SPOILER_PENALTIES: Mapping[SpoilerSensitivity, Mapping[str, float]] = {
+    "low": {"none": 0.0, "low": 0.0, "medium": 0.02, "high": 0.05},
+    "medium": {"none": 0.0, "low": 0.01, "medium": 0.04, "high": 0.10},
+    "high": {"none": 0.0, "low": 0.02, "medium": 0.08, "high": 0.18},
+}
+_COVERAGE_TYPES = ("normal_gameplay", "event", "menu")
+_COVERAGE_PERCENTAGES = (70, 25, 5)
+_SIMILARITY_RELAXATION_DELTAS = (0.03, 0.06, 0.10, 0.15)
+_MAX_SIMILARITY_CEILING = 0.98
+_VISUAL_NEAR_DUPLICATE_THRESHOLD = 0.995
+_VARIANT_GROUP_SIMILARITY_THRESHOLD = 0.95
+
+
+def select_from_shortlist_batches(
+    batches: Iterable[tuple[BlogCandidate, ...]],
+    *,
+    requested_count: int,
+    spoiler_sensitivity: SpoilerSensitivity,
+    similarity_threshold: float,
+) -> VideoSetSelectionResult:
+    """注釈済みShortlist batchを不足時だけ追加して全体を再選定する。"""
+    accumulated: list[BlogCandidate] = []
+    last_result: VideoSetSelectionResult | None = None
+    expansion_count = 0
+    for batch_index, batch in enumerate(batches):
+        if not batch:
+            msg = "Selection Shortlist expansion batchは空にできません"
+            raise ValueError(msg)
+        accumulated.extend(batch)
+        last_result = select_video_set_images(
+            tuple(accumulated),
+            requested_count=requested_count,
+            spoiler_sensitivity=spoiler_sensitivity,
+            similarity_threshold=similarity_threshold,
+        )
+        expansion_count = batch_index
+        if not last_result.shortfall:
+            return replace(
+                last_result,
+                shortlist_expansion_count=expansion_count,
+                all_candidate_moments_exhausted=False,
+            )
+    if last_result is None:
+        last_result = select_video_set_images(
+            (),
+            requested_count=requested_count,
+            spoiler_sensitivity=spoiler_sensitivity,
+            similarity_threshold=similarity_threshold,
+        )
+    return replace(
+        last_result,
+        shortlist_expansion_count=expansion_count,
+        all_candidate_moments_exhausted=True,
+    )
+
+
+def select_video_set_images(
+    candidates: tuple[BlogCandidate, ...],
+    *,
+    requested_count: int,
+    spoiler_sensitivity: SpoilerSensitivity,
+    similarity_threshold: float,
+) -> VideoSetSelectionResult:
+    """Blog Candidate集合からMarginal Selection Utility順に選ぶ。"""
+    _validate_inputs(
+        candidates,
+        requested_count,
+        spoiler_sensitivity,
+        similarity_threshold,
+    )
+    if spoiler_sensitivity == "low":
+        return _select_with_major_spoiler_limit(
+            candidates,
+            requested_count=requested_count,
+            spoiler_sensitivity="low",
+            similarity_threshold=similarity_threshold,
+            major_spoiler_limit=None,
+        )
+    low_result = _select_with_major_spoiler_limit(
+        candidates,
+        requested_count=requested_count,
+        spoiler_sensitivity="low",
+        similarity_threshold=similarity_threshold,
+        major_spoiler_limit=None,
+    )
+    medium_result = _select_with_major_spoiler_limit(
+        candidates,
+        requested_count=requested_count,
+        spoiler_sensitivity="medium",
+        similarity_threshold=similarity_threshold,
+        major_spoiler_limit=low_result.major_spoiler_selected_count,
+    )
+    if spoiler_sensitivity == "medium":
+        return medium_result
+    return _select_with_major_spoiler_limit(
+        candidates,
+        requested_count=requested_count,
+        spoiler_sensitivity="high",
+        similarity_threshold=similarity_threshold,
+        major_spoiler_limit=medium_result.major_spoiler_selected_count,
+    )
+
+
+def _select_with_major_spoiler_limit(
+    candidates: tuple[BlogCandidate, ...],
+    *,
+    requested_count: int,
+    spoiler_sensitivity: SpoilerSensitivity,
+    similarity_threshold: float,
+    major_spoiler_limit: int | None,
+) -> VideoSetSelectionResult:
+    """一つの感度とMajor Spoiler上限でgreedy選定する。"""
+    targets = _coverage_targets(requested_count)
+    actuals = dict.fromkeys((*_COVERAGE_TYPES, "title", "other"), 0)
+    variant_groups = _assign_variant_groups(candidates)
+    selected: list[SelectedBlogImage] = []
+    remaining = list(candidates)
+    counterfactual_scores: dict[str, SelectionScore] = {}
+    final_similarity_ceiling = similarity_threshold
+    for similarity_pass in _similarity_passes(similarity_threshold):
+        final_similarity_ceiling = similarity_pass
+        while remaining and len(selected) < requested_count:
+            scored = [
+                (
+                    candidate,
+                    _score(
+                        candidate,
+                        selected,
+                        targets,
+                        actuals,
+                        requested_count,
+                        spoiler_sensitivity,
+                        similarity_pass,
+                    ),
+                )
+                for candidate in remaining
+            ]
+            for candidate, score in scored:
+                previous = counterfactual_scores.get(candidate.identifier)
+                if (
+                    previous is None
+                    or score.marginal_utility > previous.marginal_utility
+                ):
+                    counterfactual_scores[candidate.identifier] = score
+            evaluated = [
+                (candidate, score)
+                for candidate, score in scored
+                if _is_visually_eligible(
+                    candidate,
+                    remaining,
+                    selected,
+                    actuals,
+                    similarity_pass,
+                    variant_groups,
+                )
+                and not (
+                    candidate.annotation.blog_image_type == "title"
+                    and actuals["title"] >= 1
+                )
+                and not _major_spoiler_limit_reached(
+                    candidate,
+                    selected,
+                    major_spoiler_limit,
+                )
+            ]
+            if not evaluated:
+                break
+            candidate, score = min(
+                evaluated,
+                key=lambda item: _selection_key(item[0], item[1]),
+            )
+            tie_break_applied = any(
+                other.identifier != candidate.identifier
+                and math.isclose(
+                    other_score.marginal_utility,
+                    score.marginal_utility,
+                    rel_tol=0,
+                    abs_tol=1e-12,
+                )
+                for other, other_score in evaluated
+            )
+            selected.append(
+                SelectedBlogImage(
+                    candidate=candidate,
+                    selection_index=len(selected) + 1,
+                    score=score,
+                    reason_codes=_reason_codes(
+                        candidate,
+                        score,
+                        variant_groups[candidate.identifier]
+                        in {
+                            item.variant_group_id
+                            for item in selected
+                            if item.candidate.annotation.scene_slug
+                            == candidate.annotation.scene_slug
+                        },
+                        tie_break_applied,
+                    ),
+                    variant_group_id=variant_groups[candidate.identifier],
+                    tie_break_applied=tie_break_applied,
+                )
+            )
+            actuals[candidate.annotation.blog_image_type] += 1
+            remaining.remove(candidate)
+        if len(selected) >= requested_count:
+            break
+    rejected = [
+        _rejection(
+            candidate,
+            selected,
+            variant_groups[candidate.identifier],
+            counterfactual_scores[candidate.identifier],
+            major_spoiler_limit,
+        )
+        for candidate in remaining
+    ]
+    rejected.sort(
+        key=lambda item: _selection_key(
+            item.candidate,
+            item.counterfactual_score,
+        )
+    )
+    return VideoSetSelectionResult(
+        selected=tuple(selected),
+        rejected=tuple(rejected),
+        requested_count=requested_count,
+        blog_image_type_targets=targets,
+        blog_image_type_actuals=actuals,
+        final_similarity_ceiling=final_similarity_ceiling,
+        major_spoiler_limit=major_spoiler_limit,
+        annotated_candidate_count=len(candidates),
+        shortlist_expansion_count=0,
+        all_candidate_moments_exhausted=True,
+    )
+
+
+def _similarity_passes(base_threshold: float) -> tuple[float, ...]:
+    candidates = (
+        base_threshold,
+        *(
+            min(base_threshold + delta, _MAX_SIMILARITY_CEILING)
+            for delta in _SIMILARITY_RELAXATION_DELTAS
+        ),
+        _MAX_SIMILARITY_CEILING,
+    )
+    return tuple(dict.fromkeys(candidates))
+
+
+def _validate_inputs(
+    candidates: tuple[BlogCandidate, ...],
+    requested_count: int,
+    spoiler_sensitivity: str,
+    similarity_threshold: float,
+) -> None:
+    identifiers = tuple(candidate.identifier for candidate in candidates)
+    moment_ids = tuple(
+        candidate.annotation.candidate_moment_id for candidate in candidates
+    )
+    shortlist_ranks = tuple(candidate.shortlist_rank for candidate in candidates)
+    feature_lengths = {len(candidate.visual_feature) for candidate in candidates}
+    if (
+        requested_count < 1
+        or spoiler_sensitivity not in _SPOILER_PENALTIES
+        or not math.isfinite(similarity_threshold)
+        or not 0 <= similarity_threshold <= 0.98
+        or len(identifiers) != len(set(identifiers))
+        or len(moment_ids) != len(set(moment_ids))
+        or len(shortlist_ranks) != len(set(shortlist_ranks))
+        or len(feature_lengths) > 1
+    ):
+        msg = "Video Set selectorの候補、要求枚数、設定が不正です"
+        raise ValueError(msg)
+
+
+def _coverage_targets(requested_count: int) -> dict[str, int]:
+    floors = [
+        requested_count * percentage // 100 for percentage in _COVERAGE_PERCENTAGES
+    ]
+    remaining = requested_count - sum(floors)
+    remainders = [
+        requested_count * percentage % 100 for percentage in _COVERAGE_PERCENTAGES
+    ]
+    allocation_order = sorted(
+        range(len(_COVERAGE_TYPES)),
+        key=lambda index: (-remainders[index], index),
+    )
+    for index in allocation_order[:remaining]:
+        floors[index] += 1
+    targets = {
+        image_type: floors[index] for index, image_type in enumerate(_COVERAGE_TYPES)
+    }
+    targets.update({"title": 0, "other": 0})
+    return targets
+
+
+def _score(
+    candidate: BlogCandidate,
+    selected: list[SelectedBlogImage],
+    targets: Mapping[str, int],
+    actuals: Mapping[str, int],
+    requested_count: int,
+    spoiler_sensitivity: SpoilerSensitivity,
+    similarity_pass: float,
+) -> SelectionScore:
+    annotation = candidate.annotation
+    base_utility = (
+        0.70 * candidate.quality_score
+        + 0.25 * _EXPLANATION_VALUES[annotation.explanation_value]
+        + 0.05 * _CONTEXT_VALUES[annotation.context_relevance]
+    )
+    spoiler_penalty = _SPOILER_PENALTIES[spoiler_sensitivity][annotation.spoiler_risk]
+    coverage_bonus = _coverage_bonus(candidate, targets, actuals)
+    temporal_penalty = _temporal_penalty(candidate, selected, requested_count)
+    nearest_similarity = _nearest_selected_similarity(candidate, selected)
+    return SelectionScore(
+        base_utility=base_utility,
+        spoiler_penalty=spoiler_penalty,
+        coverage_bonus=coverage_bonus,
+        temporal_diversity_penalty=temporal_penalty,
+        marginal_utility=(
+            base_utility + coverage_bonus - spoiler_penalty - temporal_penalty
+        ),
+        similarity_pass=similarity_pass,
+        nearest_selected_similarity=nearest_similarity,
+    )
+
+
+def _coverage_bonus(
+    candidate: BlogCandidate,
+    targets: Mapping[str, int],
+    actuals: Mapping[str, int],
+) -> float:
+    image_type = candidate.annotation.blog_image_type
+    if image_type in _COVERAGE_TYPES and actuals[image_type] < targets[image_type]:
+        return 0.10
+    if image_type == "title" and actuals["title"] == 0:
+        return 0.05
+    return 0.0
+
+
+def _temporal_penalty(
+    candidate: BlogCandidate,
+    selected: list[SelectedBlogImage],
+    requested_count: int,
+) -> float:
+    if not selected:
+        return 0.0
+    nearest_distance = min(
+        abs(candidate.video_set_progress - item.candidate.video_set_progress)
+        for item in selected
+    )
+    spacing = Fraction(1, requested_count)
+    return 0.08 * max(0.0, 1.0 - float(nearest_distance / spacing))
+
+
+def _is_visually_eligible(
+    candidate: BlogCandidate,
+    remaining: list[BlogCandidate],
+    selected: list[SelectedBlogImage],
+    actuals: Mapping[str, int],
+    similarity_threshold: float,
+    variant_groups: Mapping[str, str],
+) -> bool:
+    nearest = _nearest_selected_similarity(candidate, selected)
+    if nearest is not None and nearest > similarity_threshold:
+        return False
+    candidate_group = variant_groups[candidate.identifier]
+    selected_groups = {
+        item.variant_group_id
+        for item in selected
+        if item.candidate.annotation.scene_slug == candidate.annotation.scene_slug
+    }
+    return not (
+        candidate.scene_selection_role == "recurring_gameplay"
+        and candidate_group in selected_groups
+        and _has_unrepresented_eligible_variant_group(
+            candidate,
+            remaining,
+            selected,
+            actuals,
+            similarity_threshold,
+            variant_groups,
+            selected_groups,
+        )
+    )
+
+
+def _has_unrepresented_eligible_variant_group(
+    candidate: BlogCandidate,
+    remaining: list[BlogCandidate],
+    selected: list[SelectedBlogImage],
+    actuals: Mapping[str, int],
+    similarity_threshold: float,
+    variant_groups: Mapping[str, str],
+    selected_groups: set[str],
+) -> bool:
+    for alternative in remaining:
+        if (
+            alternative.annotation.scene_slug != candidate.annotation.scene_slug
+            or variant_groups[alternative.identifier] in selected_groups
+            or (
+                alternative.annotation.blog_image_type == "title"
+                and actuals["title"] >= 1
+            )
+        ):
+            continue
+        nearest = _nearest_selected_similarity(alternative, selected)
+        if nearest is None or nearest <= similarity_threshold:
+            return True
+    return False
+
+
+def _nearest_selected_similarity(
+    candidate: BlogCandidate,
+    selected: list[SelectedBlogImage],
+) -> float | None:
+    if not selected:
+        return None
+    return max(_cosine_similarity(candidate, item.candidate) for item in selected)
+
+
+def _cosine_similarity(left: BlogCandidate, right: BlogCandidate) -> float:
+    numerator = sum(
+        left_value * right_value
+        for left_value, right_value in zip(
+            left.visual_feature,
+            right.visual_feature,
+            strict=True,
+        )
+    )
+    left_norm = math.sqrt(sum(value * value for value in left.visual_feature))
+    right_norm = math.sqrt(sum(value * value for value in right.visual_feature))
+    if left_norm == 0 or right_norm == 0:
+        return 0.0
+    return max(-1.0, min(1.0, numerator / (left_norm * right_norm)))
+
+
+def _selection_key(
+    candidate: BlogCandidate,
+    score: SelectionScore,
+) -> tuple[float, float, float, float, int, Fraction, str]:
+    nearest_similarity = score.nearest_selected_similarity
+    return (
+        -score.marginal_utility,
+        score.spoiler_penalty,
+        -candidate.quality_score,
+        -1.0 if nearest_similarity is None else nearest_similarity,
+        candidate.video_order,
+        candidate.annotation.candidate.video_time or Fraction(0),
+        candidate.identifier,
+    )
+
+
+def _reason_codes(
+    candidate: BlogCandidate,
+    score: SelectionScore,
+    is_variant_expansion: bool,
+    tie_break_applied: bool,
+) -> tuple[str, ...]:
+    annotation = candidate.annotation
+    reasons: list[str] = []
+    if candidate.quality_score >= 0.8:
+        reasons.append("high_quality")
+    if annotation.explanation_value == "high":
+        reasons.append("high_explanation_value")
+    if annotation.context_relevance == "strong":
+        reasons.append("strong_context_relevance")
+    if score.coverage_bonus > 0:
+        reasons.append(
+            "title_first_image_bonus"
+            if annotation.blog_image_type == "title"
+            else f"{annotation.blog_image_type}_coverage"
+        )
+    if is_variant_expansion and candidate.scene_selection_role == "recurring_gameplay":
+        reasons.append("recurring_gameplay_variant")
+    if score.spoiler_penalty > 0:
+        reasons.append(f"{annotation.spoiler_risk}_spoiler_penalty_applied")
+    if tie_break_applied:
+        reasons.append("stable_tie_break")
+    return tuple(reasons)
+
+
+def _rejection(
+    candidate: BlogCandidate,
+    selected: list[SelectedBlogImage],
+    variant_group_id: str,
+    counterfactual_score: SelectionScore,
+    major_spoiler_limit: int | None,
+) -> RejectedBlogCandidate:
+    nearest_similarity = _nearest_selected_similarity(candidate, selected)
+    nearest_selected = _nearest_selected(candidate, selected)
+    selected_title = next(
+        (
+            item
+            for item in selected
+            if item.candidate.annotation.blog_image_type == "title"
+        ),
+        None,
+    )
+    if candidate.annotation.blog_image_type == "title" and selected_title is not None:
+        reason = SelectionRejectionReason.TITLE_LIMIT
+    elif (
+        nearest_similarity is not None
+        and nearest_similarity > _VISUAL_NEAR_DUPLICATE_THRESHOLD
+    ):
+        reason = SelectionRejectionReason.VISUAL_NEAR_DUPLICATE
+    elif (
+        nearest_similarity is not None and nearest_similarity > _MAX_SIMILARITY_CEILING
+    ):
+        reason = SelectionRejectionReason.SIMILARITY_CEILING
+    elif _major_spoiler_limit_reached(
+        candidate,
+        selected,
+        major_spoiler_limit,
+    ):
+        reason = SelectionRejectionReason.SPOILER_MONOTONICITY_GUARD
+    else:
+        reason = SelectionRejectionReason.LOWER_MARGINAL_UTILITY
+    return RejectedBlogCandidate(
+        candidate=candidate,
+        reason_code=reason,
+        counterfactual_score=counterfactual_score,
+        blocked_by_image_id=(
+            selected_title.candidate.identifier
+            if reason is SelectionRejectionReason.TITLE_LIMIT
+            and selected_title is not None
+            else None
+        ),
+        nearest_selected_image_id=(
+            nearest_selected.candidate.identifier
+            if reason
+            in {
+                SelectionRejectionReason.VISUAL_NEAR_DUPLICATE,
+                SelectionRejectionReason.SIMILARITY_CEILING,
+            }
+            and nearest_selected is not None
+            else None
+        ),
+        similarity=(
+            nearest_similarity
+            if reason
+            in {
+                SelectionRejectionReason.VISUAL_NEAR_DUPLICATE,
+                SelectionRejectionReason.SIMILARITY_CEILING,
+            }
+            else None
+        ),
+        variant_group_id=variant_group_id,
+    )
+
+
+def _nearest_selected(
+    candidate: BlogCandidate,
+    selected: list[SelectedBlogImage],
+) -> SelectedBlogImage | None:
+    if not selected:
+        return None
+    return min(
+        selected,
+        key=lambda item: (
+            -_cosine_similarity(candidate, item.candidate),
+            item.candidate.identifier,
+        ),
+    )
+
+
+def _assign_variant_groups(
+    candidates: tuple[BlogCandidate, ...],
+) -> dict[str, str]:
+    by_scene: dict[str, list[BlogCandidate]] = defaultdict(list)
+    for candidate in candidates:
+        by_scene[candidate.annotation.scene_slug].append(candidate)
+
+    result: dict[str, str] = {}
+    for scene_slug in sorted(by_scene):
+        scene_candidates = sorted(
+            by_scene[scene_slug],
+            key=lambda item: item.identifier,
+        )
+        unassigned = {item.identifier for item in scene_candidates}
+        by_identifier = {item.identifier: item for item in scene_candidates}
+        while unassigned:
+            root = min(unassigned)
+            component = {root}
+            frontier = [root]
+            unassigned.remove(root)
+            while frontier:
+                current_id = frontier.pop()
+                current = by_identifier[current_id]
+                connected = {
+                    other_id
+                    for other_id in unassigned
+                    if _cosine_similarity(current, by_identifier[other_id])
+                    >= _VARIANT_GROUP_SIMILARITY_THRESHOLD
+                }
+                component.update(connected)
+                frontier.extend(sorted(connected, reverse=True))
+                unassigned.difference_update(connected)
+            group_payload = "\0".join((scene_slug, *sorted(component)))
+            group_id = "variant_" + hashlib.sha256(group_payload.encode()).hexdigest()
+            result.update(dict.fromkeys(component, group_id))
+    return result
+
+
+def _major_spoiler_limit_reached(
+    candidate: BlogCandidate,
+    selected: list[SelectedBlogImage],
+    major_spoiler_limit: int | None,
+) -> bool:
+    if candidate.annotation.spoiler_risk != "high" or major_spoiler_limit is None:
+        return False
+    selected_count = sum(
+        item.candidate.annotation.spoiler_risk == "high" for item in selected
+    )
+    return selected_count >= major_spoiler_limit

--- a/src/video_selection/services/stage_version.py
+++ b/src/video_selection/services/stage_version.py
@@ -17,4 +17,6 @@ def stage_version(stage: ProcessingStage) -> str:
         return "scene-catalog-v1"
     if stage is ProcessingStage.ANNOTATE_CANDIDATE:
         return "candidate-annotation-v1"
+    if stage is ProcessingStage.SELECT_IMAGES:
+        return "video-set-selection-v1"
     return "walking-skeleton-0"

--- a/src/video_selection/services/stage_version.py
+++ b/src/video_selection/services/stage_version.py
@@ -17,6 +17,4 @@ def stage_version(stage: ProcessingStage) -> str:
         return "scene-catalog-v1"
     if stage is ProcessingStage.ANNOTATE_CANDIDATE:
         return "candidate-annotation-v1"
-    if stage is ProcessingStage.SELECT_IMAGES:
-        return "video-set-selection-v1"
     return "walking-skeleton-0"

--- a/tests/video_selection/fakes/selection_model_factory.py
+++ b/tests/video_selection/fakes/selection_model_factory.py
@@ -1,0 +1,88 @@
+"""Video Set selection model test用の実体fixture。"""
+
+from fractions import Fraction
+
+from src.video_selection.models.blog_candidate import BlogCandidate
+from src.video_selection.models.candidate_annotation import (
+    CandidateAnnotation,
+    SpoilerRisk,
+)
+from src.video_selection.models.frame_candidate import FrameCandidate
+from src.video_selection.models.neutral_image_analysis import NeutralImageAnalysis
+from src.video_selection.models.neutral_image_metrics import NeutralImageMetrics
+from src.video_selection.models.selection_score import SelectionScore
+
+
+def build_blog_candidate(
+    digest_character: str = "a",
+    *,
+    spoiler_risk: SpoilerRisk = "none",
+) -> BlogCandidate:
+    """選定model test用の適格なBlog Candidateを構築する。"""
+    metrics = NeutralImageMetrics(
+        blur_score=100.0,
+        brightness=100.0,
+        contrast=50.0,
+        edge_density=0.2,
+        color_richness=0.5,
+        ui_density=0.2,
+        action_intensity=0.4,
+        visual_balance=0.8,
+        dramatic_score=0.3,
+        luminance_entropy=1.0,
+        luminance_range=100.0,
+        near_black_ratio=0.0,
+        near_white_ratio=0.0,
+        dominant_tone_ratio=0.2,
+        information_score=0.8,
+        visibility_score=0.9,
+    )
+    frame = FrameCandidate(
+        identifier="frm_" + digest_character * 64,
+        image_bytes=digest_character.encode(),
+        video_fingerprint=digest_character * 64,
+        stream_index=0,
+        source_pts=100,
+        origin_pts=0,
+        time_base=Fraction(1, 1000),
+        video_time=Fraction(1, 10),
+        analysis=NeutralImageAnalysis(
+            source_pts=100,
+            metrics=metrics,
+            quality_score=0.8,
+            visual_feature=(1.0, 0.0),
+            grayscale_signature=b"signature",
+            reject_reason=None,
+        ),
+    )
+    annotation = CandidateAnnotation(
+        candidate=frame,
+        candidate_moment_id="mom_" + digest_character * 64,
+        summary="選定model test candidate",
+        scene_slug="test-scene",
+        blog_image_type="normal_gameplay",
+        explanation_value="high",
+        context_relevance="unavailable",
+        spoiler_risk=spoiler_risk,
+        spoiler_evidence=("物語情報が画像に示される" if spoiler_risk != "none" else ""),
+    )
+    return BlogCandidate(
+        annotation=annotation,
+        scene_selection_role="ordinary",
+        video_order=0,
+        video_set_progress=Fraction(1, 10),
+        shortlist_rank=1,
+    )
+
+
+def build_selection_score() -> SelectionScore:
+    """選定判断を再現できる固定Selection Scoreを構築する。"""
+    return SelectionScore(
+        base_utility=0.81,
+        spoiler_penalty=0.1,
+        coverage_bonus=0.05,
+        temporal_diversity_penalty=0.02,
+        marginal_utility=0.74,
+        similarity_pass=0.78,
+        nearest_selected_similarity=0.75,
+    )

--- a/tests/video_selection/models/test_blog_candidate.py
+++ b/tests/video_selection/models/test_blog_candidate.py
@@ -1,0 +1,80 @@
+"""Blog Candidate domain contractのtest。"""
+
+from fractions import Fraction
+
+import pytest
+
+from src.video_selection.models.blog_candidate import BlogCandidate
+from src.video_selection.models.candidate_annotation import CandidateAnnotation
+from src.video_selection.models.content_reject_reason import ContentRejectReason
+from src.video_selection.models.frame_candidate import FrameCandidate
+from src.video_selection.models.neutral_image_analysis import NeutralImageAnalysis
+from src.video_selection.models.neutral_image_metrics import NeutralImageMetrics
+
+
+def test_context_cue_cannot_make_rejected_frame_eligible() -> None:
+    """strong Context Cueでも不適格frameがBlog Candidateにされないこと。
+
+    Arrange:
+        - blackoutとしてrejectされたFrame Candidateが用意される
+        - strong Context Cue Relevanceを持つCandidate Annotationが用意される
+    Act:
+        - Blog Candidateが構築される
+    Assert:
+        - Context Cueによる適格化が拒否されること
+    """
+    # Arrange
+    metrics = NeutralImageMetrics(
+        blur_score=0.0,
+        brightness=0.0,
+        contrast=0.0,
+        edge_density=0.0,
+        color_richness=0.0,
+        ui_density=0.0,
+        action_intensity=0.0,
+        visual_balance=0.0,
+        dramatic_score=0.0,
+        luminance_entropy=0.0,
+        luminance_range=0.0,
+        near_black_ratio=1.0,
+        near_white_ratio=0.0,
+        dominant_tone_ratio=1.0,
+        information_score=0.0,
+        visibility_score=0.0,
+    )
+    frame = FrameCandidate(
+        identifier="frm_" + "a" * 64,
+        image_bytes=b"blackout",
+        video_fingerprint="a" * 64,
+        stream_index=0,
+        source_pts=0,
+        origin_pts=0,
+        time_base=Fraction(1, 1000),
+        video_time=Fraction(0),
+        analysis=NeutralImageAnalysis(
+            source_pts=0,
+            metrics=metrics,
+            quality_score=0.0,
+            visual_feature=(1.0, 0.0),
+            grayscale_signature=b"black",
+            reject_reason=ContentRejectReason.BLACKOUT,
+        ),
+    )
+    annotation = CandidateAnnotation(
+        candidate=frame,
+        candidate_moment_id="mom_" + "a" * 64,
+        summary="暗転frame",
+        context_relevance="strong",
+        supporting_context_cue_ids=("cue_" + "a" * 64,),
+    )
+
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="有効なframe"):
+        BlogCandidate(
+            annotation=annotation,
+            scene_selection_role="ordinary",
+            video_order=0,
+            video_set_progress=Fraction(0),
+            shortlist_rank=0,
+        )

--- a/tests/video_selection/models/test_rejected_blog_candidate.py
+++ b/tests/video_selection/models/test_rejected_blog_candidate.py
@@ -1,0 +1,47 @@
+"""Rejected Blog Candidate domain contractのtest。"""
+
+from src.video_selection.models.rejected_blog_candidate import (
+    RejectedBlogCandidate,
+)
+from src.video_selection.models.selection_rejection_reason import (
+    SelectionRejectionReason,
+)
+from tests.video_selection.fakes.selection_model_factory import (
+    build_blog_candidate,
+    build_selection_score,
+)
+
+
+def test_rejected_blog_candidate_keeps_counterfactual_and_blocking_evidence() -> None:
+    """未採用候補の反実仮想scoreとblocking evidenceが保持されること。
+
+    Arrange:
+        - Blog Candidate、反実仮想score、similarity blockerが用意される
+    Act:
+        - Rejected Blog Candidateが構築される
+    Assert:
+        - stable reason、blocking ID、similarity、Variant Groupが返されること
+    """
+    # Arrange
+    candidate = build_blog_candidate()
+    score = build_selection_score()
+
+    # Act
+    rejected = RejectedBlogCandidate(
+        candidate=candidate,
+        reason_code=SelectionRejectionReason.SIMILARITY_CEILING,
+        counterfactual_score=score,
+        blocked_by_image_id=None,
+        nearest_selected_image_id="frm_" + "b" * 64,
+        similarity=0.9,
+        variant_group_id="variant_test",
+    )
+
+    # Assert
+    assert rejected.candidate.identifier == candidate.identifier
+    assert rejected.reason_code is SelectionRejectionReason.SIMILARITY_CEILING
+    assert rejected.counterfactual_score == score
+    assert rejected.blocked_by_image_id is None
+    assert rejected.nearest_selected_image_id == "frm_" + "b" * 64
+    assert rejected.similarity == 0.9
+    assert rejected.variant_group_id == "variant_test"

--- a/tests/video_selection/models/test_selected_blog_image.py
+++ b/tests/video_selection/models/test_selected_blog_image.py
@@ -1,0 +1,40 @@
+"""Selected Blog Image domain contractのtest。"""
+
+from src.video_selection.models.selected_blog_image import SelectedBlogImage
+from tests.video_selection.fakes.selection_model_factory import (
+    build_blog_candidate,
+    build_selection_score,
+)
+
+
+def test_selected_blog_image_keeps_order_reasons_and_variant_provenance() -> None:
+    """採用画像の順序・理由・Variant provenanceが保持されること。
+
+    Arrange:
+        - Blog Candidate、Selection Score、安定した選定metadataが用意される
+    Act:
+        - Selected Blog Imageが構築される
+    Assert:
+        - 選択順、理由、Variant Group、tie-break使用有無が返されること
+    """
+    # Arrange
+    candidate = build_blog_candidate()
+    score = build_selection_score()
+
+    # Act
+    selected = SelectedBlogImage(
+        candidate=candidate,
+        selection_index=2,
+        score=score,
+        reason_codes=("high_quality", "stable_tie_break"),
+        variant_group_id="variant_test",
+        tie_break_applied=True,
+    )
+
+    # Assert
+    assert selected.candidate.identifier == candidate.identifier
+    assert selected.selection_index == 2
+    assert selected.score == score
+    assert selected.reason_codes == ("high_quality", "stable_tie_break")
+    assert selected.variant_group_id == "variant_test"
+    assert selected.tie_break_applied is True

--- a/tests/video_selection/models/test_selection_rejection_reason.py
+++ b/tests/video_selection/models/test_selection_rejection_reason.py
@@ -1,0 +1,31 @@
+"""Selection Rejection Reason domain contractのtest。"""
+
+from src.video_selection.models.selection_rejection_reason import (
+    SelectionRejectionReason,
+)
+
+
+def test_selection_rejection_reasons_have_stable_serialized_values() -> None:
+    """未採用の排他的主理由がstableな文字列として列挙されること。
+
+    Arrange:
+        - 公開するrejection reasonの文字列一覧が用意される
+    Act:
+        - Selection Rejection Reasonの値が列挙される
+    Assert:
+        - schema契約どおりのstable文字列が返されること
+    """
+    # Arrange
+    expected = (
+        "title_limit",
+        "visual_near_duplicate",
+        "similarity_ceiling",
+        "spoiler_monotonicity_guard",
+        "lower_marginal_utility",
+    )
+
+    # Act
+    actual = tuple(reason.value for reason in SelectionRejectionReason)
+
+    # Assert
+    assert actual == expected

--- a/tests/video_selection/models/test_selection_score.py
+++ b/tests/video_selection/models/test_selection_score.py
@@ -1,0 +1,40 @@
+"""Selection Score domain contractのtest。"""
+
+from src.video_selection.models.selection_score import SelectionScore
+
+
+def test_selection_score_exposes_reproducible_numeric_components() -> None:
+    """選定判断の全数値componentが再現可能な形で保持されること。
+
+    Arrange:
+        - utility、penalty、similarityの数値内訳が用意される
+    Act:
+        - Selection Scoreが構築され数値componentが読み出される
+    Assert:
+        - 入力した全数値componentが同じ値で返されること
+    """
+    # Arrange
+    expected = (0.81, 0.1, 0.05, 0.02, 0.74, 0.78, 0.75)
+
+    # Act
+    score = SelectionScore(
+        base_utility=expected[0],
+        spoiler_penalty=expected[1],
+        coverage_bonus=expected[2],
+        temporal_diversity_penalty=expected[3],
+        marginal_utility=expected[4],
+        similarity_pass=expected[5],
+        nearest_selected_similarity=expected[6],
+    )
+    actual = (
+        score.base_utility,
+        score.spoiler_penalty,
+        score.coverage_bonus,
+        score.temporal_diversity_penalty,
+        score.marginal_utility,
+        score.similarity_pass,
+        score.nearest_selected_similarity,
+    )
+
+    # Assert
+    assert actual == expected

--- a/tests/video_selection/models/test_video_set_selection_result.py
+++ b/tests/video_selection/models/test_video_set_selection_result.py
@@ -1,0 +1,88 @@
+"""Video Set Selection Result domain contractのtest。"""
+
+from src.video_selection.models.rejected_blog_candidate import (
+    RejectedBlogCandidate,
+)
+from src.video_selection.models.selected_blog_image import SelectedBlogImage
+from src.video_selection.models.selection_rejection_reason import (
+    SelectionRejectionReason,
+)
+from src.video_selection.models.video_set_selection_result import (
+    VideoSetSelectionResult,
+)
+from tests.video_selection.fakes.selection_model_factory import (
+    build_blog_candidate,
+    build_selection_score,
+)
+
+
+def test_result_summarizes_shortfall_spoilers_and_rejections() -> None:
+    """選定結果からshortfall・Major Spoiler件数・rejection件数が集計されること。
+
+    Arrange:
+        - Major Spoilerを含む選択画像2件と未採用候補2件が用意される
+        - 要求枚数が3枚に設定される
+    Act:
+        - Video Set Selection Resultのsummary propertyが読み出される
+    Assert:
+        - shortfall、Major Spoiler件数、reason別件数が返されること
+    """
+    # Arrange
+    score = build_selection_score()
+    selected = tuple(
+        SelectedBlogImage(
+            candidate=candidate,
+            selection_index=index,
+            score=score,
+            reason_codes=(),
+            variant_group_id=f"variant_{index}",
+            tie_break_applied=False,
+        )
+        for index, candidate in enumerate(
+            (
+                build_blog_candidate("a"),
+                build_blog_candidate("b", spoiler_risk="high"),
+            ),
+            start=1,
+        )
+    )
+    rejected = tuple(
+        RejectedBlogCandidate(
+            candidate=build_blog_candidate(digest),
+            reason_code=reason,
+            counterfactual_score=score,
+            blocked_by_image_id=None,
+            nearest_selected_image_id=None,
+            similarity=None,
+            variant_group_id=f"variant_{digest}",
+        )
+        for digest, reason in (
+            ("c", SelectionRejectionReason.SIMILARITY_CEILING),
+            ("d", SelectionRejectionReason.LOWER_MARGINAL_UTILITY),
+        )
+    )
+    result = VideoSetSelectionResult(
+        selected=selected,
+        rejected=rejected,
+        requested_count=3,
+        blog_image_type_targets={"normal_gameplay": 2, "event": 1},
+        blog_image_type_actuals={"normal_gameplay": 2, "event": 0},
+        final_similarity_ceiling=0.98,
+        major_spoiler_limit=1,
+        annotated_candidate_count=4,
+        shortlist_expansion_count=0,
+        all_candidate_moments_exhausted=True,
+    )
+
+    # Act
+    shortfall = result.shortfall
+    major_spoiler_count = result.major_spoiler_selected_count
+    rejection_counts = result.rejection_counts
+
+    # Assert
+    assert shortfall is True
+    assert major_spoiler_count == 1
+    assert rejection_counts == {
+        "similarity_ceiling": 1,
+        "lower_marginal_utility": 1,
+    }

--- a/tests/video_selection/services/test_select_video_set_images.py
+++ b/tests/video_selection/services/test_select_video_set_images.py
@@ -1,0 +1,835 @@
+"""決定的なVideo Set selectorのtest。"""
+
+import math
+from fractions import Fraction
+
+import pytest
+
+from src.video_selection.models.blog_candidate import BlogCandidate
+from src.video_selection.models.candidate_annotation import (
+    BlogImageType,
+    CandidateAnnotation,
+    ContextCueRelevance,
+    ExplanationValue,
+    SpoilerRisk,
+)
+from src.video_selection.models.frame_candidate import FrameCandidate
+from src.video_selection.models.neutral_image_analysis import NeutralImageAnalysis
+from src.video_selection.models.neutral_image_metrics import NeutralImageMetrics
+from src.video_selection.models.scene_catalog_entry import SceneSelectionRole
+from src.video_selection.models.video_set_selection_result import (
+    VideoSetSelectionResult,
+)
+from src.video_selection.services.select_video_set_images import (
+    SpoilerSensitivity,
+    select_from_shortlist_batches,
+    select_video_set_images,
+)
+
+type CandidateSpec = tuple[
+    str,
+    float,
+    tuple[float, ...],
+    Fraction,
+    BlogImageType,
+    ExplanationValue,
+    SpoilerRisk,
+]
+
+
+def _metrics() -> NeutralImageMetrics:
+    return NeutralImageMetrics(
+        blur_score=100.0,
+        brightness=100.0,
+        contrast=50.0,
+        edge_density=0.2,
+        color_richness=0.5,
+        ui_density=0.2,
+        action_intensity=0.4,
+        visual_balance=0.8,
+        dramatic_score=0.3,
+        luminance_entropy=1.0,
+        luminance_range=100.0,
+        near_black_ratio=0.0,
+        near_white_ratio=0.0,
+        dominant_tone_ratio=0.2,
+        information_score=0.8,
+        visibility_score=0.9,
+    )
+
+
+def _candidate(
+    digest_character: str,
+    *,
+    quality: float,
+    feature: tuple[float, ...],
+    progress: Fraction,
+    blog_image_type: BlogImageType,
+    explanation_value: ExplanationValue,
+    context_relevance: ContextCueRelevance,
+    spoiler_risk: SpoilerRisk = "none",
+    scene_selection_role: SceneSelectionRole = "ordinary",
+    scene_slug: str | None = None,
+    video_order: int = 0,
+) -> BlogCandidate:
+    frame = FrameCandidate(
+        identifier="frm_" + digest_character * 64,
+        image_bytes=digest_character.encode(),
+        video_fingerprint=digest_character * 64,
+        stream_index=0,
+        source_pts=int(progress * 1000),
+        origin_pts=0,
+        time_base=Fraction(1, 1000),
+        video_time=progress * 100,
+        analysis=NeutralImageAnalysis(
+            source_pts=int(progress * 1000),
+            metrics=_metrics(),
+            quality_score=quality,
+            visual_feature=feature,
+            grayscale_signature=b"signature",
+            reject_reason=None,
+        ),
+    )
+    annotation = CandidateAnnotation(
+        candidate=frame,
+        candidate_moment_id="mom_" + digest_character * 64,
+        summary=f"candidate {digest_character}",
+        scene_slug=scene_slug or "scene-" + digest_character,
+        blog_image_type=blog_image_type,
+        explanation_value=explanation_value,
+        context_relevance=context_relevance,
+        supporting_context_cue_ids=(
+            ("cue_" + digest_character * 64,)
+            if context_relevance in {"weak", "strong"}
+            else ()
+        ),
+        spoiler_risk=spoiler_risk,
+        spoiler_evidence=(
+            "重大な物語情報が画像に示される" if spoiler_risk != "none" else ""
+        ),
+    )
+    return BlogCandidate(
+        annotation=annotation,
+        scene_selection_role=scene_selection_role,
+        video_order=video_order,
+        video_set_progress=progress,
+        shortlist_rank=ord(digest_character),
+    )
+
+
+def _normalized(result: VideoSetSelectionResult) -> list[dict[str, object]]:
+    selected = result.selected
+    return [
+        {
+            "id": item.candidate.annotation.candidate.identifier,
+            "reason_codes": list(item.reason_codes),
+            "base": round(item.score.base_utility, 6),
+            "coverage": round(item.score.coverage_bonus, 6),
+            "spoiler": round(item.score.spoiler_penalty, 6),
+            "temporal": round(item.score.temporal_diversity_penalty, 6),
+            "marginal": round(item.score.marginal_utility, 6),
+            "pass": item.score.similarity_pass,
+        }
+        for item in selected
+    ]
+
+
+def test_normalized_selection_is_exact_and_independent_of_input_order() -> None:
+    """同じ候補集合のselected ID・順序・理由・数値が一定であること。
+
+    Arrange:
+        - 品質、説明価値、coverage、spoiler、進行位置が異なる4候補が用意される
+        - 同じ候補集合が異なる入力順で用意される
+    Act:
+        - Video Set selectorが両方の候補集合へ実行される
+    Assert:
+        - 正規化したselected ID、順序、reason code、数値内訳がgoldenと一致すること
+    """
+    # Arrange
+    candidates = (
+        _candidate(
+            "b",
+            quality=0.9,
+            feature=(1.0, 0.0, 0.0, 0.0),
+            progress=Fraction(82, 100),
+            blog_image_type="normal_gameplay",
+            explanation_value="high",
+            context_relevance="strong",
+        ),
+        _candidate(
+            "d",
+            quality=0.8,
+            feature=(0.0, 1.0, 0.0, 0.0),
+            progress=Fraction(40, 100),
+            blog_image_type="event",
+            explanation_value="high",
+            context_relevance="strong",
+        ),
+        _candidate(
+            "c",
+            quality=0.95,
+            feature=(0.0, 0.0, 1.0, 0.0),
+            progress=Fraction(90, 100),
+            blog_image_type="event",
+            explanation_value="high",
+            context_relevance="strong",
+            spoiler_risk="high",
+        ),
+        _candidate(
+            "a",
+            quality=0.7,
+            feature=(0.0, 0.0, 0.0, 1.0),
+            progress=Fraction(10, 100),
+            blog_image_type="normal_gameplay",
+            explanation_value="low",
+            context_relevance="none",
+        ),
+    )
+    expected = [
+        {
+            "id": "frm_" + "b" * 64,
+            "reason_codes": [
+                "high_quality",
+                "high_explanation_value",
+                "strong_context_relevance",
+                "normal_gameplay_coverage",
+            ],
+            "base": 0.93,
+            "coverage": 0.1,
+            "spoiler": 0.0,
+            "temporal": 0.0,
+            "marginal": 1.03,
+            "pass": 0.72,
+        },
+        {
+            "id": "frm_" + "d" * 64,
+            "reason_codes": [
+                "high_quality",
+                "high_explanation_value",
+                "strong_context_relevance",
+                "event_coverage",
+            ],
+            "base": 0.86,
+            "coverage": 0.1,
+            "spoiler": 0.0,
+            "temporal": 0.0,
+            "marginal": 0.96,
+            "pass": 0.72,
+        },
+        {
+            "id": "frm_" + "c" * 64,
+            "reason_codes": [
+                "high_quality",
+                "high_explanation_value",
+                "strong_context_relevance",
+                "high_spoiler_penalty_applied",
+            ],
+            "base": 0.965,
+            "coverage": 0.0,
+            "spoiler": 0.1,
+            "temporal": 0.0544,
+            "marginal": 0.8106,
+            "pass": 0.72,
+        },
+        {
+            "id": "frm_" + "a" * 64,
+            "reason_codes": ["normal_gameplay_coverage"],
+            "base": 0.573333,
+            "coverage": 0.1,
+            "spoiler": 0.0,
+            "temporal": 0.0,
+            "marginal": 0.673333,
+            "pass": 0.72,
+        },
+    ]
+
+    # Act
+    forward = select_video_set_images(
+        candidates,
+        requested_count=4,
+        spoiler_sensitivity="medium",
+        similarity_threshold=0.72,
+    )
+    reordered = select_video_set_images(
+        tuple(reversed(candidates)),
+        requested_count=4,
+        spoiler_sensitivity="medium",
+        similarity_threshold=0.72,
+    )
+
+    # Assert
+    assert _normalized(forward) == expected
+    assert _normalized(reordered) == expected
+
+
+def test_visual_near_duplicate_is_rejected_even_when_selection_is_short() -> None:
+    """Visual Near-Duplicateで要求不足が穴埋めされないこと。
+
+    Arrange:
+        - cosine similarityが0.995を超えるrecurring gameplay候補が2件用意される
+        - 2枚の選定が要求される
+    Act:
+        - Video Set selectorが終端similarity passまで実行される
+    Assert:
+        - 近似重複の2件目が選択されずSelection Shortfallになること
+        - stable rejection codeとblocking candidateが返されること
+    """
+    # Arrange
+    first = _candidate(
+        "e",
+        quality=0.9,
+        feature=(1.0, 0.0),
+        progress=Fraction(1, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="high",
+        context_relevance="none",
+        scene_selection_role="recurring_gameplay",
+    )
+    second = _candidate(
+        "f",
+        quality=0.8,
+        feature=(0.996, math.sqrt(1 - 0.996**2)),
+        progress=Fraction(8, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="high",
+        context_relevance="none",
+        scene_selection_role="recurring_gameplay",
+    )
+
+    # Act
+    result = select_video_set_images(
+        (second, first),
+        requested_count=2,
+        spoiler_sensitivity="medium",
+        similarity_threshold=0.72,
+    )
+
+    # Assert
+    assert [item.candidate.identifier for item in result.selected] == [first.identifier]
+    assert result.shortfall is True
+    assert result.final_similarity_ceiling == 0.98
+    assert len(result.rejected) == 1
+    rejection = result.rejected[0]
+    assert rejection.candidate.identifier == second.identifier
+    assert rejection.reason_code == "visual_near_duplicate"
+    assert rejection.nearest_selected_image_id == first.identifier
+    assert rejection.similarity == pytest.approx(0.996)
+
+
+def test_recurring_gameplay_expands_only_after_each_variant_group() -> None:
+    """recurring gameplayで各Variant Groupの代表後に状態差が選ばれること。
+
+    Arrange:
+        - 同じrecurring sceneに同一groupの高品質2候補と別groupの低品質候補がある
+        - base ceilingでは最初の候補以外が視覚条件を満たさない
+    Act:
+        - 3枚の選定が要求され終端passまでselectorが実行される
+    Assert:
+        - 別groupの代表が同一groupの2枚目より先に選択されること
+        - 同一groupの2枚目にvariant expansionのstable reasonが付くこと
+    """
+    # Arrange
+    first = _candidate(
+        "1",
+        quality=0.9,
+        feature=(1.0, 0.0, 0.0),
+        progress=Fraction(1, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="high",
+        context_relevance="none",
+        scene_selection_role="recurring_gameplay",
+        scene_slug="battle",
+    )
+    same_group = _candidate(
+        "2",
+        quality=0.89,
+        feature=(0.96, math.sqrt(1 - 0.96**2), 0.0),
+        progress=Fraction(8, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="high",
+        context_relevance="none",
+        scene_selection_role="recurring_gameplay",
+        scene_slug="battle",
+    )
+    other_group = _candidate(
+        "3",
+        quality=0.5,
+        feature=(0.9, 0.0, math.sqrt(1 - 0.9**2)),
+        progress=Fraction(45, 100),
+        blog_image_type="normal_gameplay",
+        explanation_value="none",
+        context_relevance="none",
+        scene_selection_role="recurring_gameplay",
+        scene_slug="battle",
+    )
+
+    # Act
+    result = select_video_set_images(
+        (same_group, other_group, first),
+        requested_count=3,
+        spoiler_sensitivity="medium",
+        similarity_threshold=0.72,
+    )
+
+    # Assert
+    assert [item.candidate.identifier for item in result.selected] == [
+        first.identifier,
+        other_group.identifier,
+        same_group.identifier,
+    ]
+    first_selected, other_selected, expanded = result.selected
+    assert first_selected.variant_group_id == expanded.variant_group_id
+    assert other_selected.variant_group_id != expanded.variant_group_id
+    assert expanded.score.similarity_pass == 0.98
+    assert "recurring_gameplay_variant" in expanded.reason_codes
+
+
+def test_second_title_is_rejected_with_counterfactual_score() -> None:
+    """2枚目のtitleがnear-miss数値を保ったままhard limitで拒否されること。
+
+    Arrange:
+        - 視覚的に異なるtitle候補が2件用意される
+        - 2枚の選定が要求される
+    Act:
+        - Video Set selectorが終端passまで実行される
+    Assert:
+        - titleは1件だけ選択されSelection Shortfallになること
+        - 2件目へtitle limit、blocking ID、制約前の数値内訳が返されること
+    """
+    # Arrange
+    best = _candidate(
+        "4",
+        quality=0.9,
+        feature=(1.0, 0.0),
+        progress=Fraction(1, 10),
+        blog_image_type="title",
+        explanation_value="high",
+        context_relevance="none",
+    )
+    second = _candidate(
+        "5",
+        quality=0.8,
+        feature=(0.0, 1.0),
+        progress=Fraction(9, 10),
+        blog_image_type="title",
+        explanation_value="high",
+        context_relevance="none",
+    )
+
+    # Act
+    result = select_video_set_images(
+        (second, best),
+        requested_count=2,
+        spoiler_sensitivity="medium",
+        similarity_threshold=0.72,
+    )
+
+    # Assert
+    assert [item.candidate.identifier for item in result.selected] == [best.identifier]
+    assert result.shortfall is True
+    assert len(result.rejected) == 1
+    rejection = result.rejected[0]
+    assert rejection.reason_code == "title_limit"
+    assert rejection.blocked_by_image_id == best.identifier
+    assert rejection.nearest_selected_image_id is None
+    assert rejection.counterfactual_score.base_utility == pytest.approx(0.81)
+    assert rejection.counterfactual_score.coverage_bonus == 0.05
+    assert rejection.counterfactual_score.temporal_diversity_penalty == 0.0
+    assert rejection.counterfactual_score.marginal_utility == pytest.approx(0.86)
+
+
+def test_soft_coverage_allows_event_overflow_when_other_types_are_absent() -> None:
+    """候補不足のtypeをhard quotaにせず有用なeventで超過できること。
+
+    Arrange:
+        - 視覚的に異なるevent候補だけが3件用意される
+        - 3枚の選定が要求される
+    Act:
+        - Video Set selectorが実行される
+    Assert:
+        - event目標1件を超えて3件すべて選択されること
+        - 5種のtargetとactualからcoverage超過が説明できること
+    """
+    # Arrange
+    candidates = tuple(
+        _candidate(
+            digest,
+            quality=quality,
+            feature=feature,
+            progress=progress,
+            blog_image_type="event",
+            explanation_value="high",
+            context_relevance="none",
+        )
+        for digest, quality, feature, progress in (
+            ("6", 0.9, (1.0, 0.0, 0.0), Fraction(1, 10)),
+            ("7", 0.8, (0.0, 1.0, 0.0), Fraction(5, 10)),
+            ("8", 0.7, (0.0, 0.0, 1.0), Fraction(9, 10)),
+        )
+    )
+
+    # Act
+    result = select_video_set_images(
+        candidates,
+        requested_count=3,
+        spoiler_sensitivity="medium",
+        similarity_threshold=0.72,
+    )
+
+    # Assert
+    assert len(result.selected) == 3
+    assert result.shortfall is False
+    assert result.blog_image_type_targets == {
+        "normal_gameplay": 2,
+        "event": 1,
+        "menu": 0,
+        "title": 0,
+        "other": 0,
+    }
+    assert result.blog_image_type_actuals == {
+        "normal_gameplay": 0,
+        "event": 3,
+        "menu": 0,
+        "title": 0,
+        "other": 0,
+    }
+    assert "event_coverage" in result.selected[0].reason_codes
+    assert all(
+        "event_coverage" not in item.reason_codes for item in result.selected[1:]
+    )
+
+
+def test_higher_spoiler_sensitivity_never_increases_major_spoilers() -> None:
+    """感度上昇で同じ候補集合のMajor Spoiler選択数が増えないこと。
+
+    Arrange:
+        - 単純greedyではdiversityとcoverageによりhigh感度の件数が増える候補行列がある
+        - 同じ7候補と要求3枚がlow、medium、high向けに用意される
+    Act:
+        - 各Spoiler SensitivityでVideo Set selectorが実行される
+    Assert:
+        - Major Spoiler選択数が感度順に単調非増加であること
+    """
+    # Arrange
+    specs: tuple[CandidateSpec, ...] = (
+        (
+            "0",
+            0.38,
+            (0.3010184307, 0.2251490036, 0.8531105982, 0.3617984767),
+            Fraction(18, 25),
+            "event",
+            "low",
+            "high",
+        ),
+        (
+            "1",
+            0.70,
+            (0.9405985621, 0.1960576527, 0.2755141423, 0.0304581544),
+            Fraction(17, 25),
+            "event",
+            "low",
+            "none",
+        ),
+        (
+            "2",
+            0.53,
+            (0.6382307865, 0.1248780060, 0.7098586663, 0.2704951396),
+            Fraction(69, 100),
+            "normal_gameplay",
+            "none",
+            "high",
+        ),
+        (
+            "3",
+            0.90,
+            (0.5763720210, 0.1029043598, 0.6540056522, 0.4790434145),
+            Fraction(47, 50),
+            "normal_gameplay",
+            "high",
+            "high",
+        ),
+        (
+            "4",
+            0.81,
+            (0.8368746524, 0.1520583373, 0.2970922673, 0.4338839281),
+            Fraction(7, 100),
+            "event",
+            "high",
+            "none",
+        ),
+        (
+            "5",
+            0.48,
+            (0.8195546317, 0.3893717013, 0.4171090861, 0.0523439990),
+            Fraction(91, 100),
+            "event",
+            "low",
+            "high",
+        ),
+        (
+            "6",
+            0.44,
+            (0.6511259894, 0.2176397414, 0.7058702682, 0.1743991209),
+            Fraction(3, 50),
+            "menu",
+            "high",
+            "high",
+        ),
+    )
+    candidates = tuple(
+        _candidate(
+            digest,
+            quality=quality,
+            feature=feature,
+            progress=progress,
+            blog_image_type=image_type,
+            explanation_value=explanation,
+            context_relevance="none",
+            spoiler_risk=spoiler,
+        )
+        for (
+            digest,
+            quality,
+            feature,
+            progress,
+            image_type,
+            explanation,
+            spoiler,
+        ) in specs
+    )
+
+    # Act
+    sensitivities: tuple[SpoilerSensitivity, ...] = ("low", "medium", "high")
+    results = tuple(
+        select_video_set_images(
+            candidates,
+            requested_count=3,
+            spoiler_sensitivity=sensitivity,
+            similarity_threshold=0.72,
+        )
+        for sensitivity in sensitivities
+    )
+
+    # Assert
+    major_counts = [result.major_spoiler_selected_count for result in results]
+    assert major_counts[0] == 1
+    assert major_counts == sorted(major_counts, reverse=True)
+
+
+def test_shortlist_expansion_recomputes_selection_from_full_expanded_pool() -> None:
+    """Shortlist拡張後に以前の選択を固定せず全候補から再計算されること。
+
+    Arrange:
+        - 初期batchには要求数を満たさない低utility候補が1件だけある
+        - 次のbatchには視覚的に異なる高utility候補が2件ある
+    Act:
+        - lazyなSelection Shortlist batch列から選定される
+    Assert:
+        - 拡張poolの高utility候補2件が選ばれ初期候補が固定されないこと
+        - annotation件数と拡張回数が返されること
+    """
+    # Arrange
+    initial = _candidate(
+        "9",
+        quality=0.5,
+        feature=(1.0, 0.0, 0.0),
+        progress=Fraction(1, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="none",
+        context_relevance="none",
+    )
+    event = _candidate(
+        "a",
+        quality=0.9,
+        feature=(0.0, 1.0, 0.0),
+        progress=Fraction(5, 10),
+        blog_image_type="event",
+        explanation_value="high",
+        context_relevance="none",
+    )
+    gameplay = _candidate(
+        "b",
+        quality=0.8,
+        feature=(0.0, 0.0, 1.0),
+        progress=Fraction(9, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="high",
+        context_relevance="none",
+    )
+
+    # Act
+    result = select_from_shortlist_batches(
+        ((initial,), (gameplay, event)),
+        requested_count=2,
+        spoiler_sensitivity="medium",
+        similarity_threshold=0.72,
+    )
+
+    # Assert
+    assert [item.candidate.identifier for item in result.selected] == [
+        event.identifier,
+        gameplay.identifier,
+    ]
+    assert [item.candidate.identifier for item in result.rejected] == [
+        initial.identifier
+    ]
+    assert result.rejected[0].reason_code == "lower_marginal_utility"
+    assert result.annotated_candidate_count == 3
+    assert result.shortlist_expansion_count == 1
+    assert result.all_candidate_moments_exhausted is False
+
+
+def test_exact_utility_tie_uses_stable_video_order_and_records_tie_break() -> None:
+    """完全同点がVideo Orderで安定解消され診断へ残ること。
+
+    Arrange:
+        - utility、spoiler、quality、選択前visual similarityが同じ2候補がある
+        - 入力順の後ろにある候補のVideo Orderが小さい
+    Act:
+        - 1枚の選定が要求される
+    Assert:
+        - 小さいVideo Orderの候補が選ばれること
+        - stable tie-breakが使われたことをreasonとfieldで確認できること
+    """
+    # Arrange
+    later_video = _candidate(
+        "c",
+        quality=0.8,
+        feature=(1.0, 0.0),
+        progress=Fraction(1, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="high",
+        context_relevance="none",
+        video_order=1,
+    )
+    earlier_video = _candidate(
+        "d",
+        quality=0.8,
+        feature=(0.0, 1.0),
+        progress=Fraction(9, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="high",
+        context_relevance="none",
+        video_order=0,
+    )
+
+    # Act
+    result = select_video_set_images(
+        (later_video, earlier_video),
+        requested_count=1,
+        spoiler_sensitivity="medium",
+        similarity_threshold=0.72,
+    )
+
+    # Assert
+    selected = result.selected[0]
+    assert selected.candidate.identifier == earlier_video.identifier
+    assert selected.tie_break_applied is True
+    assert "stable_tie_break" in selected.reason_codes
+
+
+def test_similarity_above_terminal_ceiling_is_counted_separately() -> None:
+    """0.98超の候補がVisual Near-Duplicateとは別理由で集計されること。
+
+    Arrange:
+        - cosine similarityが0.98超0.995以下のordinary候補が2件ある
+        - 2枚の選定が要求される
+    Act:
+        - selectorが終端similarity passまで実行される
+    Assert:
+        - 2件目がsimilarity ceilingで拒否されること
+        - shortfallのreason countをstable enumで説明できること
+    """
+    # Arrange
+    first = _candidate(
+        "e",
+        quality=0.9,
+        feature=(1.0, 0.0),
+        progress=Fraction(1, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="high",
+        context_relevance="none",
+    )
+    second = _candidate(
+        "f",
+        quality=0.8,
+        feature=(0.985, math.sqrt(1 - 0.985**2)),
+        progress=Fraction(9, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="high",
+        context_relevance="none",
+    )
+
+    # Act
+    result = select_video_set_images(
+        (second, first),
+        requested_count=2,
+        spoiler_sensitivity="medium",
+        similarity_threshold=0.72,
+    )
+
+    # Assert
+    assert result.shortfall is True
+    assert result.final_similarity_ceiling == 0.98
+    assert result.rejection_counts == {"similarity_ceiling": 1}
+    rejection = result.rejected[0]
+    assert rejection.reason_code == "similarity_ceiling"
+    assert rejection.nearest_selected_image_id == first.identifier
+    assert rejection.similarity == pytest.approx(0.985)
+
+
+def test_rejections_are_ordered_by_counterfactual_utility() -> None:
+    """near-miss候補が反実仮想utilityとstable tie-break順で返されること。
+
+    Arrange:
+        - 選択1件と、ID順がutility順の逆になる未採用2件が用意される
+    Act:
+        - 1枚の選定が要求される
+    Assert:
+        - 未採用候補がID順でなくcounterfactual utility降順になること
+    """
+    # Arrange
+    selected = _candidate(
+        "9",
+        quality=0.9,
+        feature=(1.0, 0.0, 0.0),
+        progress=Fraction(1, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="none",
+        context_relevance="none",
+    )
+    stronger_near_miss = _candidate(
+        "f",
+        quality=0.8,
+        feature=(0.0, 1.0, 0.0),
+        progress=Fraction(5, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="none",
+        context_relevance="none",
+    )
+    weaker_near_miss = _candidate(
+        "0",
+        quality=0.1,
+        feature=(0.0, 0.0, 1.0),
+        progress=Fraction(9, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="none",
+        context_relevance="none",
+    )
+
+    # Act
+    result = select_video_set_images(
+        (weaker_near_miss, selected, stronger_near_miss),
+        requested_count=1,
+        spoiler_sensitivity="medium",
+        similarity_threshold=0.72,
+    )
+
+    # Assert
+    assert [item.candidate.identifier for item in result.rejected] == [
+        stronger_near_miss.identifier,
+        weaker_near_miss.identifier,
+    ]
+    assert [
+        round(item.counterfactual_score.marginal_utility, 2) for item in result.rejected
+    ] == [0.66, 0.17]

--- a/tests/video_selection/services/test_select_video_set_images.py
+++ b/tests/video_selection/services/test_select_video_set_images.py
@@ -384,6 +384,82 @@ def test_recurring_gameplay_expands_only_after_each_variant_group() -> None:
     assert "recurring_gameplay_variant" in expanded.reason_codes
 
 
+def test_spoiler_guarded_group_does_not_block_recurring_variant_expansion() -> None:
+    """Spoiler上限で採用不能なGroupにより採用可能なvariantが阻害されないこと。
+
+    Arrange:
+        - 同じrecurring sceneに選択済みGroupのvariantと未代表のMajor Spoiler Groupがある
+        - 別sceneのMajor Spoilerでlow感度由来の件数上限が満たされる候補順がある
+    Act:
+        - medium感度で3枚の選定が要求される
+    Assert:
+        - guard対象Groupを待たず採用可能なvariantで要求数が満たされること
+    """
+    # Arrange
+    first = _candidate(
+        "a",
+        quality=0.8,
+        feature=(1.0, 0.0, 0.0),
+        progress=Fraction(1, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="none",
+        context_relevance="none",
+        scene_selection_role="recurring_gameplay",
+        scene_slug="battle",
+    )
+    same_group = _candidate(
+        "b",
+        quality=0.8,
+        feature=(0.96, math.sqrt(1 - 0.96**2), 0.0),
+        progress=Fraction(9, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="none",
+        context_relevance="none",
+        scene_selection_role="recurring_gameplay",
+        scene_slug="battle",
+    )
+    guarded_group = _candidate(
+        "c",
+        quality=127 / 140,
+        feature=(0.0, 1.0, 0.0),
+        progress=Fraction(1, 10),
+        blog_image_type="event",
+        explanation_value="none",
+        context_relevance="none",
+        spoiler_risk="high",
+        scene_selection_role="recurring_gameplay",
+        scene_slug="battle",
+    )
+    selected_major = _candidate(
+        "d",
+        quality=123 / 140,
+        feature=(0.0, 0.97, math.sqrt(1 - 0.97**2)),
+        progress=Fraction(9, 10),
+        blog_image_type="event",
+        explanation_value="none",
+        context_relevance="none",
+        spoiler_risk="high",
+    )
+
+    # Act
+    result = select_video_set_images(
+        (same_group, guarded_group, selected_major, first),
+        requested_count=3,
+        spoiler_sensitivity="medium",
+        similarity_threshold=0.72,
+    )
+
+    # Assert
+    assert [item.candidate.identifier for item in result.selected] == [
+        first.identifier,
+        selected_major.identifier,
+        same_group.identifier,
+    ]
+    assert result.shortfall is False
+    assert result.major_spoiler_limit == 1
+    assert result.major_spoiler_selected_count == 1
+
+
 def test_second_title_is_rejected_with_counterfactual_score() -> None:
     """2枚目のtitleがnear-miss数値を保ったままhard limitで拒否されること。
 
@@ -776,6 +852,62 @@ def test_similarity_above_terminal_ceiling_is_counted_separately() -> None:
     assert rejection.reason_code == "similarity_ceiling"
     assert rejection.nearest_selected_image_id == first.identifier
     assert rejection.similarity == pytest.approx(0.985)
+
+
+def test_rejection_uses_pass_that_satisfied_request() -> None:
+    """要求数を満たした実際のpassでsimilarity rejectionが説明されること。
+
+    Arrange:
+        - base passで選ばれる2候補とbase超0.98以下の高utility候補がある
+    Act:
+        - base passで2枚の選定が満たされる
+    Assert:
+        - 未採用候補が最終到達passによるsimilarity ceilingとして返されること
+    """
+    # Arrange
+    first = _candidate(
+        "e",
+        quality=0.9,
+        feature=(1.0, 0.0),
+        progress=Fraction(1, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="high",
+        context_relevance="none",
+    )
+    similar_near_miss = _candidate(
+        "f",
+        quality=0.89,
+        feature=(0.9, math.sqrt(1 - 0.9**2)),
+        progress=Fraction(9, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="high",
+        context_relevance="none",
+    )
+    diverse_filler = _candidate(
+        "0",
+        quality=0.5,
+        feature=(0.0, 1.0),
+        progress=Fraction(9, 10),
+        blog_image_type="normal_gameplay",
+        explanation_value="none",
+        context_relevance="none",
+    )
+
+    # Act
+    result = select_video_set_images(
+        (similar_near_miss, diverse_filler, first),
+        requested_count=2,
+        spoiler_sensitivity="medium",
+        similarity_threshold=0.72,
+    )
+
+    # Assert
+    assert result.final_similarity_ceiling == 0.72
+    rejection = result.rejected[0]
+    assert rejection.candidate.identifier == similar_near_miss.identifier
+    assert rejection.reason_code == "similarity_ceiling"
+    assert rejection.nearest_selected_image_id == first.identifier
+    assert rejection.similarity == pytest.approx(0.9)
 
 
 def test_rejections_are_ordered_by_counterfactual_utility() -> None:

--- a/tests/video_selection/services/test_stage_version.py
+++ b/tests/video_selection/services/test_stage_version.py
@@ -42,3 +42,23 @@ def test_resolve_models_has_model_resolution_stage_version() -> None:
 
     # Assert
     assert version == "model-resolution-v1"
+
+
+def test_select_images_has_video_set_selection_policy_version() -> None:
+    """最終選定Stageに決定的selector固有versionが付与されること。
+
+    Arrange:
+        - select-images Processing Stageが用意される
+    Act:
+        - Stage versionが解決される
+    Assert:
+        - Video Set selection policy固有のversionが返されること
+    """
+    # Arrange
+    stage = ProcessingStage.SELECT_IMAGES
+
+    # Act
+    version = stage_version(stage)
+
+    # Assert
+    assert version == "video-set-selection-v1"

--- a/tests/video_selection/services/test_stage_version.py
+++ b/tests/video_selection/services/test_stage_version.py
@@ -44,15 +44,15 @@ def test_resolve_models_has_model_resolution_stage_version() -> None:
     assert version == "model-resolution-v1"
 
 
-def test_select_images_has_video_set_selection_policy_version() -> None:
-    """最終選定Stageに決定的selector固有versionが付与されること。
+def test_select_images_keeps_walking_skeleton_version_until_selector_is_wired() -> None:
+    """旧selectorの実行中はwalking skeleton versionが維持されること。
 
     Arrange:
         - select-images Processing Stageが用意される
     Act:
         - Stage versionが解決される
     Assert:
-        - Video Set selection policy固有のversionが返されること
+        - 現行のwalking skeleton versionが返されること
     """
     # Arrange
     stage = ProcessingStage.SELECT_IMAGES
@@ -61,4 +61,4 @@ def test_select_images_has_video_set_selection_policy_version() -> None:
     version = stage_version(stage)
 
     # Assert
-    assert version == "video-set-selection-v1"
+    assert version == "walking-skeleton-0"


### PR DESCRIPTION
## 概要

- Quality 70%・Explanation 25%・Context 5%のSelection Base UtilityとgreedyなMarginal Selection Utilityを実装
- Blog Image Type 70/25/5 soft coverage、title最大1枚、Temporal Diversity Penaltyを実装
- similarity ceilingを設定値から決定的に緩和し、0.98終端と0.995超のVisual Near-Duplicate hard blockを実装
- scene内Variant Groupを入力順非依存で構築し、recurring gameplayを各Group一巡後だけ拡張
- Spoiler Sensitivity上昇時にMajor Spoiler選択数が増えないmonotonicity guardを追加
- stable tie-break、Selection Shortfall、rejection enum、Counterfactual Selection Scoreを結果contractへ追加
- lazyなSelection Shortlist batch拡張時に、拡張pool全体から空の選択状態で再計算
- CONTEXT、ADR 0004、README、Vision Stage文書を更新し、Selection Stage運用文書を追加

## 主な仕様判断

- model自由文やconfidenceではなく、domain enumとlocal numeric componentだけで採否を再現する
- coverageはhard quotaにせず、候補不足時は有用なtypeの超過を許す
- Video Orderや後半位置自体をquality・spoiler根拠にせず、動画ごとの最低採用枠を設けない
- 旧Cinematic Soft Capを新selectorへ持ち込まない
- 2枚目のtitle、Visual Near-Duplicate、不適格frame、未完了Annotationでshortfallを穴埋めしない
- public CLIとpackage versionは変更しない

## 検証

- `uv run task test`: 475 passed
- Ruff check / format: 成功
- strict mypy: 345 source files成功
- exact normalized selector golden、入力順不変性、spoiler metamorphic反例、soft coverage、variant expansion、shortlist expansion、tie-break、near-miss順を検証

## Follow-up

- WebP・Canonical Selection Report・atomic publicationは#187
- real model capacityとtarget性能受け入れは#189
- public video CLI cutoverは#190

関連: #186


