### PR TITLE
feat: canonical選定成果物のatomic公開を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## 動画入力版の設計と内部実装（公開前）
 
-複数のゲーム録画を一つのVideo Setとして扱う次期interfaceは、次の一つのcommandへ置き換える設計です。探索・content identity・Input Lock・Completed Stage cache、system FFmpeg/ffprobeを閉じ込めるMediaRuntimeに加え、動画単位のscan、exact timeline、Candidate Moment、native frame refinement、model-free Neutral Image Analysis、embedded subtitle/audio STTからのContext Cue収集、Ollama/Hugging Faceのmodel lifecycleとrun単位のidentity freeze、共有Scene Catalog、Moment単位のCandidate Annotation、soft coverage・spoiler・動画横断diversityを扱う決定的な最終selectorまで内部実装済みです。canonical reportとpublic CLIの接続・切り替えは後続Issueで行うため、このcommandはまだ実行できません。
+複数のゲーム録画を一つのVideo Setとして扱う次期interfaceは、次の一つのcommandへ置き換える設計です。探索・content identity・Input Lock・Completed Stage cache、system FFmpeg/ffprobeを閉じ込めるMediaRuntimeに加え、動画単位のscan、exact timeline、Candidate Moment、native frame refinement、model-free Neutral Image Analysis、embedded subtitle/audio STTからのContext Cue収集、Ollama/Hugging Faceのmodel lifecycleとrun単位のidentity freeze、共有Scene Catalog、Moment単位のCandidate Annotation、soft coverage・spoiler・動画横断diversityを扱う決定的な最終selector、固定WebP、`game-screen-pick/report@1.0.0`、gallery-first Markdown、atomic publisherまで内部実装済みです。Video Set applicationへのcanonical publisher接続とpublic CLI切り替えは後続Issueで行うため、このcommandはまだ実行できません。
 
 ```bash
 game-screen-pick \

--- a/docs/adr/0005-publish-video-selection-artifacts-atomically.md
+++ b/docs/adr/0005-publish-video-selection-artifacts-atomically.md
@@ -68,8 +68,10 @@ Each selected output record includes relative path, SHA-256, width, height, and 
 Both reports identify a source with:
 
 - Video Order;
-- short Video Source ID;
+- Video Source ID, normally shortened to a 12-character fingerprint prefix;
 - Report Source Path relative to the Video Input Folder.
+
+If two source fingerprints share that prefix, only the colliding IDs expand to the complete 64-character fingerprint. Source IDs must remain unique within a report.
 
 The relative path uses `/`, contains no `..`, and never acts as Video Identity. Absolute input, cache, staging, and output paths are omitted.
 
@@ -96,6 +98,8 @@ For a selected image or published near miss, `report.json` stores:
 ```
 
 The reduced `offset_seconds` rational is authoritative. Float seconds and frame index are not part of the public contract. The display value uses unbounded hours, does not wrap at 24 hours, and rounds half-up to milliseconds.
+
+Context Cue records retain their source timestamp basis. When container cue timing is not losslessly aligned to an integer source PTS grid, the record omits reconstructed PTS values and uses the authoritative reduced `offset_seconds` form instead.
 
 `report.json` also keeps Candidate Moment ID and Timeline Segment ID for selected images. `report.md` shows only Video Order, Report Source Path, Video Source ID, and display time.
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -20,6 +20,8 @@ output/
 
 画像名は全体選択順、Scene Slug、Frame Candidate IDの短縮digestから作ります。安定identityはfilenameではなく、完全なFrame Candidate IDです。
 
+Video Source IDは通常、whole-file SHA-256の先頭12文字を使います。同じVideo Set内でそのprefixが衝突した場合は、衝突したsourceだけを64文字の完全digestへ拡張し、一意性を保ちます。
+
 producerが検証する厳密なschema実体は[`report-1.0.0.schema.json`](../src/video_selection/schemas/report-1.0.0.schema.json)です。readerは同じmajorの将来minor field／enumを保持できるcompatibility gateを別に持ち、producerの厳密検証とは分離しています。report schema versionはpackage versionから独立します。
 
 ## provenanceとmodel更新
@@ -30,7 +32,9 @@ producerが検証する厳密なschema実体は[`report-1.0.0.schema.json`](../s
 
 ## 公開しない情報
 
-絶対path、環境変数、credential、prompt本文、raw model response、stack trace、字幕・STT本文、生成した画面内textの逐語引用はreportへ含めません。Context CueはID、source、正確な時間範囲、reliability、選定への関連度だけを公開します。
+絶対path、環境変数、credential、prompt本文、raw model response、stack trace、字幕・STT本文、生成した画面内textの逐語引用はreportへ含めません。Context CueはID、source、正確な時間範囲、reliability、選定への関連度だけを公開します。逐語転載の検査はmodel由来の公開自由文を対象とし、独立生成と区別できない1〜2文字の一般語は引用判定から除外します。
+
+Context Cueの時刻がsource streamの整数PTS gridへlosslessに対応する場合は、`source_pts`、`origin_pts`、`time_base`を保持します。containerが与えるCue時刻とPTS gridが非整列の場合は、`timestamp_basis`を維持しつつ、reduced rationalの`offset_seconds`へlosslessにfallbackします。
 
 Spoiler Riskは常時表示しますが、`none`以外の短いevidence summaryはMarkdownで閉じた`details`にします。選定に使ったSpoiler Penaltyとは別fieldです。
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -1,7 +1,7 @@
 # 動画入力の成果物
 
 > [!IMPORTANT]
-> この文書は将来のVideo Set selectorの確定済み契約です。現在のscreenshot入力実装ではまだ生成されません。
+> この文書のWebP encoder、Canonical Selection Report producer、Markdown renderer、検証、atomic publisherは内部実装済みです。現在のpublic commandはまだscreenshot入力版であり、Video Set applicationへの接続とCLI切り替えまでは生成されません。
 
 成功した一つのrunは、Output Folderへ次の成果物をatomicに公開します。
 
@@ -20,6 +20,8 @@ output/
 
 画像名は全体選択順、Scene Slug、Frame Candidate IDの短縮digestから作ります。安定identityはfilenameではなく、完全なFrame Candidate IDです。
 
+producerが検証する厳密なschema実体は[`report-1.0.0.schema.json`](../src/video_selection/schemas/report-1.0.0.schema.json)です。readerは同じmajorの将来minor field／enumを保持できるcompatibility gateを別に持ち、producerの厳密検証とは分離しています。report schema versionはpackage versionから独立します。
+
 ## provenanceとmodel更新
 
 `report.json`は各Processing Stageについて、完全なStage Fingerprint、上流fingerprint、cache結果、実行時間、正規化済み設定、tool/runtime version、実行時に解決した完全なmodel digestまたはcommit SHAを保持します。`report.md`は短縮fingerprintと主要診断だけを表示します。
@@ -33,5 +35,7 @@ output/
 Spoiler Riskは常時表示しますが、`none`以外の短いevidence summaryはMarkdownで閉じた`details`にします。選定に使ったSpoiler Penaltyとは別fieldです。
 
 Selection Shortfallはwarning付き正常成果物として選択済みsubsetを公開します。model更新が利用不能でも完全でload可能なlocal artifactを再検査できた場合は、`model_update_unavailable`と対象roleをwarningとして公開します。それ以外のfatal error、schema不正、renderer失敗、成果物不一致ではOutput Folderを公開しません。
+
+publisherはartifact生成前に同じparent内のdirectory renameをprobeし、元動画のsnapshotを開始時と最終rename直前に再検証します。hidden sibling staging内のfileとdirectoryをflushし、schema・画像hash／寸法／path・JSON serialization・Markdown再render・privacy・layoutを検証してから一回だけfinal renameを行い、そのparent directoryもflushします。renameの前後を含む失敗時はstagingとfinal Output Folderを除去します。
 
 完全なfield、命名、時刻、near miss、schema evolution、atomic publication契約は[ADR 0005](adr/0005-publish-video-selection-artifacts-atomically.md)を参照してください。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "click>=8.1.7",
     "faster-whisper>=1.2.1,<2.0.0",
     "huggingface-hub>=0.36.2,<1.0.0",
+    "jsonschema>=4.23.0,<5.0.0",
     "numpy>=2.3.1",
     "opencv-python>=4.11.0.86",
     "pillow>=12.1.0",
@@ -36,6 +37,7 @@ dev = [
     "python-decouple-stubs>=0.1",
     "ruff>=0.14.10",
     "taskipy>=1.14.1",
+    "types-jsonschema>=4.23.0.20240813",
     "types-requests>=2.32.4.20250913",
     "vulture>=2.14",
 ]

--- a/src/video_selection/media/ffmpeg_media_runtime.py
+++ b/src/video_selection/media/ffmpeg_media_runtime.py
@@ -349,6 +349,35 @@ class FfmpegMediaRuntime:
             msg = "max_dimensionは正の整数である必要があります"
             raise ValueError(msg)
         frame_filter = f"select=eq(pts\\,{pts})," + _scale_filter(max_dimension)
+        return self._extract_exact_video_frame(
+            media_path,
+            stream_index,
+            pts,
+            frame_filter,
+        )
+
+    def extract_original_video_frame(
+        self,
+        media_path: Path,
+        stream_index: int,
+        pts: int,
+    ) -> DecodedVideoFrame:
+        """指定source PTSの一つの元寸法RGB24 frameを返す。"""
+        return self._extract_exact_video_frame(
+            media_path,
+            stream_index,
+            pts,
+            f"select=eq(pts\\,{pts}),format=rgb24,showinfo",
+        )
+
+    def _extract_exact_video_frame(
+        self,
+        media_path: Path,
+        stream_index: int,
+        pts: int,
+        frame_filter: str,
+    ) -> DecodedVideoFrame:
+        """指定filterでexact PTSのRGB24 frameを一つだけ返す。"""
         command = self._video_decode_command(
             media_path,
             stream_index,

--- a/src/video_selection/models/canonical_publication_request.py
+++ b/src/video_selection/models/canonical_publication_request.py
@@ -1,0 +1,138 @@
+"""Canonical Selection Report公開に必要な確定済みdomain input。"""
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+
+from .candidate_annotation import candidate_annotation_free_text_is_safe
+from .effective_configuration import EffectiveConfiguration
+from .report_provenance import ReportProvenance
+from .resolved_models import ResolvedModels
+from .scene_catalog import SceneCatalog
+from .video_set import VideoSet
+from .video_set_selection_result import VideoSetSelectionResult
+from .video_stage_result import VideoStageResult
+
+_RUN_ID = re.compile(r"run_[0-9A-Za-z][0-9A-Za-z._:-]{0,127}")
+_CONTEXT_CUE_ID = re.compile(r"cue_[0-9a-f]{64}")
+
+
+@dataclass(frozen=True)
+class CanonicalPublicationRequest:
+    """公開済みartifact以外の全Canonical report sourceをまとめる。"""
+
+    video_set: VideoSet
+    video_stage_results: tuple[VideoStageResult, ...]
+    scene_catalog: SceneCatalog
+    selection_result: VideoSetSelectionResult
+    resolved_models: ResolvedModels
+    configuration: EffectiveConfiguration
+    run_id: str
+    started_at: datetime
+    completed_at: datetime
+    provenance: ReportProvenance
+
+    def __post_init__(self) -> None:
+        """source、selection、Catalog、Cue、run metadataの整合を検証する。"""
+        if (
+            _RUN_ID.fullmatch(self.run_id) is None
+            or self.started_at.tzinfo is None
+            or self.completed_at.tzinfo is None
+            or self.completed_at < self.started_at
+            or self.configuration.video_input_folder.resolve(strict=False)
+            != self.video_set.input_folder.resolve(strict=False)
+            or self.configuration.image_count != self.selection_result.requested_count
+            or tuple(item.source for item in self.video_stage_results)
+            != self.video_set.sources
+        ):
+            msg = "Canonical Publication RequestのrunまたはVideo Setが不正です"
+            raise ValueError(msg)
+        selected = self.selection_result.selected
+        rejected = self.selection_result.rejected
+        if tuple(item.selection_index for item in selected) != tuple(
+            range(1, len(selected) + 1)
+        ):
+            msg = "Selected Imageのselection indexが連続していません"
+            raise ValueError(msg)
+        selected_ids = tuple(item.candidate.identifier for item in selected)
+        rejected_ids = tuple(item.candidate.identifier for item in rejected)
+        if (
+            len(selected_ids) != len(set(selected_ids))
+            or len(rejected_ids) != len(set(rejected_ids))
+            or set(selected_ids) & set(rejected_ids)
+            or len(selected) + len(rejected)
+            != self.selection_result.annotated_candidate_count
+        ):
+            msg = "Canonical Publication Requestの選定集合が不正です"
+            raise ValueError(msg)
+        stages_by_fingerprint = {
+            item.source.fingerprint: item for item in self.video_stage_results
+        }
+        cues = tuple(
+            cue for stage in self.video_stage_results for cue in stage.context.cues
+        )
+        cue_ids = tuple(item.identifier for item in cues)
+        if len(cue_ids) != len(set(cue_ids)) or not all(
+            _stage_context_cues_are_valid(stage) for stage in self.video_stage_results
+        ):
+            msg = "Canonical Publication RequestのContext Cueが不正です"
+            raise ValueError(msg)
+        candidates = (
+            *(item.candidate for item in selected),
+            *(item.candidate for item in rejected),
+        )
+        raw_context_texts = tuple(cue.text for cue in cues if cue.text)
+        for candidate in candidates:
+            frame = candidate.annotation.candidate
+            fingerprint = frame.video_fingerprint
+            if fingerprint is None or fingerprint not in stages_by_fingerprint:
+                msg = "Blog CandidateのVideo Sourceが見つかりません"
+                raise ValueError(msg)
+            stage = stages_by_fingerprint[fingerprint]
+            source_index = self.video_set.sources.index(stage.source)
+            moment_ids = {moment.identifier for moment in stage.extraction.moments}
+            stage_cue_ids = {cue.identifier for cue in stage.context.cues}
+            annotation = candidate.annotation
+            scene = self.scene_catalog.for_slug(annotation.scene_slug)
+            if (
+                candidate.video_order != source_index
+                or annotation.candidate_moment_id not in moment_ids
+                or candidate.scene_selection_role != scene.selection_role
+                or not set(annotation.supporting_context_cue_ids) <= stage_cue_ids
+                or not candidate_annotation_free_text_is_safe(
+                    (
+                        annotation.summary,
+                        annotation.frame_choice_reason or "",
+                        annotation.spoiler_evidence,
+                    ),
+                    raw_context_texts,
+                )
+            ):
+                msg = "Blog Candidateのsource、Moment、Scene、Context Cueが不正です"
+                raise ValueError(msg)
+
+
+def _stage_context_cues_are_valid(stage: VideoStageResult) -> bool:
+    """一つのVideo Stageに属する公開対象Cueの基本契約を検証する。"""
+    duration = stage.scan.timeline.duration.seconds
+    for cue in stage.context.cues:
+        provenance = cue.provenance
+        if (
+            _CONTEXT_CUE_ID.fullmatch(cue.identifier) is None
+            or cue.video_fingerprint != stage.source.fingerprint
+            or cue.source_kind not in {"embedded_subtitle", "speech_to_text"}
+            or cue.timestamp_basis
+            not in {"source_pts", "container_text_ms", "asr_sample_grid_estimate"}
+            or cue.stream_index < 0
+            or cue.start < 0
+            or cue.end <= cue.start
+            or cue.end > duration
+            or not cue.text.strip()
+            or cue.reliability != "usable"
+            or provenance is None
+            or provenance.source_time_base <= 0
+            or provenance.language_source
+            not in {"stream_metadata", "speech_recognition"}
+        ):
+            return False
+    return True

--- a/src/video_selection/models/report_provenance.py
+++ b/src/video_selection/models/report_provenance.py
@@ -1,0 +1,48 @@
+"""Canonical Selection Reportのrun-level provenance。"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from .model_role import ModelRole
+from .report_stage_provenance import ReportStageProvenance
+from .report_value import validate_privacy_safe_mapping, validate_reference
+
+
+@dataclass(frozen=True)
+class ReportProvenance:
+    """runtime、tool、contract registryとStage診断を保持する。"""
+
+    runtime: Mapping[str, object]
+    tools: Mapping[str, str]
+    contracts: Mapping[str, str]
+    stages: tuple[ReportStageProvenance, ...]
+
+    def __post_init__(self) -> None:
+        """registry参照とprivacy-safeな値だけを受理する。"""
+        if not self.tools or not self.contracts or not self.stages:
+            msg = "Report provenanceにはtool、contract、Stageが必要です"
+            raise ValueError(msg)
+        validate_privacy_safe_mapping(self.runtime, field_name="Report runtime")
+        validate_privacy_safe_mapping(self.tools, field_name="Report tools")
+        validate_privacy_safe_mapping(self.contracts, field_name="Report contracts")
+        for registry_name, registry in (
+            ("tools", self.tools),
+            ("contracts", self.contracts),
+        ):
+            for key in registry:
+                validate_reference(key, field_name=f"Report {registry_name}")
+        names = tuple(item.name for item in self.stages)
+        fingerprints = {item.fingerprint for item in self.stages}
+        if len(names) != len(set(names)) or len(fingerprints) != len(self.stages):
+            msg = "Report Stageのnameとfingerprintは一意である必要があります"
+            raise ValueError(msg)
+        model_refs = {role.value for role in ModelRole}
+        for stage in self.stages:
+            if (
+                not set(stage.upstream_fingerprints) <= fingerprints
+                or not set(stage.tool_refs) <= set(self.tools)
+                or not set(stage.model_refs) <= model_refs
+                or not set(stage.contract_refs) <= set(self.contracts)
+            ):
+                msg = "Report Stage provenanceのregistry参照が解決できません"
+                raise ValueError(msg)

--- a/src/video_selection/models/report_stage_provenance.py
+++ b/src/video_selection/models/report_stage_provenance.py
@@ -1,0 +1,65 @@
+"""Human/Canonical reportへ公開するStage provenance。"""
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from .report_value import validate_privacy_safe_mapping, validate_reference
+
+_STAGE_FINGERPRINT = re.compile(r"stg_[0-9a-f]{64}")
+
+
+@dataclass(frozen=True)
+class ReportStageProvenance:
+    """一つのProcessing Stageのprivacy-safeな再現診断。"""
+
+    name: str
+    fingerprint: str
+    upstream_fingerprints: tuple[str, ...]
+    cache_hits: int
+    cache_misses: int
+    recomputed_items: int
+    attempt_count: int
+    validation_failures: int
+    effective_settings: Mapping[str, object]
+    tool_refs: tuple[str, ...]
+    model_refs: tuple[str, ...]
+    contract_refs: tuple[str, ...]
+    duration_ms: int
+    prompt_eval_tokens: int | None = None
+    eval_tokens: int | None = None
+
+    def __post_init__(self) -> None:
+        """fingerprint、件数、registry参照、設定の公開安全性を検証する。"""
+        validate_reference(self.name, field_name="Report Stage name")
+        fingerprints = (self.fingerprint, *self.upstream_fingerprints)
+        counts = (
+            self.cache_hits,
+            self.cache_misses,
+            self.recomputed_items,
+            self.attempt_count,
+            self.validation_failures,
+            self.duration_ms,
+        )
+        optional_counts = (self.prompt_eval_tokens, self.eval_tokens)
+        reference_groups = (self.tool_refs, self.model_refs, self.contract_refs)
+        if (
+            any(_STAGE_FINGERPRINT.fullmatch(item) is None for item in fingerprints)
+            or len(self.upstream_fingerprints) != len(set(self.upstream_fingerprints))
+            or any(item < 0 for item in counts)
+            or any(item is not None and item < 0 for item in optional_counts)
+            or any(len(group) != len(set(group)) for group in reference_groups)
+        ):
+            msg = "Report Stage provenanceのfingerprintまたは件数が不正です"
+            raise ValueError(msg)
+        for group_name, group in (
+            ("tool_refs", self.tool_refs),
+            ("model_refs", self.model_refs),
+            ("contract_refs", self.contract_refs),
+        ):
+            for item in group:
+                validate_reference(item, field_name=group_name)
+        validate_privacy_safe_mapping(
+            self.effective_settings,
+            field_name="Report Stage effective settings",
+        )

--- a/src/video_selection/models/report_value.py
+++ b/src/video_selection/models/report_value.py
@@ -1,0 +1,77 @@
+"""report provenanceへ安全に含められるJSON値の検証。"""
+
+import json
+import math
+import re
+from collections.abc import Mapping
+
+_WINDOWS_ABSOLUTE_PATH = re.compile(r"[A-Za-z]:[\\/]")
+_SAFE_REFERENCE = re.compile(r"[a-z0-9][a-z0-9._-]{0,127}")
+_PRIVATE_KEY_PARTS = (
+    "credential",
+    "environment_variable",
+    "host",
+    "password",
+    "path",
+    "prompt_body",
+    "raw_response",
+    "secret",
+    "stack_trace",
+    "token_value",
+)
+
+
+def validate_privacy_safe_mapping(
+    value: Mapping[str, object],
+    *,
+    field_name: str,
+) -> None:
+    """pathやsecret-bearing keyを含まないJSON mappingを検証する。"""
+    try:
+        json.dumps(value, ensure_ascii=False, allow_nan=False)
+    except (TypeError, ValueError) as error:
+        msg = f"{field_name}には有限なJSON値が必要です"
+        raise ValueError(msg) from error
+    _validate_value(value, field_name)
+
+
+def validate_reference(value: str, *, field_name: str) -> None:
+    """registry参照に使えるprivacy-safeな短い名前を検証する。"""
+    if _SAFE_REFERENCE.fullmatch(value) is None:
+        msg = f"{field_name}にはcanonical reference nameが必要です"
+        raise ValueError(msg)
+
+
+def string_looks_private(value: str) -> bool:
+    """絶対path、endpoint、改行を含む文字列かを返す。"""
+    return (
+        (value != "/" and value.startswith(("/", "\\")))
+        or _WINDOWS_ABSOLUTE_PATH.match(value) is not None
+        or "://" in value
+        or "\n" in value
+        or "\r" in value
+    )
+
+
+def _validate_value(value: object, location: str) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                msg = f"{location}のkeyは文字列である必要があります"
+                raise ValueError(msg)
+            normalized_key = key.casefold()
+            if any(part in normalized_key for part in _PRIVATE_KEY_PARTS):
+                msg = f"{location}に非公開keyは指定できません: {key}"
+                raise ValueError(msg)
+            _validate_value(item, f"{location}.{key}")
+        return
+    if isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            _validate_value(item, f"{location}[{index}]")
+        return
+    if isinstance(value, str) and string_looks_private(value):
+        msg = f"{location}に絶対pathまたはendpointは指定できません"
+        raise ValueError(msg)
+    if isinstance(value, float) and not math.isfinite(value):
+        msg = f"{location}には有限値が必要です"
+        raise ValueError(msg)

--- a/src/video_selection/models/selected_image_artifact.py
+++ b/src/video_selection/models/selected_image_artifact.py
@@ -1,0 +1,38 @@
+"""staging済みSelected Image artifact。"""
+
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+_FRAME_ID = re.compile(r"frm_[0-9a-f]{64}")
+_SHA256 = re.compile(r"[0-9a-f]{64}")
+
+
+@dataclass(frozen=True)
+class SelectedImageArtifact:
+    """選択frameと公開WebPのidentity、path、内容診断を結ぶ。"""
+
+    image_id: str
+    relative_path: str
+    sha256: str
+    width: int
+    height: int
+    size_bytes: int
+
+    def __post_init__(self) -> None:
+        """stable ID、relative WebP path、hash、寸法を検証する。"""
+        path = PurePosixPath(self.relative_path)
+        if (
+            _FRAME_ID.fullmatch(self.image_id) is None
+            or _SHA256.fullmatch(self.sha256) is None
+            or path.is_absolute()
+            or ".." in path.parts
+            or path.parts[:1] != ("images",)
+            or path.suffix != ".webp"
+            or self.relative_path != path.as_posix()
+            or self.width < 1
+            or self.height < 1
+            or self.size_bytes < 1
+        ):
+            msg = "Selected Image artifactのID、path、hash、寸法が不正です"
+            raise ValueError(msg)

--- a/src/video_selection/protocols/media_runtime.py
+++ b/src/video_selection/protocols/media_runtime.py
@@ -62,6 +62,14 @@ class MediaRuntime(Protocol):
     ) -> DecodedVideoFrame:
         """指定source PTSの一つのframeを返す。"""
 
+    def extract_original_video_frame(
+        self,
+        media_path: Path,
+        stream_index: int,
+        pts: int,
+    ) -> DecodedVideoFrame:
+        """指定source PTSの一つの元寸法frameを返す。"""
+
     def write_mjpeg_proxy(
         self,
         frame: DecodedVideoFrame,

--- a/src/video_selection/protocols/selected_frame_media_runtime.py
+++ b/src/video_selection/protocols/selected_frame_media_runtime.py
@@ -1,0 +1,19 @@
+"""Selected Image公開に必要なMediaRuntime port。"""
+
+from pathlib import Path
+from typing import Protocol
+
+from ..models.decoded_video_frame import DecodedVideoFrame
+
+
+class SelectedFrameMediaRuntime(Protocol):
+    """exact PTSの元解像度frame再抽出だけを公開する境界。"""
+
+    def extract_video_frame(
+        self,
+        media_path: Path,
+        stream_index: int,
+        pts: int,
+        max_dimension: int,
+    ) -> DecodedVideoFrame:
+        """指定source PTSの一つのRGB24 frameを返す。"""

--- a/src/video_selection/protocols/selected_frame_media_runtime.py
+++ b/src/video_selection/protocols/selected_frame_media_runtime.py
@@ -9,11 +9,10 @@ from ..models.decoded_video_frame import DecodedVideoFrame
 class SelectedFrameMediaRuntime(Protocol):
     """exact PTSの元解像度frame再抽出だけを公開する境界。"""
 
-    def extract_video_frame(
+    def extract_original_video_frame(
         self,
         media_path: Path,
         stream_index: int,
         pts: int,
-        max_dimension: int,
     ) -> DecodedVideoFrame:
-        """指定source PTSの一つのRGB24 frameを返す。"""
+        """指定source PTSの一つの元寸法RGB24 frameを返す。"""

--- a/src/video_selection/schemas/report-1.0.0.schema.json
+++ b/src/video_selection/schemas/report-1.0.0.schema.json
@@ -254,7 +254,7 @@
       "additionalProperties": false,
       "required": ["id", "order", "relative_path", "fingerprint", "duration"],
       "properties": {
-        "id": {"type": "string", "pattern": "^vid_[0-9a-f]{12}$"},
+        "id": {"type": "string", "pattern": "^vid_(?:[0-9a-f]{12}|[0-9a-f]{64})$"},
         "order": {"type": "integer", "minimum": 1},
         "relative_path": {"type": "string", "minLength": 1},
         "fingerprint": {
@@ -331,7 +331,7 @@
       "additionalProperties": false,
       "required": ["video_id", "candidate_moment_id", "timeline_segment_id", "video_time", "video_set_progress"],
       "properties": {
-        "video_id": {"type": "string", "pattern": "^vid_[0-9a-f]{12}$"},
+        "video_id": {"type": "string", "pattern": "^vid_(?:[0-9a-f]{12}|[0-9a-f]{64})$"},
         "candidate_moment_id": {"type": "string", "pattern": "^mom_[0-9a-f]{64}$"},
         "timeline_segment_id": {"type": "string", "pattern": "^seg_[0-9a-f]{64}$"},
         "video_time": {"$ref": "#/$defs/videoTime"},
@@ -472,7 +472,7 @@
       "required": ["id", "video_id", "source_kind", "stream_index", "language", "timestamp_basis", "start", "end", "reliability", "text_included"],
       "properties": {
         "id": {"type": "string", "pattern": "^cue_[0-9a-f]{64}$"},
-        "video_id": {"type": "string", "pattern": "^vid_[0-9a-f]{12}$"},
+        "video_id": {"type": "string", "pattern": "^vid_(?:[0-9a-f]{12}|[0-9a-f]{64})$"},
         "source_kind": {"enum": ["embedded_subtitle", "speech_to_text"]},
         "stream_index": {"type": "integer", "minimum": 0},
         "language": {

--- a/src/video_selection/schemas/report-1.0.0.schema.json
+++ b/src/video_selection/schemas/report-1.0.0.schema.json
@@ -1,0 +1,624 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://game-screen-pick.local/schemas/report-1.0.0.schema.json",
+  "title": "game-screen-pick Canonical Selection Report 1.0.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "run",
+    "artifacts",
+    "video_set",
+    "selection_summary",
+    "rejection_summary",
+    "selected",
+    "near_miss_publication",
+    "near_misses",
+    "context_cues",
+    "provenance",
+    "privacy"
+  ],
+  "properties": {
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": {"const": "game-screen-pick/report"},
+        "version": {"const": "1.0.0"}
+      }
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "status",
+        "started_at",
+        "completed_at",
+        "requested_image_count",
+        "selected_image_count",
+        "warnings"
+      ],
+      "properties": {
+        "id": {"type": "string", "pattern": "^run_[0-9A-Za-z][0-9A-Za-z._:-]{0,127}$"},
+        "status": {"enum": ["completed", "completed_with_warnings"]},
+        "started_at": {"type": "string", "pattern": "Z$"},
+        "completed_at": {"type": "string", "pattern": "Z$"},
+        "requested_image_count": {"type": "integer", "minimum": 1},
+        "selected_image_count": {"type": "integer", "minimum": 0},
+        "warnings": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/warning"}
+        }
+      }
+    },
+    "artifacts": {"$ref": "#/$defs/artifacts"},
+    "video_set": {"$ref": "#/$defs/videoSet"},
+    "selection_summary": {"$ref": "#/$defs/selectionSummary"},
+    "rejection_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "by_reason"],
+      "properties": {
+        "total": {"type": "integer", "minimum": 0},
+        "by_reason": {
+          "type": "object",
+          "additionalProperties": {"type": "integer", "minimum": 0}
+        }
+      }
+    },
+    "selected": {"type": "array", "items": {"$ref": "#/$defs/selected"}},
+    "near_miss_publication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "json_limit_formula",
+        "json_limit_for_this_run",
+        "markdown_limit",
+        "coverage",
+        "fill_order"
+      ],
+      "properties": {
+        "json_limit_formula": {"type": "string"},
+        "json_limit_for_this_run": {"type": "integer", "minimum": 0, "maximum": 100},
+        "markdown_limit": {"const": 10},
+        "coverage": {"const": "at_least_one_per_rejection_reason"},
+        "fill_order": {"const": "counterfactual_marginal_utility_desc_then_selection_tie_break"}
+      }
+    },
+    "near_misses": {"type": "array", "items": {"$ref": "#/$defs/nearMiss"}},
+    "context_cues": {"type": "array", "items": {"$ref": "#/$defs/contextCue"}},
+    "provenance": {"$ref": "#/$defs/provenance"},
+    "privacy": {"$ref": "#/$defs/privacy"}
+  },
+  "$defs": {
+    "warning": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["code", "message", "details"],
+          "properties": {
+            "code": {"const": "selection_shortfall"},
+            "message": {"type": "string", "minLength": 1},
+            "details": {
+              "type": "object",
+              "additionalProperties": {"type": "integer", "minimum": 0}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["code", "message", "details"],
+          "properties": {
+            "code": {"const": "model_update_unavailable"},
+            "message": {"type": "string", "minLength": 1},
+            "details": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["roles"],
+              "properties": {
+                "roles": {
+                  "type": "array",
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "items": {"enum": ["candidate_annotation", "scene_catalog", "speech_to_text"]}
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "rational": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["numerator", "denominator"],
+      "properties": {
+        "numerator": {"type": "integer"},
+        "denominator": {"type": "integer", "minimum": 1}
+      }
+    },
+    "videoTime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_pts", "origin_pts", "time_base", "offset_seconds", "display"],
+      "properties": {
+        "source_pts": {"type": "integer"},
+        "origin_pts": {"type": "integer"},
+        "time_base": {"$ref": "#/$defs/rational"},
+        "offset_seconds": {"$ref": "#/$defs/rational"},
+        "display": {"type": "string", "pattern": "^[0-9]{2,}:[0-5][0-9]:[0-5][0-9]\\.[0-9]{3}$"}
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["report_json", "report_markdown", "image_directory", "image_contract", "publication_contract", "projection_contract"],
+      "properties": {
+        "report_json": {"const": "report.json"},
+        "report_markdown": {"const": "report.md"},
+        "image_directory": {"const": "images"},
+        "image_contract": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["frame_candidate_id_algorithm", "frame_candidate_id_format", "filename_pattern", "format", "encoding", "quality", "color_space", "metadata", "size_policy", "configurable", "status"],
+          "properties": {
+            "frame_candidate_id_algorithm": {"const": "video-fingerprint-video-time-sha256-v1"},
+            "frame_candidate_id_format": {"const": "frm_<64-lowercase-hex>"},
+            "filename_pattern": {"type": "string"},
+            "format": {"const": "webp"},
+            "encoding": {"const": "lossy"},
+            "quality": {"const": 95},
+            "color_space": {"const": "srgb"},
+            "metadata": {"const": "stripped"},
+            "size_policy": {"const": "source_dimensions"},
+            "configurable": {"const": false},
+            "status": {"const": "fixed_for_v1"}
+          }
+        },
+        "publication_contract": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode", "staging", "validated_before_publish", "non_atomic_fallback"],
+          "properties": {
+            "mode": {"const": "atomic_directory_rename"},
+            "staging": {"const": "hidden_sibling_same_filesystem"},
+            "validated_before_publish": {"const": true},
+            "non_atomic_fallback": {"const": false}
+          }
+        },
+        "projection_contract": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["canonical_machine_report", "markdown_source", "cache_or_model_reread", "json_key_order_significant", "cross_artifact_mismatch", "selected_image_rendering", "thumbnail_artifacts", "alt_text"],
+          "properties": {
+            "canonical_machine_report": {"const": "report.json"},
+            "markdown_source": {"const": "validated_canonical_report_object"},
+            "cache_or_model_reread": {"const": false},
+            "json_key_order_significant": {"const": false},
+            "cross_artifact_mismatch": {"const": "fatal"},
+            "selected_image_rendering": {"const": "clickable_inline_original"},
+            "thumbnail_artifacts": {"const": false},
+            "alt_text": {"const": "selection_index_and_scene_display_name"}
+          }
+        }
+      }
+    },
+    "videoSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "fingerprint_algorithm", "time_contract", "source_path_policy", "duration", "sources"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^vset_[0-9a-f]{12}$"},
+        "fingerprint_algorithm": {"const": "ordered-video-sha256-v1"},
+        "time_contract": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["authoritative_value", "display_format", "display_rounding", "frame_index"],
+          "properties": {
+            "authoritative_value": {"const": "offset_seconds_rational"},
+            "display_format": {"const": "unbounded_hours_HH:MM:SS.mmm"},
+            "display_rounding": {"const": "half_up"},
+            "frame_index": {"const": "omitted"}
+          }
+        },
+        "source_path_policy": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["base", "separator", "parent_segments", "absolute_paths"],
+          "properties": {
+            "base": {"const": "video_input_folder"},
+            "separator": {"const": "/"},
+            "parent_segments": {"const": "forbidden"},
+            "absolute_paths": {"const": "omitted"}
+          }
+        },
+        "duration": {"$ref": "#/$defs/duration"},
+        "sources": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/videoSource"}}
+      }
+    },
+    "duration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exact_seconds", "display"],
+      "properties": {
+        "exact_seconds": {"type": "string", "minLength": 1},
+        "display": {"type": "string", "pattern": "^[0-9]{2,}:[0-5][0-9]:[0-5][0-9]\\.[0-9]{3}$"}
+      }
+    },
+    "videoSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "order", "relative_path", "fingerprint", "duration"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^vid_[0-9a-f]{12}$"},
+        "order": {"type": "integer", "minimum": 1},
+        "relative_path": {"type": "string", "minLength": 1},
+        "fingerprint": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["algorithm", "value"],
+          "properties": {
+            "algorithm": {"const": "sha256-whole-file"},
+            "value": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+          }
+        },
+        "duration": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source_pts", "origin_pts", "time_base", "exact_seconds", "display"],
+          "properties": {
+            "source_pts": {"type": "integer"},
+            "origin_pts": {"type": "integer"},
+            "time_base": {"$ref": "#/$defs/rational"},
+            "exact_seconds": {"type": "string", "minLength": 1},
+            "display": {"type": "string", "pattern": "^[0-9]{2,}:[0-5][0-9]:[0-5][0-9]\\.[0-9]{3}$"}
+          }
+        }
+      }
+    },
+    "selectionSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["candidate_moments", "moments_without_valid_frame", "candidate_annotations", "candidate_annotation_failures", "selected", "not_selected", "final_similarity_ceiling", "shortlist_expansion_count", "shortfall", "blog_image_type"],
+      "properties": {
+        "candidate_moments": {"type": "integer", "minimum": 0},
+        "moments_without_valid_frame": {"type": "integer", "minimum": 0},
+        "candidate_annotations": {"type": "integer", "minimum": 0},
+        "candidate_annotation_failures": {"type": "integer", "minimum": 0},
+        "selected": {"type": "integer", "minimum": 0},
+        "not_selected": {"type": "integer", "minimum": 0},
+        "final_similarity_ceiling": {"type": "number", "minimum": 0, "maximum": 1},
+        "shortlist_expansion_count": {"type": "integer", "minimum": 0},
+        "shortfall": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["requested", "selected", "all_candidate_moments_exhausted"],
+          "properties": {
+            "requested": {"type": "integer", "minimum": 1},
+            "selected": {"type": "integer", "minimum": 0},
+            "all_candidate_moments_exhausted": {"type": "boolean"}
+          }
+        },
+        "blog_image_type": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["normal_gameplay", "event", "menu", "title", "other"],
+          "properties": {
+            "normal_gameplay": {"$ref": "#/$defs/targetActual"},
+            "event": {"$ref": "#/$defs/targetActual"},
+            "menu": {"$ref": "#/$defs/targetActual"},
+            "title": {"$ref": "#/$defs/targetActual"},
+            "other": {"$ref": "#/$defs/targetActual"}
+          }
+        }
+      }
+    },
+    "targetActual": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "actual"],
+      "properties": {
+        "target": {"type": "integer", "minimum": 0},
+        "actual": {"type": "integer", "minimum": 0}
+      }
+    },
+    "candidateSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["video_id", "candidate_moment_id", "timeline_segment_id", "video_time", "video_set_progress"],
+      "properties": {
+        "video_id": {"type": "string", "pattern": "^vid_[0-9a-f]{12}$"},
+        "candidate_moment_id": {"type": "string", "pattern": "^mom_[0-9a-f]{64}$"},
+        "timeline_segment_id": {"type": "string", "pattern": "^seg_[0-9a-f]{64}$"},
+        "video_time": {"$ref": "#/$defs/videoTime"},
+        "video_set_progress": {"type": "number", "minimum": 0, "exclusiveMaximum": 1}
+      }
+    },
+    "classification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scene_slug", "scene_display_name", "scene_selection_role", "blog_image_type", "explanation_value", "screen_text_kind", "spoiler_risk", "spoiler_evidence"],
+      "properties": {
+        "scene_slug": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
+        "scene_display_name": {"type": "string", "minLength": 1},
+        "scene_selection_role": {"enum": ["ordinary", "cinematic", "recurring_gameplay"]},
+        "blog_image_type": {"enum": ["normal_gameplay", "event", "menu", "title", "other"]},
+        "explanation_value": {"enum": ["none", "low", "medium", "high"]},
+        "screen_text_kind": {"enum": ["none", "dialogue", "menu", "title", "hud", "other"]},
+        "spoiler_risk": {"enum": ["none", "low", "medium", "high"]},
+        "spoiler_evidence": {
+          "anyOf": [
+            {"type": "null"},
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["source", "summary"],
+              "properties": {
+                "source": {"const": "candidate_annotation"},
+                "summary": {"type": "string", "minLength": 1}
+              }
+            }
+          ]
+        }
+      }
+    },
+    "annotation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary", "representative_frame_reason", "context_cue_relevance", "supporting_context_cue_ids"],
+      "properties": {
+        "summary": {"type": "string", "minLength": 1},
+        "representative_frame_reason": {"type": "string", "minLength": 1},
+        "context_cue_relevance": {"enum": ["unavailable", "none", "weak", "strong"]},
+        "supporting_context_cue_ids": {"type": "array", "uniqueItems": true, "items": {"type": "string", "pattern": "^cue_[0-9a-f]{64}$"}}
+      }
+    },
+    "score": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["base_utility", "spoiler_penalty", "coverage_bonus", "temporal_diversity_penalty", "marginal_utility", "similarity_pass", "nearest_selected_similarity"],
+      "properties": {
+        "base_utility": {"type": "number"},
+        "spoiler_penalty": {"type": "number"},
+        "coverage_bonus": {"type": "number"},
+        "temporal_diversity_penalty": {"type": "number"},
+        "marginal_utility": {"type": "number"},
+        "similarity_pass": {"type": "number", "minimum": 0, "maximum": 1},
+        "nearest_selected_similarity": {"type": ["number", "null"]}
+      }
+    },
+    "selectedScore": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["base_utility", "spoiler_penalty", "coverage_bonus", "temporal_diversity_penalty", "marginal_utility", "similarity_pass", "nearest_selected_similarity", "reason_codes", "decision_explanation", "variant_group_id", "tie_break_applied"],
+      "properties": {
+        "base_utility": {"type": "number"},
+        "spoiler_penalty": {"type": "number"},
+        "coverage_bonus": {"type": "number"},
+        "temporal_diversity_penalty": {"type": "number"},
+        "marginal_utility": {"type": "number"},
+        "similarity_pass": {"type": "number", "minimum": 0, "maximum": 1},
+        "nearest_selected_similarity": {"type": ["number", "null"]},
+        "reason_codes": {"type": "array", "items": {"type": "string"}},
+        "decision_explanation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["renderer", "text"],
+          "properties": {
+            "renderer": {"const": "selection-explanation-ja-v1"},
+            "text": {"type": "string", "minLength": 1}
+          }
+        },
+        "variant_group_id": {"type": "string", "pattern": "^variant_[0-9a-f]{64}$"},
+        "tie_break_applied": {"type": "boolean"}
+      }
+    },
+    "selected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["image_id", "selection_index", "output", "source", "classification", "annotation", "selection"],
+      "properties": {
+        "image_id": {"type": "string", "pattern": "^frm_[0-9a-f]{64}$"},
+        "selection_index": {"type": "integer", "minimum": 1},
+        "output": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["relative_path", "sha256", "width", "height", "bytes"],
+          "properties": {
+            "relative_path": {"type": "string", "pattern": "^images/[a-z0-9_.-]+\\.webp$"},
+            "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+            "width": {"type": "integer", "minimum": 1},
+            "height": {"type": "integer", "minimum": 1},
+            "bytes": {"type": "integer", "minimum": 1}
+          }
+        },
+        "source": {"$ref": "#/$defs/candidateSource"},
+        "classification": {"$ref": "#/$defs/classification"},
+        "annotation": {"$ref": "#/$defs/annotation"},
+        "selection": {"$ref": "#/$defs/selectedScore"}
+      }
+    },
+    "nearMiss": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["image_id", "source", "classification", "annotation", "counterfactual_selection", "rejection", "variant_group_id"],
+      "properties": {
+        "image_id": {"type": "string", "pattern": "^frm_[0-9a-f]{64}$"},
+        "source": {"$ref": "#/$defs/candidateSource"},
+        "classification": {"$ref": "#/$defs/classification"},
+        "annotation": {"$ref": "#/$defs/annotation"},
+        "counterfactual_selection": {"$ref": "#/$defs/score"},
+        "rejection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["reason_code"],
+          "properties": {
+            "reason_code": {"enum": ["title_limit", "visual_near_duplicate", "similarity_ceiling", "spoiler_monotonicity_guard", "lower_marginal_utility"]},
+            "blocked_by_image_id": {"type": "string", "pattern": "^frm_[0-9a-f]{64}$"},
+            "nearest_selected_image_id": {"type": "string", "pattern": "^frm_[0-9a-f]{64}$"},
+            "similarity": {"type": "number", "minimum": -1, "maximum": 1}
+          }
+        },
+        "variant_group_id": {"type": "string", "pattern": "^variant_[0-9a-f]{64}$"}
+      }
+    },
+    "contextCue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "video_id", "source_kind", "stream_index", "language", "timestamp_basis", "start", "end", "reliability", "text_included"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^cue_[0-9a-f]{64}$"},
+        "video_id": {"type": "string", "pattern": "^vid_[0-9a-f]{12}$"},
+        "source_kind": {"enum": ["embedded_subtitle", "speech_to_text"]},
+        "stream_index": {"type": "integer", "minimum": 0},
+        "language": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["value", "origin"],
+          "properties": {
+            "value": {"type": ["string", "null"]},
+            "origin": {"enum": ["stream_metadata", "speech_recognition"]}
+          }
+        },
+        "timestamp_basis": {"enum": ["source_pts", "container_text_ms", "asr_sample_grid_estimate"]},
+        "start": {"$ref": "#/$defs/contextTime"},
+        "end": {"$ref": "#/$defs/contextTime"},
+        "reliability": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["policy"],
+          "properties": {
+            "policy": {"const": "usable"},
+            "average_log_probability": {"type": "number"}
+          }
+        },
+        "text_included": {"const": false}
+      }
+    },
+    "contextTime": {
+      "oneOf": [
+        {"$ref": "#/$defs/videoTime"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sample_index", "sample_rate_hz", "exact_seconds", "display"],
+          "properties": {
+            "sample_index": {"type": "integer", "minimum": 0},
+            "sample_rate_hz": {"type": "integer", "minimum": 1},
+            "exact_seconds": {"type": "string", "minLength": 1},
+            "display": {"type": "string"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["offset_seconds", "display"],
+          "properties": {
+            "offset_seconds": {"$ref": "#/$defs/rational"},
+            "display": {"type": "string"}
+          }
+        }
+      ]
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["selection", "runtime", "tools", "models", "contracts", "stages"],
+      "properties": {
+        "selection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["policy_version", "spoiler_sensitivity", "blog_image_type_target", "similarity_base", "similarity_final"],
+          "properties": {
+            "policy_version": {"const": "video-set-selection-v1"},
+            "spoiler_sensitivity": {"enum": ["low", "medium", "high"]},
+            "blog_image_type_target": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["normal_gameplay", "event", "menu"],
+              "properties": {
+                "normal_gameplay": {"const": 0.7},
+                "event": {"const": 0.25},
+                "menu": {"const": 0.05}
+              }
+            },
+            "similarity_base": {"type": "number", "minimum": 0, "maximum": 1},
+            "similarity_final": {"type": "number", "minimum": 0, "maximum": 1}
+          }
+        },
+        "runtime": {"type": "object"},
+        "tools": {"type": "object", "additionalProperties": {"type": "string"}},
+        "models": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["scene_catalog", "candidate_annotation", "speech_to_text"],
+          "properties": {
+            "scene_catalog": {"$ref": "#/$defs/model"},
+            "candidate_annotation": {"$ref": "#/$defs/model"},
+            "speech_to_text": {"$ref": "#/$defs/model"}
+          }
+        },
+        "contracts": {"type": "object", "additionalProperties": {"type": "string"}},
+        "stages": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/stage"}}
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["store", "configured_name", "canonical_name", "local_identity_before_update", "update_status", "execution_identity", "runtime_identity"],
+      "properties": {
+        "store": {"enum": ["ollama", "hugging_face"]},
+        "configured_name": {"type": "string", "minLength": 1},
+        "canonical_name": {"type": "string", "minLength": 1},
+        "local_identity_before_update": {"type": ["string", "null"]},
+        "update_status": {"enum": ["not_requested", "unchanged", "updated", "bootstrapped", "unavailable"]},
+        "execution_identity": {"type": "string", "minLength": 1},
+        "runtime_identity": {"type": "string", "minLength": 1}
+      }
+    },
+    "stage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "status", "fingerprint", "upstream_fingerprints", "cache_hits", "cache_misses", "recomputed_items", "attempt_count", "validation_failures", "effective_settings", "tool_refs", "model_refs", "contract_refs", "duration_ms"],
+      "properties": {
+        "name": {"type": "string"},
+        "status": {"const": "completed"},
+        "fingerprint": {"type": "string", "pattern": "^stg_[0-9a-f]{64}$"},
+        "upstream_fingerprints": {"type": "array", "uniqueItems": true, "items": {"type": "string", "pattern": "^stg_[0-9a-f]{64}$"}},
+        "cache_hits": {"type": "integer", "minimum": 0},
+        "cache_misses": {"type": "integer", "minimum": 0},
+        "recomputed_items": {"type": "integer", "minimum": 0},
+        "attempt_count": {"type": "integer", "minimum": 0},
+        "validation_failures": {"type": "integer", "minimum": 0},
+        "effective_settings": {"type": "object"},
+        "tool_refs": {"type": "array", "uniqueItems": true, "items": {"type": "string"}},
+        "model_refs": {"type": "array", "uniqueItems": true, "items": {"type": "string"}},
+        "contract_refs": {"type": "array", "uniqueItems": true, "items": {"type": "string"}},
+        "duration_ms": {"type": "integer", "minimum": 0},
+        "prompt_eval_tokens": {"type": "integer", "minimum": 0},
+        "eval_tokens": {"type": "integer", "minimum": 0}
+      }
+    },
+    "privacy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["absolute_paths", "model_reasoning_trace", "raw_model_responses", "generated_screen_text_quotations", "raw_context_cue_text", "relative_source_paths", "environment_variables", "credentials", "prompt_bodies", "stack_traces"],
+      "properties": {
+        "absolute_paths": {"const": "omitted"},
+        "model_reasoning_trace": {"const": "omitted"},
+        "raw_model_responses": {"const": "omitted"},
+        "generated_screen_text_quotations": {"const": "omitted"},
+        "raw_context_cue_text": {"const": "processing_cache_only"},
+        "relative_source_paths": {"const": "included"},
+        "environment_variables": {"const": "omitted"},
+        "credentials": {"const": "omitted"},
+        "prompt_bodies": {"const": "omitted"},
+        "stack_traces": {"const": "omitted"}
+      }
+    }
+  }
+}

--- a/src/video_selection/services/build_canonical_selection_report.py
+++ b/src/video_selection/services/build_canonical_selection_report.py
@@ -11,6 +11,7 @@ from ..models.selected_blog_image import SelectedBlogImage
 from ..models.selected_image_artifact import SelectedImageArtifact
 from ..models.selection_score import SelectionScore
 from ..models.video_stage_result import VideoStageResult
+from .build_video_source_ids import build_video_source_ids
 from .report_time import (
     display_report_time,
     exact_seconds_string,
@@ -53,10 +54,7 @@ def build_canonical_selection_report(
     stages_by_fingerprint = {
         item.source.fingerprint: item for item in request.video_stage_results
     }
-    source_ids = {
-        source.fingerprint: f"vid_{source.fingerprint[:12]}"
-        for source in request.video_set.sources
-    }
+    source_ids = build_video_source_ids(request.video_set.sources)
     near_misses = _published_near_misses(selection.rejected, selection.requested_count)
     referenced_cue_ids = {
         cue_id
@@ -546,9 +544,9 @@ def _source_pts_context_time_records(
         raise ValueError("Report Context Evidenceにprovenanceがありません")
     time_base = provenance.source_time_base
     origin_pts = Fraction(provenance.source_pts) - cue.start / time_base
-    if origin_pts.denominator != 1:
-        msg = "Context Cueのsource origin PTSをlosslessに復元できません"
-        raise ValueError(msg)
+    end_pts = origin_pts + cue.end / time_base
+    if origin_pts.denominator != 1 or end_pts.denominator != 1:
+        return _offset_time_record(cue.start), _offset_time_record(cue.end)
     origin = origin_pts.numerator
     return (
         _video_time_record(
@@ -558,7 +556,7 @@ def _source_pts_context_time_records(
             cue.start,
         ),
         _video_time_record(
-            _source_pts(origin, time_base, cue.end),
+            end_pts.numerator,
             origin,
             time_base,
             cue.end,

--- a/src/video_selection/services/build_canonical_selection_report.py
+++ b/src/video_selection/services/build_canonical_selection_report.py
@@ -162,9 +162,7 @@ def build_canonical_selection_report(
             ),
         },
         "near_misses": near_miss_records,
-        "context_cues": [
-            _context_cue_record(cue, stages_by_fingerprint, source_ids) for cue in cues
-        ],
+        "context_cues": [_context_cue_record(cue, source_ids) for cue in cues],
         "provenance": {
             "selection": {
                 "policy_version": SELECTION_POLICY_VERSION,
@@ -504,10 +502,8 @@ def _near_miss_limit(total_rejected: int, requested_count: int) -> int:
 
 def _context_cue_record(
     cue: ContextCue,
-    stages: dict[str, VideoStageResult],
     source_ids: dict[str, str],
 ) -> dict[str, object]:
-    stage = stages[cue.video_fingerprint]
     provenance = cue.provenance
     if provenance is None:
         raise ValueError("Report Context Evidenceにprovenanceがありません")
@@ -517,19 +513,7 @@ def _context_cue_record(
         else "stream_metadata"
     )
     if cue.timestamp_basis == "source_pts":
-        timeline = stage.scan.timeline
-        start = _video_time_record(
-            _source_pts(timeline.origin_pts, timeline.time_base, cue.start),
-            timeline.origin_pts,
-            timeline.time_base,
-            cue.start,
-        )
-        end = _video_time_record(
-            _source_pts(timeline.origin_pts, timeline.time_base, cue.end),
-            timeline.origin_pts,
-            timeline.time_base,
-            cue.end,
-        )
+        start, end = _source_pts_context_time_records(cue)
     elif cue.timestamp_basis == "asr_sample_grid_estimate":
         start = _sample_time_record(cue.start, provenance.source_time_base)
         end = _sample_time_record(cue.end, provenance.source_time_base)
@@ -551,6 +535,35 @@ def _context_cue_record(
         "reliability": reliability,
         "text_included": False,
     }
+
+
+def _source_pts_context_time_records(
+    cue: ContextCue,
+) -> tuple[dict[str, object], dict[str, object]]:
+    """Context source stream固有PTSから開始・終了時刻を構築する。"""
+    provenance = cue.provenance
+    if provenance is None:
+        raise ValueError("Report Context Evidenceにprovenanceがありません")
+    time_base = provenance.source_time_base
+    origin_pts = Fraction(provenance.source_pts) - cue.start / time_base
+    if origin_pts.denominator != 1:
+        msg = "Context Cueのsource origin PTSをlosslessに復元できません"
+        raise ValueError(msg)
+    origin = origin_pts.numerator
+    return (
+        _video_time_record(
+            provenance.source_pts,
+            origin,
+            time_base,
+            cue.start,
+        ),
+        _video_time_record(
+            _source_pts(origin, time_base, cue.end),
+            origin,
+            time_base,
+            cue.end,
+        ),
+    )
 
 
 def _sample_time_record(

--- a/src/video_selection/services/build_canonical_selection_report.py
+++ b/src/video_selection/services/build_canonical_selection_report.py
@@ -1,0 +1,629 @@
+"""確定済みdomain resultからCanonical Selection Reportを構築する。"""
+
+from fractions import Fraction
+
+from ..models.blog_candidate import BlogCandidate
+from ..models.canonical_publication_request import CanonicalPublicationRequest
+from ..models.context_cue import ContextCue
+from ..models.rejected_blog_candidate import RejectedBlogCandidate
+from ..models.report_stage_provenance import ReportStageProvenance
+from ..models.selected_blog_image import SelectedBlogImage
+from ..models.selected_image_artifact import SelectedImageArtifact
+from ..models.selection_score import SelectionScore
+from ..models.video_stage_result import VideoStageResult
+from .report_time import (
+    display_report_time,
+    exact_seconds_string,
+    rational_report_value,
+    utc_report_datetime,
+)
+
+REPORT_SCHEMA_NAME = "game-screen-pick/report"
+REPORT_SCHEMA_VERSION = "1.0.0"
+SELECTION_POLICY_VERSION = "video-set-selection-v1"
+SELECTION_EXPLANATION_RENDERER = "selection-explanation-ja-v1"
+
+_REASON_LABELS = {
+    "high_quality": "高い画質",
+    "high_explanation_value": "高い説明価値",
+    "strong_context_relevance": "強いContext Cue relevance",
+    "normal_gameplay_coverage": "normal_gameplay coverage",
+    "event_coverage": "event coverage",
+    "menu_coverage": "menu coverage",
+    "title_first_image_bonus": "最初のtitle bonus",
+    "recurring_gameplay_variant": "recurring gameplayの状態差",
+    "low_spoiler_penalty_applied": "low spoiler penalty適用後のutility",
+    "medium_spoiler_penalty_applied": "medium spoiler penalty適用後のutility",
+    "high_spoiler_penalty_applied": "high spoiler penalty適用後のutility",
+    "stable_tie_break": "安定tie-break",
+}
+
+
+def build_canonical_selection_report(
+    request: CanonicalPublicationRequest,
+    image_artifacts: tuple[SelectedImageArtifact, ...],
+) -> dict[str, object]:
+    """画像artifactを含むreport@1.0.0 objectを返す。"""
+    selection = request.selection_result
+    artifacts_by_id = {item.image_id: item for item in image_artifacts}
+    selected_ids = {item.candidate.identifier for item in selection.selected}
+    if set(artifacts_by_id) != selected_ids:
+        msg = "Selected Image artifactとselection resultが一致しません"
+        raise ValueError(msg)
+    stages_by_fingerprint = {
+        item.source.fingerprint: item for item in request.video_stage_results
+    }
+    source_ids = {
+        source.fingerprint: f"vid_{source.fingerprint[:12]}"
+        for source in request.video_set.sources
+    }
+    near_misses = _published_near_misses(selection.rejected, selection.requested_count)
+    referenced_cue_ids = {
+        cue_id
+        for candidate in (
+            *(item.candidate for item in selection.selected),
+            *(item.candidate for item in near_misses),
+        )
+        for cue_id in candidate.annotation.supporting_context_cue_ids
+    }
+    cues = tuple(
+        cue
+        for stage in request.video_stage_results
+        for cue in stage.context.cues
+        if cue.identifier in referenced_cue_ids
+    )
+    warnings = _warnings(request)
+    selected_records = [
+        _selected_record(
+            item,
+            artifacts_by_id[item.candidate.identifier],
+            stages_by_fingerprint,
+            source_ids,
+            request,
+        )
+        for item in selection.selected
+    ]
+    near_miss_records = [
+        _near_miss_record(
+            item,
+            stages_by_fingerprint,
+            source_ids,
+            request,
+        )
+        for item in near_misses
+    ]
+    sources = [
+        _video_source_record(index, stage, source_ids[stage.source.fingerprint])
+        for index, stage in enumerate(request.video_stage_results, start=1)
+    ]
+    total_duration = sum(
+        (stage.scan.timeline.duration.seconds for stage in request.video_stage_results),
+        start=Fraction(0),
+    )
+    models = {
+        item.role.value: item.provenance()
+        for item in sorted(
+            request.resolved_models.items, key=lambda value: value.role.value
+        )
+    }
+    contracts = dict(request.provenance.contracts)
+    contracts["report_schema"] = REPORT_SCHEMA_VERSION
+    contracts["video_set_selection_policy"] = SELECTION_POLICY_VERSION
+    report: dict[str, object] = {
+        "schema": {"name": REPORT_SCHEMA_NAME, "version": REPORT_SCHEMA_VERSION},
+        "run": {
+            "id": request.run_id,
+            "status": "completed_with_warnings" if warnings else "completed",
+            "started_at": utc_report_datetime(request.started_at),
+            "completed_at": utc_report_datetime(request.completed_at),
+            "requested_image_count": selection.requested_count,
+            "selected_image_count": len(selection.selected),
+            "warnings": warnings,
+        },
+        "artifacts": _artifact_contract(),
+        "video_set": {
+            "id": f"vset_{request.video_set.fingerprint[:12]}",
+            "fingerprint_algorithm": "ordered-video-sha256-v1",
+            "time_contract": {
+                "authoritative_value": "offset_seconds_rational",
+                "display_format": "unbounded_hours_HH:MM:SS.mmm",
+                "display_rounding": "half_up",
+                "frame_index": "omitted",
+            },
+            "source_path_policy": {
+                "base": "video_input_folder",
+                "separator": "/",
+                "parent_segments": "forbidden",
+                "absolute_paths": "omitted",
+            },
+            "duration": {
+                "exact_seconds": exact_seconds_string(total_duration),
+                "display": display_report_time(total_duration),
+            },
+            "sources": sources,
+        },
+        "selection_summary": _selection_summary(request),
+        "rejection_summary": {
+            "total": len(selection.rejected),
+            "by_reason": selection.rejection_counts,
+        },
+        "selected": selected_records,
+        "near_miss_publication": {
+            "json_limit_formula": (
+                "min(total_rejected, 100, max(20, requested_image_count * 2))"
+            ),
+            "json_limit_for_this_run": _near_miss_limit(
+                len(selection.rejected), selection.requested_count
+            ),
+            "markdown_limit": 10,
+            "coverage": "at_least_one_per_rejection_reason",
+            "fill_order": (
+                "counterfactual_marginal_utility_desc_then_selection_tie_break"
+            ),
+        },
+        "near_misses": near_miss_records,
+        "context_cues": [
+            _context_cue_record(cue, stages_by_fingerprint, source_ids) for cue in cues
+        ],
+        "provenance": {
+            "selection": {
+                "policy_version": SELECTION_POLICY_VERSION,
+                "spoiler_sensitivity": request.configuration.spoiler_sensitivity,
+                "blog_image_type_target": {
+                    "normal_gameplay": 0.70,
+                    "event": 0.25,
+                    "menu": 0.05,
+                },
+                "similarity_base": request.configuration.similarity_threshold,
+                "similarity_final": selection.final_similarity_ceiling,
+            },
+            "runtime": dict(request.provenance.runtime),
+            "tools": dict(request.provenance.tools),
+            "models": models,
+            "contracts": contracts,
+            "stages": [_stage_record(item) for item in request.provenance.stages],
+        },
+        "privacy": {
+            "absolute_paths": "omitted",
+            "model_reasoning_trace": "omitted",
+            "raw_model_responses": "omitted",
+            "generated_screen_text_quotations": "omitted",
+            "raw_context_cue_text": "processing_cache_only",
+            "relative_source_paths": "included",
+            "environment_variables": "omitted",
+            "credentials": "omitted",
+            "prompt_bodies": "omitted",
+            "stack_traces": "omitted",
+        },
+    }
+    return report
+
+
+def _artifact_contract() -> dict[str, object]:
+    return {
+        "report_json": "report.json",
+        "report_markdown": "report.md",
+        "image_directory": "images",
+        "image_contract": {
+            "frame_candidate_id_algorithm": "video-fingerprint-video-time-sha256-v1",
+            "frame_candidate_id_format": "frm_<64-lowercase-hex>",
+            "filename_pattern": (
+                "<selection-index-min-width-4>_<scene-slug>_"
+                "<frame-digest-prefix-12-or-full>.webp"
+            ),
+            "format": "webp",
+            "encoding": "lossy",
+            "quality": 95,
+            "color_space": "srgb",
+            "metadata": "stripped",
+            "size_policy": "source_dimensions",
+            "configurable": False,
+            "status": "fixed_for_v1",
+        },
+        "publication_contract": {
+            "mode": "atomic_directory_rename",
+            "staging": "hidden_sibling_same_filesystem",
+            "validated_before_publish": True,
+            "non_atomic_fallback": False,
+        },
+        "projection_contract": {
+            "canonical_machine_report": "report.json",
+            "markdown_source": "validated_canonical_report_object",
+            "cache_or_model_reread": False,
+            "json_key_order_significant": False,
+            "cross_artifact_mismatch": "fatal",
+            "selected_image_rendering": "clickable_inline_original",
+            "thumbnail_artifacts": False,
+            "alt_text": "selection_index_and_scene_display_name",
+        },
+    }
+
+
+def _warnings(request: CanonicalPublicationRequest) -> list[dict[str, object]]:
+    selection = request.selection_result
+    warnings: list[dict[str, object]] = []
+    if selection.shortfall:
+        warnings.append(
+            {
+                "code": "selection_shortfall",
+                "message": (
+                    f"要求{selection.requested_count}枚に対して"
+                    f"{len(selection.selected)}枚を選択しました。"
+                ),
+                "details": selection.rejection_counts,
+            }
+        )
+    unavailable_roles = [
+        role.value for role in request.resolved_models.unavailable_roles()
+    ]
+    if unavailable_roles:
+        warnings.append(
+            {
+                "code": "model_update_unavailable",
+                "message": (
+                    "model更新確認を完了できず検証済みlocal artifactを使用しました。"
+                ),
+                "details": {"roles": unavailable_roles},
+            }
+        )
+    return warnings
+
+
+def _selection_summary(request: CanonicalPublicationRequest) -> dict[str, object]:
+    selection = request.selection_result
+    moment_count = sum(
+        len(stage.extraction.moments) for stage in request.video_stage_results
+    )
+    zero_frame_count = sum(
+        stage.extraction.zero_frame_moment_count
+        for stage in request.video_stage_results
+    )
+    image_types = {
+        name: {
+            "target": selection.blog_image_type_targets[name],
+            "actual": selection.blog_image_type_actuals[name],
+        }
+        for name in selection.blog_image_type_targets
+    }
+    return {
+        "candidate_moments": moment_count,
+        "moments_without_valid_frame": zero_frame_count,
+        "candidate_annotations": selection.annotated_candidate_count,
+        "candidate_annotation_failures": 0,
+        "selected": len(selection.selected),
+        "not_selected": len(selection.rejected),
+        "final_similarity_ceiling": selection.final_similarity_ceiling,
+        "shortlist_expansion_count": selection.shortlist_expansion_count,
+        "shortfall": {
+            "requested": selection.requested_count,
+            "selected": len(selection.selected),
+            "all_candidate_moments_exhausted": (
+                selection.all_candidate_moments_exhausted
+            ),
+        },
+        "blog_image_type": image_types,
+    }
+
+
+def _video_source_record(
+    order: int,
+    stage: VideoStageResult,
+    video_id: str,
+) -> dict[str, object]:
+    timeline = stage.scan.timeline
+    duration = timeline.duration.seconds
+    duration_pts = _source_pts(timeline.origin_pts, timeline.time_base, duration)
+    return {
+        "id": video_id,
+        "order": order,
+        "relative_path": stage.source.relative_path,
+        "fingerprint": {
+            "algorithm": "sha256-whole-file",
+            "value": stage.source.fingerprint,
+        },
+        "duration": {
+            "source_pts": duration_pts,
+            "origin_pts": timeline.origin_pts,
+            "time_base": rational_report_value(timeline.time_base),
+            "exact_seconds": exact_seconds_string(duration),
+            "display": display_report_time(duration),
+        },
+    }
+
+
+def _selected_record(
+    selected: SelectedBlogImage,
+    artifact: SelectedImageArtifact,
+    stages: dict[str, VideoStageResult],
+    source_ids: dict[str, str],
+    request: CanonicalPublicationRequest,
+) -> dict[str, object]:
+    candidate = selected.candidate
+    return {
+        "image_id": candidate.identifier,
+        "selection_index": selected.selection_index,
+        "output": {
+            "relative_path": artifact.relative_path,
+            "sha256": artifact.sha256,
+            "width": artifact.width,
+            "height": artifact.height,
+            "bytes": artifact.size_bytes,
+        },
+        "source": _candidate_source(candidate, stages, source_ids),
+        "classification": _classification(candidate, request),
+        "annotation": _annotation(candidate),
+        "selection": {
+            **_selection_score(selected.score),
+            "reason_codes": list(selected.reason_codes),
+            "decision_explanation": {
+                "renderer": SELECTION_EXPLANATION_RENDERER,
+                "text": _selection_explanation(selected.reason_codes),
+            },
+            "variant_group_id": selected.variant_group_id,
+            "tie_break_applied": selected.tie_break_applied,
+        },
+    }
+
+
+def _near_miss_record(
+    rejected: RejectedBlogCandidate,
+    stages: dict[str, VideoStageResult],
+    source_ids: dict[str, str],
+    request: CanonicalPublicationRequest,
+) -> dict[str, object]:
+    rejection: dict[str, object] = {"reason_code": rejected.reason_code.value}
+    if rejected.blocked_by_image_id is not None:
+        rejection["blocked_by_image_id"] = rejected.blocked_by_image_id
+    if rejected.nearest_selected_image_id is not None:
+        rejection["nearest_selected_image_id"] = rejected.nearest_selected_image_id
+    if rejected.similarity is not None:
+        rejection["similarity"] = rejected.similarity
+    return {
+        "image_id": rejected.candidate.identifier,
+        "source": _candidate_source(rejected.candidate, stages, source_ids),
+        "classification": _classification(rejected.candidate, request),
+        "annotation": _annotation(rejected.candidate),
+        "counterfactual_selection": _selection_score(rejected.counterfactual_score),
+        "rejection": rejection,
+        "variant_group_id": rejected.variant_group_id,
+    }
+
+
+def _candidate_source(
+    candidate: BlogCandidate,
+    stages: dict[str, VideoStageResult],
+    source_ids: dict[str, str],
+) -> dict[str, object]:
+    frame = candidate.annotation.candidate
+    fingerprint = frame.video_fingerprint
+    if fingerprint is None:
+        raise ValueError("Report candidateにVideo Fingerprintがありません")
+    stage = stages[fingerprint]
+    moment = next(
+        item
+        for item in stage.extraction.moments
+        if item.identifier == candidate.annotation.candidate_moment_id
+    )
+    video_time = frame.video_time
+    if (
+        frame.source_pts is None
+        or frame.origin_pts is None
+        or frame.time_base is None
+        or video_time is None
+    ):
+        raise ValueError("Report candidateにexact Video Timeがありません")
+    return {
+        "video_id": source_ids[fingerprint],
+        "candidate_moment_id": moment.identifier,
+        "timeline_segment_id": moment.timeline_segment_id,
+        "video_time": _video_time_record(
+            frame.source_pts,
+            frame.origin_pts,
+            frame.time_base,
+            video_time,
+        ),
+        "video_set_progress": float(candidate.video_set_progress),
+    }
+
+
+def _classification(
+    candidate: BlogCandidate,
+    request: CanonicalPublicationRequest,
+) -> dict[str, object]:
+    annotation = candidate.annotation
+    scene = request.scene_catalog.for_slug(annotation.scene_slug)
+    spoiler_evidence: dict[str, str] | None = None
+    if annotation.spoiler_risk != "none":
+        spoiler_evidence = {
+            "source": "candidate_annotation",
+            "summary": annotation.spoiler_evidence,
+        }
+    return {
+        "scene_slug": annotation.scene_slug,
+        "scene_display_name": scene.display_name,
+        "scene_selection_role": candidate.scene_selection_role,
+        "blog_image_type": annotation.blog_image_type,
+        "explanation_value": annotation.explanation_value,
+        "screen_text_kind": annotation.screen_text_kind,
+        "spoiler_risk": annotation.spoiler_risk,
+        "spoiler_evidence": spoiler_evidence,
+    }
+
+
+def _annotation(candidate: BlogCandidate) -> dict[str, object]:
+    annotation = candidate.annotation
+    return {
+        "summary": annotation.summary,
+        "representative_frame_reason": annotation.frame_choice_reason,
+        "context_cue_relevance": annotation.context_relevance,
+        "supporting_context_cue_ids": list(annotation.supporting_context_cue_ids),
+    }
+
+
+def _selection_score(score: SelectionScore) -> dict[str, object]:
+    return {
+        "base_utility": score.base_utility,
+        "spoiler_penalty": score.spoiler_penalty,
+        "coverage_bonus": score.coverage_bonus,
+        "temporal_diversity_penalty": score.temporal_diversity_penalty,
+        "marginal_utility": score.marginal_utility,
+        "similarity_pass": score.similarity_pass,
+        "nearest_selected_similarity": score.nearest_selected_similarity,
+    }
+
+
+def _selection_explanation(reason_codes: tuple[str, ...]) -> str:
+    if not reason_codes:
+        return "Marginal Selection Utilityと安定tie-breakにより選択された。"
+    labels = [_REASON_LABELS.get(item, f"`{item}`") for item in reason_codes]
+    return "、".join(labels) + "により選択された。"
+
+
+def _published_near_misses(
+    rejected: tuple[RejectedBlogCandidate, ...],
+    requested_count: int,
+) -> tuple[RejectedBlogCandidate, ...]:
+    limit = _near_miss_limit(len(rejected), requested_count)
+    representatives: list[RejectedBlogCandidate] = []
+    for reason in sorted(
+        {item.reason_code for item in rejected}, key=lambda item: item.value
+    ):
+        representatives.append(
+            next(item for item in rejected if item.reason_code is reason)
+        )
+    represented_ids = {item.candidate.identifier for item in representatives}
+    remainder = [
+        item for item in rejected if item.candidate.identifier not in represented_ids
+    ]
+    return tuple((*representatives, *remainder)[:limit])
+
+
+def _near_miss_limit(total_rejected: int, requested_count: int) -> int:
+    return min(total_rejected, 100, max(20, requested_count * 2))
+
+
+def _context_cue_record(
+    cue: ContextCue,
+    stages: dict[str, VideoStageResult],
+    source_ids: dict[str, str],
+) -> dict[str, object]:
+    stage = stages[cue.video_fingerprint]
+    provenance = cue.provenance
+    if provenance is None:
+        raise ValueError("Report Context Evidenceにprovenanceがありません")
+    language_origin = (
+        "speech_recognition"
+        if provenance.language_source == "speech_recognition"
+        else "stream_metadata"
+    )
+    if cue.timestamp_basis == "source_pts":
+        timeline = stage.scan.timeline
+        start = _video_time_record(
+            _source_pts(timeline.origin_pts, timeline.time_base, cue.start),
+            timeline.origin_pts,
+            timeline.time_base,
+            cue.start,
+        )
+        end = _video_time_record(
+            _source_pts(timeline.origin_pts, timeline.time_base, cue.end),
+            timeline.origin_pts,
+            timeline.time_base,
+            cue.end,
+        )
+    elif cue.timestamp_basis == "asr_sample_grid_estimate":
+        start = _sample_time_record(cue.start, provenance.source_time_base)
+        end = _sample_time_record(cue.end, provenance.source_time_base)
+    else:
+        start = _offset_time_record(cue.start)
+        end = _offset_time_record(cue.end)
+    reliability: dict[str, object] = {"policy": cue.reliability}
+    if cue.diagnostics is not None:
+        reliability["average_log_probability"] = cue.diagnostics.average_log_probability
+    return {
+        "id": cue.identifier,
+        "video_id": source_ids[cue.video_fingerprint],
+        "source_kind": cue.source_kind,
+        "stream_index": cue.stream_index,
+        "language": {"value": cue.language, "origin": language_origin},
+        "timestamp_basis": cue.timestamp_basis,
+        "start": start,
+        "end": end,
+        "reliability": reliability,
+        "text_included": False,
+    }
+
+
+def _sample_time_record(
+    value: Fraction,
+    source_time_base: Fraction,
+) -> dict[str, object]:
+    sample_rate = Fraction(1, 1) / source_time_base
+    sample_index = value * sample_rate
+    if sample_rate.denominator == 1 and sample_index.denominator == 1:
+        return {
+            "sample_index": sample_index.numerator,
+            "sample_rate_hz": sample_rate.numerator,
+            "exact_seconds": exact_seconds_string(value),
+            "display": display_report_time(value),
+        }
+    return {
+        "offset_seconds": rational_report_value(value),
+        "display": display_report_time(value),
+    }
+
+
+def _offset_time_record(value: Fraction) -> dict[str, object]:
+    return {
+        "offset_seconds": rational_report_value(value),
+        "display": display_report_time(value),
+    }
+
+
+def _video_time_record(
+    source_pts: int,
+    origin_pts: int,
+    time_base: Fraction,
+    video_time: Fraction,
+) -> dict[str, object]:
+    if (source_pts - origin_pts) * time_base != video_time:
+        msg = "source PTSとReport Video Timeが一致しません"
+        raise ValueError(msg)
+    return {
+        "source_pts": source_pts,
+        "origin_pts": origin_pts,
+        "time_base": rational_report_value(time_base),
+        "offset_seconds": rational_report_value(video_time),
+        "display": display_report_time(video_time),
+    }
+
+
+def _source_pts(origin_pts: int, time_base: Fraction, value: Fraction) -> int:
+    pts = Fraction(origin_pts) + value / time_base
+    if pts.denominator != 1:
+        msg = "Report Video Timeをsource PTSへlosslessに変換できません"
+        raise ValueError(msg)
+    return pts.numerator
+
+
+def _stage_record(stage: ReportStageProvenance) -> dict[str, object]:
+    record: dict[str, object] = {
+        "name": stage.name,
+        "status": "completed",
+        "fingerprint": stage.fingerprint,
+        "upstream_fingerprints": list(stage.upstream_fingerprints),
+        "cache_hits": stage.cache_hits,
+        "cache_misses": stage.cache_misses,
+        "recomputed_items": stage.recomputed_items,
+        "attempt_count": stage.attempt_count,
+        "validation_failures": stage.validation_failures,
+        "effective_settings": dict(stage.effective_settings),
+        "tool_refs": list(stage.tool_refs),
+        "model_refs": list(stage.model_refs),
+        "contract_refs": list(stage.contract_refs),
+        "duration_ms": stage.duration_ms,
+    }
+    if stage.prompt_eval_tokens is not None:
+        record["prompt_eval_tokens"] = stage.prompt_eval_tokens
+    if stage.eval_tokens is not None:
+        record["eval_tokens"] = stage.eval_tokens
+    return record

--- a/src/video_selection/services/build_selected_image_output_paths.py
+++ b/src/video_selection/services/build_selected_image_output_paths.py
@@ -1,0 +1,25 @@
+"""Selected Image Output Nameの決定的な構築。"""
+
+from ..models.video_set_selection_result import VideoSetSelectionResult
+
+
+def build_selected_image_output_paths(
+    selection: VideoSetSelectionResult,
+) -> dict[str, str]:
+    """選択順、Scene Slug、衝突対応digestからrelative pathを返す。"""
+    prefixes: dict[str, int] = {}
+    for item in selection.selected:
+        digest = item.candidate.identifier.removeprefix("frm_")
+        prefix = digest[:12]
+        prefixes[prefix] = prefixes.get(prefix, 0) + 1
+    width = max(4, len(str(len(selection.selected))))
+    paths: dict[str, str] = {}
+    for item in selection.selected:
+        identifier = item.candidate.identifier
+        digest = identifier.removeprefix("frm_")
+        digest_part = digest if prefixes[digest[:12]] > 1 else digest[:12]
+        scene_slug = item.candidate.annotation.scene_slug
+        paths[identifier] = (
+            f"images/{item.selection_index:0{width}d}_{scene_slug}_{digest_part}.webp"
+        )
+    return paths

--- a/src/video_selection/services/build_video_source_ids.py
+++ b/src/video_selection/services/build_video_source_ids.py
@@ -1,0 +1,23 @@
+"""Video Set内で一意な公開Video Source IDを構築する。"""
+
+from collections import Counter
+
+from ..models.video_source import VideoSource
+
+_SHORT_DIGEST_LENGTH = 12
+
+
+def build_video_source_ids(
+    sources: tuple[VideoSource, ...],
+) -> dict[str, str]:
+    """衝突した短縮digestだけを完全digestへ拡張して返す。"""
+    prefix_counts = Counter(
+        source.fingerprint[:_SHORT_DIGEST_LENGTH] for source in sources
+    )
+    identifiers: dict[str, str] = {}
+    for source in sources:
+        fingerprint = source.fingerprint
+        prefix = fingerprint[:_SHORT_DIGEST_LENGTH]
+        digest = fingerprint if prefix_counts[prefix] > 1 else prefix
+        identifiers[fingerprint] = f"vid_{digest}"
+    return identifiers

--- a/src/video_selection/services/canonical_output_publisher.py
+++ b/src/video_selection/services/canonical_output_publisher.py
@@ -135,11 +135,10 @@ class CanonicalOutputPublisher:
         ):
             msg = "Selected Imageのexact frame情報が不足しています"
             raise ValueError(msg)
-        decoded = self._media_runtime.extract_video_frame(
+        decoded = self._media_runtime.extract_original_video_frame(
             stage.source.path,
             candidate.stream_index,
             candidate.source_pts,
-            max(stream.width, stream.height),
         )
         if (
             decoded.stream_index != candidate.stream_index

--- a/src/video_selection/services/canonical_output_publisher.py
+++ b/src/video_selection/services/canonical_output_publisher.py
@@ -1,0 +1,221 @@
+"""Canonical Selection ReportとSelected Imageをatomicに公開する。"""
+
+import os
+import shutil
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+from ..models.canonical_publication_request import CanonicalPublicationRequest
+from ..models.decoded_video_frame import DecodedVideoFrame
+from ..models.frame_candidate import FrameCandidate
+from ..models.selected_image_artifact import SelectedImageArtifact
+from ..models.video_stage_result import VideoStageResult
+from ..protocols.selected_frame_media_runtime import SelectedFrameMediaRuntime
+from .build_canonical_selection_report import build_canonical_selection_report
+from .build_selected_image_output_paths import build_selected_image_output_paths
+from .encode_selected_webp import encode_selected_webp
+from .render_human_selection_report import render_human_selection_report
+from .serialize_canonical_selection_report import (
+    serialize_canonical_selection_report,
+)
+from .validate_canonical_selection_report import (
+    validate_canonical_selection_report,
+)
+from .validate_output_folder import validate_output_folder
+from .validate_video_set_snapshot import validate_video_set_snapshot
+
+PublicationFaultInjector = Callable[[str, Path], None]
+DirectoryRenamer = Callable[[Path, Path], None]
+
+
+class CanonicalOutputPublisher:
+    """検証済みstaging Folderを一回のdirectory renameで公開する。"""
+
+    def __init__(
+        self,
+        media_runtime: SelectedFrameMediaRuntime,
+        *,
+        fault_injector: PublicationFaultInjector | None = None,
+        directory_renamer: DirectoryRenamer | None = None,
+    ) -> None:
+        self._media_runtime = media_runtime
+        self._fault_injector = fault_injector or _ignore_fault
+        self._directory_renamer = directory_renamer or _rename_directory
+
+    def publish(
+        self,
+        request: CanonicalPublicationRequest,
+    ) -> dict[str, object]:
+        """WebP、Canonical JSON、Markdownを検証してatomicに公開する。"""
+        output_folder = request.configuration.output_folder
+        validate_video_set_snapshot(request.video_set)
+        validate_output_folder(request.video_set.input_folder, output_folder)
+        output_folder.parent.mkdir(parents=True, exist_ok=True)
+        if output_folder.exists():
+            output_folder.rmdir()
+        _verify_atomic_directory_rename(output_folder.parent, output_folder.name)
+        staging_folder = Path(
+            tempfile.mkdtemp(
+                prefix=f".{output_folder.name}.",
+                suffix=".staging",
+                dir=output_folder.parent,
+            )
+        )
+        try:
+            report = self._prepare_and_validate(request, staging_folder)
+            validate_video_set_snapshot(request.video_set)
+            self._fault_injector("before-rename", staging_folder)
+            if output_folder.exists():
+                raise ValueError("Output Folderが公開前に再作成されました")
+            self._directory_renamer(staging_folder, output_folder)
+            self._fault_injector("after-rename-before-parent-flush", output_folder)
+            _flush_directory(output_folder.parent)
+            return report
+        except BaseException:
+            if not staging_folder.exists() and output_folder.exists():
+                _remove_failed_publication(output_folder)
+            shutil.rmtree(staging_folder, ignore_errors=True)
+            raise
+
+    def _prepare_and_validate(
+        self,
+        request: CanonicalPublicationRequest,
+        staging_folder: Path,
+    ) -> dict[str, object]:
+        """全artifactをstagingしflushとcross-validationまで完了する。"""
+        images_folder = staging_folder / "images"
+        images_folder.mkdir()
+        paths = build_selected_image_output_paths(request.selection_result)
+        stages = {item.source.fingerprint: item for item in request.video_stage_results}
+        artifacts: list[SelectedImageArtifact] = []
+        for selected in request.selection_result.selected:
+            self._fault_injector("before-image-write", staging_folder)
+            frame = selected.candidate.annotation.candidate
+            stage = _stage_for_frame(frame, stages)
+            decoded = self._extract_original_frame(frame, stage)
+            relative_path = paths[selected.candidate.identifier]
+            artifacts.append(
+                encode_selected_webp(
+                    selected.candidate.identifier,
+                    decoded,
+                    staging_folder / relative_path,
+                    relative_path,
+                )
+            )
+        report = build_canonical_selection_report(request, tuple(artifacts))
+        self._fault_injector("before-report-json-write", staging_folder)
+        (staging_folder / "report.json").write_text(
+            serialize_canonical_selection_report(report),
+            encoding="utf-8",
+        )
+        self._fault_injector("before-markdown-render", staging_folder)
+        markdown = render_human_selection_report(report)
+        self._fault_injector("before-report-markdown-write", staging_folder)
+        (staging_folder / "report.md").write_text(markdown, encoding="utf-8")
+        self._fault_injector("before-flush", staging_folder)
+        _flush_staging_tree(staging_folder)
+        self._fault_injector("before-validation", staging_folder)
+        validate_canonical_selection_report(report, staging_folder, request)
+        return report
+
+    def _extract_original_frame(
+        self,
+        candidate: FrameCandidate,
+        stage: VideoStageResult,
+    ) -> DecodedVideoFrame:
+        """選択candidateのexact PTSから元寸法RGB frameを再抽出する。"""
+        stream = stage.scan.primary_stream
+        if (
+            candidate.stream_index is None
+            or candidate.source_pts is None
+            or candidate.time_base is None
+            or stream.width is None
+            or stream.height is None
+        ):
+            msg = "Selected Imageのexact frame情報が不足しています"
+            raise ValueError(msg)
+        decoded = self._media_runtime.extract_video_frame(
+            stage.source.path,
+            candidate.stream_index,
+            candidate.source_pts,
+            max(stream.width, stream.height),
+        )
+        if (
+            decoded.stream_index != candidate.stream_index
+            or decoded.pts != candidate.source_pts
+            or decoded.time_base != candidate.time_base
+            or decoded.width != stream.width
+            or decoded.height != stream.height
+        ):
+            msg = "再抽出したSelected Imageがexact PTSまたは元寸法と一致しません"
+            raise ValueError(msg)
+        return decoded
+
+
+def _stage_for_frame(
+    frame: FrameCandidate,
+    stages: dict[str, VideoStageResult],
+) -> VideoStageResult:
+    fingerprint = frame.video_fingerprint
+    if fingerprint is None:
+        raise ValueError("Selected ImageにVideo Fingerprintがありません")
+    return stages[fingerprint]
+
+
+def _flush_staging_tree(staging_folder: Path) -> None:
+    """staging内の全fileとdirectory entryをrename前にflushする。"""
+    paths = sorted(staging_folder.rglob("*"))
+    for path in paths:
+        if path.is_file() and not path.is_symlink():
+            with path.open("rb") as file:
+                os.fsync(file.fileno())
+    directories = [
+        staging_folder.parent,
+        staging_folder,
+        *(path for path in paths if path.is_dir()),
+    ]
+    for directory in reversed(directories):
+        _flush_directory(directory)
+
+
+def _flush_directory(directory: Path) -> None:
+    descriptor = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _rename_directory(source: Path, destination: Path) -> None:
+    source.rename(destination)
+
+
+def _verify_atomic_directory_rename(parent: Path, output_name: str) -> None:
+    """同じparent内のdirectory rename能力をartifact生成前に検証する。"""
+    probe_source = Path(
+        tempfile.mkdtemp(
+            prefix=f".{output_name}.rename-probe.",
+            dir=parent,
+        )
+    )
+    probe_destination = probe_source.with_name(probe_source.name + ".renamed")
+    try:
+        os.rename(probe_source, probe_destination)
+    except OSError as error:
+        msg = "Output Folderのfilesystemでatomic directory renameを利用できません"
+        raise OSError(msg) from error
+    finally:
+        shutil.rmtree(probe_source, ignore_errors=True)
+        shutil.rmtree(probe_destination, ignore_errors=True)
+
+
+def _remove_failed_publication(output_folder: Path) -> None:
+    if output_folder.is_dir() and not output_folder.is_symlink():
+        shutil.rmtree(output_folder, ignore_errors=True)
+    else:
+        output_folder.unlink(missing_ok=True)
+
+
+def _ignore_fault(_checkpoint: str, _staging_folder: Path) -> None:
+    return

--- a/src/video_selection/services/encode_selected_webp.py
+++ b/src/video_selection/services/encode_selected_webp.py
@@ -1,0 +1,41 @@
+"""Selected Image Encoding v1。"""
+
+import hashlib
+from pathlib import Path
+
+from PIL import Image
+
+from ..models.decoded_video_frame import DecodedVideoFrame
+from ..models.selected_image_artifact import SelectedImageArtifact
+
+SELECTED_WEBP_QUALITY = 95
+
+
+def encode_selected_webp(
+    image_id: str,
+    frame: DecodedVideoFrame,
+    output_path: Path,
+    relative_path: str,
+) -> SelectedImageArtifact:
+    """RGB24 frameを元寸法のmetadataなしlossy WebPへ保存する。"""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with Image.frombytes("RGB", (frame.width, frame.height), frame.pixels) as image:
+        image.save(
+            output_path,
+            format="WEBP",
+            lossless=False,
+            quality=SELECTED_WEBP_QUALITY,
+            method=6,
+            exif=b"",
+            icc_profile=None,
+            xmp=b"",
+        )
+    content = output_path.read_bytes()
+    return SelectedImageArtifact(
+        image_id=image_id,
+        relative_path=relative_path,
+        sha256=hashlib.sha256(content).hexdigest(),
+        width=frame.width,
+        height=frame.height,
+        size_bytes=len(content),
+    )

--- a/src/video_selection/services/render_human_selection_report.py
+++ b/src/video_selection/services/render_human_selection_report.py
@@ -68,7 +68,8 @@ def render_human_selection_report(report: dict[str, object]) -> str:
             if "similarity" in rejection:
                 detail += f" ({float(rejection['similarity']):.3f})"
             lines.append(
-                f"| `{_abbreviate(identifier, 8)}` {annotation['summary']} | "
+                f"| `{_abbreviate(identifier, 8)}` "
+                f"{_escape_markdown_table_cell(str(annotation['summary']))} | "
                 f"{float(counterfactual['marginal_utility']):.6f} | `{detail}` |"
             )
     else:
@@ -278,6 +279,17 @@ def _abbreviate(value: str, count: int) -> str:
     if len(value) <= count:
         return value
     return value[:count] + "…"
+
+
+def _escape_markdown_table_cell(value: str) -> str:
+    """自由文を一つのMarkdown table cell内へ閉じ込める。"""
+    return (
+        value.replace("\\", "\\\\")
+        .replace("|", "\\|")
+        .replace("\r\n", "<br>")
+        .replace("\r", "<br>")
+        .replace("\n", "<br>")
+    )
 
 
 def _mapping(value: object) -> dict[str, Any]:

--- a/src/video_selection/services/render_human_selection_report.py
+++ b/src/video_selection/services/render_human_selection_report.py
@@ -1,0 +1,288 @@
+"""Canonical Selection Reportからgallery-first Markdownを描画する。"""
+
+from typing import Any, cast
+
+
+def render_human_selection_report(report: dict[str, object]) -> str:
+    """検証対象のreport objectだけから決定的なMarkdownを返す。"""
+    run = _mapping(report["run"])
+    video_set = _mapping(report["video_set"])
+    selection_summary = _mapping(report["selection_summary"])
+    selected = _mapping_list(report["selected"])
+    near_misses = _mapping_list(report["near_misses"])
+    provenance = _mapping(report["provenance"])
+    lines = [
+        "# 画像選定レポート",
+        "",
+        f"`{run['id']}` · {run['started_at']}",
+        "",
+    ]
+    warnings = _mapping_list(run["warnings"])
+    for warning in warnings:
+        lines.extend(
+            (
+                "> [!WARNING]",
+                f"> {warning['message']}",
+                "",
+            )
+        )
+    lines.extend(
+        (
+            "## Summary",
+            "",
+            "| Requested | Selected | Videos | Duration | Candidate Moments |",
+            "|---:|---:|---:|---:|---:|",
+            (
+                f"| {run['requested_image_count']} | {run['selected_image_count']} | "
+                f"{len(cast(list[object], video_set['sources']))} | "
+                f"{_mapping(video_set['duration'])['display']} | "
+                f"{selection_summary['candidate_moments']} |"
+            ),
+            "",
+            "| Blog Image Type | Target | Actual |",
+            "|---|---:|---:|",
+        )
+    )
+    image_types = _mapping(selection_summary["blog_image_type"])
+    for name, counts_value in image_types.items():
+        counts = _mapping(counts_value)
+        lines.append(f"| {name} | {counts['target']} | {counts['actual']} |")
+    lines.extend(("", "## Selected images", ""))
+    sources = {item["id"]: item for item in _mapping_list(video_set["sources"])}
+    for item in selected:
+        _append_selected(lines, item, sources)
+    lines.extend(("## Near misses", ""))
+    if near_misses:
+        lines.extend(
+            (
+                "| Candidate | Counterfactual utility | Not selected because |",
+                "|---|---:|---|",
+            )
+        )
+        for item in near_misses[:10]:
+            annotation = _mapping(item["annotation"])
+            counterfactual = _mapping(item["counterfactual_selection"])
+            rejection = _mapping(item["rejection"])
+            identifier = str(item["image_id"])
+            detail = str(rejection["reason_code"])
+            if "similarity" in rejection:
+                detail += f" ({float(rejection['similarity']):.3f})"
+            lines.append(
+                f"| `{_abbreviate(identifier, 8)}` {annotation['summary']} | "
+                f"{float(counterfactual['marginal_utility']):.6f} | `{detail}` |"
+            )
+    else:
+        lines.append("該当なし。")
+    lines.extend(("", "## Reproduction appendix", "", "### Selection funnel", ""))
+    shortfall = _mapping(selection_summary["shortfall"])
+    refined_count = int(selection_summary["candidate_moments"]) - int(
+        selection_summary["moments_without_valid_frame"]
+    )
+    requested = shortfall["requested"]
+    selected_count = shortfall["selected"]
+    lines.extend(
+        (
+            "| Stage | Input | Kept |",
+            "|---|---:|---:|",
+            (
+                f"| Candidate Moment discovery | "
+                f"{selection_summary['candidate_moments']} | "
+                f"{selection_summary['candidate_moments']} |"
+            ),
+            (
+                f"| Frame refinement | {selection_summary['candidate_moments']} | "
+                f"{refined_count} |"
+            ),
+            (
+                f"| Candidate Annotation | "
+                f"{selection_summary['candidate_annotations']} | "
+                f"{selection_summary['candidate_annotations']} |"
+            ),
+            (
+                f"| Final selection | {selection_summary['candidate_annotations']} | "
+                f"{selection_summary['selected']} |"
+            ),
+            "",
+            (
+                f"Requested {requested} / selected {selected_count}。"
+                f" all_candidate_moments_exhausted="
+                f"`{str(shortfall['all_candidate_moments_exhausted']).lower()}`。"
+            ),
+            "",
+            "### Decision ledger",
+            "",
+            (
+                "| Frame ID | Decision | Type | Base | Coverage | Spoiler | "
+                "Temporal | Marginal | Reasons |"
+            ),
+            "|---|---|---|---:|---:|---:|---:|---:|---|",
+        )
+    )
+    for item in selected:
+        classification = _mapping(item["classification"])
+        selection = _mapping(item["selection"])
+        reasons = ", ".join(cast(list[str], selection["reason_codes"]))
+        lines.append(
+            f"| `{_abbreviate(str(item['image_id']), 12)}` | "
+            f"selected {int(item['selection_index']):02d} | "
+            f"{classification['blog_image_type']} | "
+            f"{float(selection['base_utility']):.6f} | "
+            f"{float(selection['coverage_bonus']):.6f} | "
+            f"{float(selection['spoiler_penalty']):.6f} | "
+            f"{float(selection['temporal_diversity_penalty']):.6f} | "
+            f"**{float(selection['marginal_utility']):.6f}** | `{reasons}` |"
+        )
+    for item in near_misses[:10]:
+        classification = _mapping(item["classification"])
+        score = _mapping(item["counterfactual_selection"])
+        rejection = _mapping(item["rejection"])
+        lines.append(
+            f"| `{_abbreviate(str(item['image_id']), 12)}` | "
+            f"`{rejection['reason_code']}` | {classification['blog_image_type']} | "
+            f"{float(score['base_utility']):.6f} | "
+            f"{float(score['coverage_bonus']):.6f} | "
+            f"{float(score['spoiler_penalty']):.6f} | "
+            f"{float(score['temporal_diversity_penalty']):.6f} | "
+            f"{float(score['marginal_utility']):.6f} | — |"
+        )
+    lines.extend(("", "### Stage provenance", ""))
+    lines.extend(
+        (
+            "| Stage | Fingerprint | Cache | Duration | Contracts |",
+            "|---|---|---|---:|---|",
+        )
+    )
+    for stage in _mapping_list(provenance["stages"]):
+        contracts = ", ".join(cast(list[str], stage["contract_refs"])) or "—"
+        lines.append(
+            f"| `{stage['name']}` | `{_abbreviate(str(stage['fingerprint']), 8)}` | "
+            f"{stage['cache_hits']} hit / {stage['cache_misses']} miss | "
+            f"{int(stage['duration_ms']) / 1000:.3f}s | `{contracts}` |"
+        )
+    lines.extend(("", "### Model and tool provenance", ""))
+    schema = _mapping(report["schema"])
+    lines.append(f"- Report schema: `{schema['name']}@{schema['version']}`")
+    models = _mapping(provenance["models"])
+    for role, model_value in models.items():
+        model = _mapping(model_value)
+        lines.append(
+            f"- {role}: `{model['configured_name']}` @ "
+            f"`{_abbreviate(str(model['execution_identity']), 18)}` "
+            f"({model['update_status']})"
+        )
+    tools = _mapping(provenance["tools"])
+    for name, version in tools.items():
+        lines.append(f"- {name}: `{version}`")
+    lines.extend(
+        (
+            "",
+            "### Deliberately omitted",
+            "",
+            "- absolute input/cache/output paths",
+            "- environment variables and credentials",
+            (
+                "- prompt bodies, model reasoning traces, raw model responses, "
+                "and stack traces"
+            ),
+            "- generated screen-text quotations",
+            "- raw Context Cue text（processing cacheだけに保持）",
+            "",
+            "完全なscore内訳、PTS/time base、Stage provenanceは"
+            "[`report.json`](report.json)を参照する。",
+            "",
+        )
+    )
+    return "\n".join(lines)
+
+
+def _append_selected(
+    lines: list[str],
+    item: dict[str, Any],
+    sources: dict[object, dict[str, Any]],
+) -> None:
+    index = int(item["selection_index"])
+    output = _mapping(item["output"])
+    source = _mapping(item["source"])
+    classification = _mapping(item["classification"])
+    annotation = _mapping(item["annotation"])
+    selection = _mapping(item["selection"])
+    decision = _mapping(selection["decision_explanation"])
+    source_video = sources[source["video_id"]]
+    video_time = _mapping(source["video_time"])
+    relative_path = str(output["relative_path"])
+    lines.extend(
+        (
+            f"### {index:02d} — {annotation['summary']}",
+            "",
+            (
+                f"[![{index:02d} — {classification['scene_display_name']}]"
+                f"({relative_path})]({relative_path})"
+            ),
+            "",
+            f"`{_abbreviate(str(item['image_id']), 12)}` · `{relative_path}`",
+            "",
+            f"- **画像の説明（model）**: {annotation['summary']}",
+            (
+                "- **Representative Frameの理由（model）**: "
+                f"{annotation['representative_frame_reason']}"
+            ),
+            f"- **採用理由（selector）**: {decision['text']}",
+            (
+                f"- **Reason codes**: `"
+                f"{', '.join(cast(list[str], selection['reason_codes']))}`"
+            ),
+            (
+                f"- **Source**: Video {source_video['order']} "
+                f"`{source_video['relative_path']}` (`{source['video_id']}`) · "
+                f"`{video_time['display']}`"
+            ),
+            (
+                f"- **Classification**: `{classification['scene_slug']}` · "
+                f"`{classification['scene_selection_role']}` · "
+                f"`{classification['blog_image_type']}` · spoiler "
+                f"`{classification['spoiler_risk']}`"
+            ),
+            _context_line(annotation),
+            f"- **Utility**: {float(selection['marginal_utility']):.6f}",
+            "",
+        )
+    )
+    evidence = classification["spoiler_evidence"]
+    if evidence is not None:
+        evidence_value = _mapping(evidence)
+        lines.extend(
+            (
+                "<details>",
+                "<summary>Spoiler evidence（model）</summary>",
+                "",
+                str(evidence_value["summary"]),
+                "",
+                "</details>",
+                "",
+            )
+        )
+
+
+def _context_line(annotation: dict[str, Any]) -> str:
+    relevance = str(annotation["context_cue_relevance"])
+    cue_ids = cast(list[str], annotation["supporting_context_cue_ids"])
+    suffix = "" if not cue_ids else " · " + " / ".join(f"`{item}`" for item in cue_ids)
+    return f"- **Context**: `{relevance}`{suffix}"
+
+
+def _abbreviate(value: str, count: int) -> str:
+    if value.startswith("frm_"):
+        return f"frm_{value[4 : 4 + count]}…"
+    if value.startswith("stg_"):
+        return f"stg_{value[4 : 4 + count]}…"
+    if len(value) <= count:
+        return value
+    return value[:count] + "…"
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    return cast(dict[str, Any], value)
+
+
+def _mapping_list(value: object) -> list[dict[str, Any]]:
+    return cast(list[dict[str, Any]], value)

--- a/src/video_selection/services/report_time.py
+++ b/src/video_selection/services/report_time.py
@@ -1,0 +1,49 @@
+"""Canonical reportのexact time projection。"""
+
+import math
+from datetime import datetime, timezone
+from decimal import Decimal, localcontext
+from fractions import Fraction
+
+
+def display_report_time(value: Fraction) -> str:
+    """非負のexact秒をhalf-upでunbounded hour表示する。"""
+    if value < 0:
+        msg = "Report Video Timeは0以上である必要があります"
+        raise ValueError(msg)
+    milliseconds = math.floor(value * 1000 + Fraction(1, 2))
+    hours, remainder = divmod(milliseconds, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    seconds, milliseconds = divmod(remainder, 1000)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}.{milliseconds:03d}"
+
+
+def rational_report_value(value: Fraction) -> dict[str, int]:
+    """既約FractionをJSON objectへ投影する。"""
+    return {"numerator": value.numerator, "denominator": value.denominator}
+
+
+def exact_seconds_string(value: Fraction) -> str:
+    """有限小数は小数、それ以外は既約分数としてlosslessに表示する。"""
+    denominator = value.denominator
+    reduced = denominator
+    for factor in (2, 5):
+        while reduced % factor == 0:
+            reduced //= factor
+    if reduced != 1:
+        return f"{value.numerator}/{value.denominator}"
+    with localcontext() as context:
+        context.prec = max(len(str(abs(value.numerator))), len(str(denominator))) + 8
+        result = Decimal(value.numerator) / Decimal(denominator)
+    rendered = format(result, "f")
+    if "." in rendered:
+        rendered = rendered.rstrip("0").rstrip(".")
+    return rendered or "0"
+
+
+def utc_report_datetime(value: datetime) -> str:
+    """timezone-aware datetimeをUTCのZ表記へ正規化する。"""
+    if value.tzinfo is None:
+        msg = "Report datetimeにはtimezoneが必要です"
+        raise ValueError(msg)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/src/video_selection/services/serialize_canonical_selection_report.py
+++ b/src/video_selection/services/serialize_canonical_selection_report.py
@@ -1,0 +1,17 @@
+"""Canonical Selection Reportの決定的なJSON serialization。"""
+
+import json
+
+
+def serialize_canonical_selection_report(report: dict[str, object]) -> str:
+    """JSON key順を契約化せずproducer出力だけを安定化して返す。"""
+    return (
+        json.dumps(
+            report,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n"
+    )

--- a/src/video_selection/services/validate_canonical_selection_report.py
+++ b/src/video_selection/services/validate_canonical_selection_report.py
@@ -1,0 +1,423 @@
+"""Canonical report schemaとstaging artifactのcross-validation。"""
+
+import hashlib
+import json
+import math
+from fractions import Fraction
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, cast
+
+from jsonschema import Draft202012Validator
+from PIL import Image
+
+from ..models.canonical_publication_request import CanonicalPublicationRequest
+from ..models.report_value import string_looks_private
+from .render_human_selection_report import render_human_selection_report
+from .report_time import display_report_time, exact_seconds_string
+from .serialize_canonical_selection_report import (
+    serialize_canonical_selection_report,
+)
+
+
+def validate_canonical_selection_report(
+    report: dict[str, object],
+    staging_folder: Path,
+    request: CanonicalPublicationRequest,
+) -> None:
+    """schema、画像、JSON、Markdown、privacyの公開前整合を検証する。"""
+    try:
+        report_from_disk = _read_json_artifact(staging_folder)
+        _validate_schema(report_from_disk)
+        _validate_schema(report)
+        _validate_json_artifact(report, report_from_disk, staging_folder)
+        _validate_report_relationships(report, request)
+        _validate_images(report, staging_folder)
+        _validate_markdown(report, staging_folder)
+        _validate_privacy(report, staging_folder, request)
+        _validate_staging_layout(report, staging_folder)
+    except (AssertionError, KeyError, OSError, TypeError, ValueError) as error:
+        if isinstance(error, ValueError) and str(error).startswith(
+            "Canonical Selection Report"
+        ):
+            raise
+        msg = f"Canonical Selection Reportの検証に失敗しました: {error}"
+        raise ValueError(msg) from error
+
+
+def _validate_schema(report: dict[str, object]) -> None:
+    errors = sorted(
+        _schema_validator().iter_errors(report),
+        key=lambda item: tuple(str(part) for part in item.absolute_path),
+    )
+    if errors:
+        error = errors[0]
+        location = ".".join(str(item) for item in error.absolute_path) or "root"
+        raise ValueError(
+            f"Canonical Selection Report schema不一致: {location}: {error.message}"
+        )
+
+
+@lru_cache(maxsize=1)
+def _schema_validator() -> Draft202012Validator:
+    schema_path = Path(__file__).parent.parent / "schemas" / "report-1.0.0.schema.json"
+    schema_value: object = json.loads(schema_path.read_text(encoding="utf-8"))
+    if not isinstance(schema_value, dict):
+        raise ValueError("Canonical Selection Report schemaがJSON objectではありません")
+    schema = cast(dict[str, Any], schema_value)
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def _validate_json_artifact(
+    report: dict[str, object],
+    report_from_disk: dict[str, object],
+    staging_folder: Path,
+) -> None:
+    report_path = staging_folder / "report.json"
+    content = report_path.read_text(encoding="utf-8")
+    if content != serialize_canonical_selection_report(report):
+        raise ValueError("Canonical Selection Report JSON serializationが一致しません")
+    if report_from_disk != report:
+        raise ValueError("Canonical Selection Report JSON objectが一致しません")
+
+
+def _read_json_artifact(staging_folder: Path) -> dict[str, object]:
+    content = (staging_folder / "report.json").read_text(encoding="utf-8")
+    parsed: object = json.loads(content, parse_constant=_reject_json_constant)
+    if not isinstance(parsed, dict) or not all(isinstance(key, str) for key in parsed):
+        raise ValueError("Canonical Selection Report JSONはobjectである必要があります")
+    return cast(dict[str, object], parsed)
+
+
+def _reject_json_constant(value: str) -> object:
+    raise ValueError(f"非有限JSON numberは使用できません: {value}")
+
+
+def _validate_report_relationships(
+    report: dict[str, object],
+    request: CanonicalPublicationRequest,
+) -> None:
+    run = _mapping(report["run"])
+    warnings = _mapping_list(run["warnings"])
+    selected = _mapping_list(report["selected"])
+    near_misses = _mapping_list(report["near_misses"])
+    selection_summary = _mapping(report["selection_summary"])
+    rejection_summary = _mapping(report["rejection_summary"])
+    warning_codes = [str(item["code"]) for item in warnings]
+    expected_status = "completed_with_warnings" if warnings else "completed"
+    selection = request.selection_result
+    if (
+        run["status"] != expected_status
+        or len(warning_codes) != len(set(warning_codes))
+        or ("selection_shortfall" in warning_codes) != selection.shortfall
+        or run["requested_image_count"] != selection.requested_count
+        or len(selected) != run["selected_image_count"]
+        or len(selected) != selection_summary["selected"]
+        or _mapping(selection_summary["shortfall"])["requested"]
+        != selection.requested_count
+        or _mapping(selection_summary["shortfall"])["selected"] != len(selected)
+        or len(near_misses)
+        > _mapping(report["near_miss_publication"])["json_limit_for_this_run"]
+        or rejection_summary["total"] != selection_summary["not_selected"]
+        or rejection_summary["total"]
+        != sum(cast(dict[str, int], rejection_summary["by_reason"]).values())
+        or rejection_summary["by_reason"] != selection.rejection_counts
+    ):
+        raise ValueError("Canonical Selection Reportのselection countが一致しません")
+    _validate_warning_relationships(warnings, request)
+    selected_ids = {str(item["image_id"]) for item in selected}
+    if len(selected_ids) != len(selected):
+        raise ValueError(
+            "Canonical Selection ReportのSelected Image IDが重複しています"
+        )
+    source_ids = {
+        str(item["id"])
+        for item in _mapping_list(_mapping(report["video_set"])["sources"])
+    }
+    context_cues = _mapping_list(report["context_cues"])
+    cue_ids = {str(item["id"]) for item in context_cues}
+    if len(cue_ids) != len(context_cues):
+        raise ValueError("Canonical Selection ReportのContext Cue IDが重複しています")
+    rejection_reasons = set(cast(dict[str, int], rejection_summary["by_reason"]))
+    published_reasons = {
+        str(_mapping(item["rejection"])["reason_code"]) for item in near_misses
+    }
+    if not rejection_reasons <= published_reasons:
+        raise ValueError(
+            "Canonical Selection ReportのNear Miss reason coverageが不足しています"
+        )
+    for expected_index, item in enumerate(selected, start=1):
+        if item["selection_index"] != expected_index:
+            raise ValueError("Canonical Selection Reportのselection indexが不正です")
+        _validate_candidate_record(item, source_ids, cue_ids)
+        score = _mapping(item["selection"])
+        _validate_score(score)
+    for item in near_misses:
+        _validate_candidate_record(item, source_ids, cue_ids)
+        _validate_score(_mapping(item["counterfactual_selection"]))
+        rejection = _mapping(item["rejection"])
+        for field in ("blocked_by_image_id", "nearest_selected_image_id"):
+            if field in rejection and rejection[field] not in selected_ids:
+                raise ValueError(
+                    "Canonical Selection Reportのrejection参照が解決できません"
+                )
+    source_durations = {
+        str(item["id"]): Fraction(str(_mapping(item["duration"])["exact_seconds"]))
+        for item in _mapping_list(_mapping(report["video_set"])["sources"])
+    }
+    for cue in context_cues:
+        video_id = str(cue["video_id"])
+        if video_id not in source_ids:
+            raise ValueError("Canonical Selection ReportのContext Cue sourceが不正です")
+        _validate_context_cue_time(cue, source_durations[video_id])
+    stages = _mapping_list(_mapping(report["provenance"])["stages"])
+    stage_fingerprints = {str(item["fingerprint"]) for item in stages}
+    tools = set(_mapping(_mapping(report["provenance"])["tools"]))
+    models = set(_mapping(_mapping(report["provenance"])["models"]))
+    contracts = set(_mapping(_mapping(report["provenance"])["contracts"]))
+    for stage in stages:
+        if (
+            not set(cast(list[str], stage["upstream_fingerprints"]))
+            <= stage_fingerprints
+            or not set(cast(list[str], stage["tool_refs"])) <= tools
+            or not set(cast(list[str], stage["model_refs"])) <= models
+            or not set(cast(list[str], stage["contract_refs"])) <= contracts
+        ):
+            raise ValueError(
+                "Canonical Selection ReportのStage provenance参照が解決できません"
+            )
+
+
+def _validate_warning_relationships(
+    warnings: list[dict[str, Any]],
+    request: CanonicalPublicationRequest,
+) -> None:
+    """warning codeとdomain resultの対応を検証する。"""
+    by_code = {str(item["code"]): item for item in warnings}
+    shortfall = by_code.get("selection_shortfall")
+    if (
+        shortfall is not None
+        and _mapping(shortfall["details"]) != request.selection_result.rejection_counts
+    ):
+        raise ValueError(
+            "Canonical Selection ReportのSelection Shortfall warningが不正です"
+        )
+    unavailable = by_code.get("model_update_unavailable")
+    expected_roles = [
+        role.value for role in request.resolved_models.unavailable_roles()
+    ]
+    if (unavailable is None) != (not expected_roles) or (
+        unavailable is not None
+        and _mapping(unavailable["details"])["roles"] != expected_roles
+    ):
+        raise ValueError("Canonical Selection Reportのmodel update warningが不正です")
+
+
+def _validate_context_cue_time(
+    cue: dict[str, Any],
+    source_duration: Fraction,
+) -> None:
+    """Context Cueのbasis固有時刻と表示値を検証する。"""
+    basis = str(cue["timestamp_basis"])
+    start_value = _mapping(cue["start"])
+    end_value = _mapping(cue["end"])
+    start = _context_time_offset(start_value, basis)
+    end = _context_time_offset(end_value, basis)
+    if start < 0 or end <= start or end > source_duration:
+        raise ValueError("Canonical Selection ReportのContext Cue timeが不正です")
+    for value, offset in ((start_value, start), (end_value, end)):
+        if value["display"] != display_report_time(offset) or (
+            "exact_seconds" in value
+            and value["exact_seconds"] != exact_seconds_string(offset)
+        ):
+            raise ValueError(
+                "Canonical Selection ReportのContext Cue表示時刻が不正です"
+            )
+
+
+def _context_time_offset(value: dict[str, Any], basis: str) -> Fraction:
+    if basis == "source_pts":
+        if "source_pts" not in value:
+            raise ValueError("Canonical Selection ReportのContext Cue PTSがありません")
+        time_base = _fraction(_mapping(value["time_base"]))
+        offset = _fraction(_mapping(value["offset_seconds"]))
+        if (int(value["source_pts"]) - int(value["origin_pts"])) * time_base != offset:
+            raise ValueError("Canonical Selection ReportのContext Cue PTSが不正です")
+        return offset
+    if basis == "container_text_ms":
+        if "offset_seconds" not in value or "sample_index" in value:
+            raise ValueError(
+                "Canonical Selection Reportのcontainer text timeが不正です"
+            )
+        return _fraction(_mapping(value["offset_seconds"]))
+    if "sample_index" in value:
+        return Fraction(int(value["sample_index"]), int(value["sample_rate_hz"]))
+    if "offset_seconds" in value:
+        return _fraction(_mapping(value["offset_seconds"]))
+    raise ValueError("Canonical Selection ReportのASR sample timeが不正です")
+
+
+def _validate_candidate_record(
+    item: dict[str, Any],
+    source_ids: set[str],
+    cue_ids: set[str],
+) -> None:
+    source = _mapping(item["source"])
+    annotation = _mapping(item["annotation"])
+    if source["video_id"] not in source_ids:
+        raise ValueError("Canonical Selection ReportのVideo Source参照が不正です")
+    if not set(cast(list[str], annotation["supporting_context_cue_ids"])) <= cue_ids:
+        raise ValueError("Canonical Selection ReportのContext Cue参照が不正です")
+    video_time = _mapping(source["video_time"])
+    time_base = _fraction(_mapping(video_time["time_base"]))
+    offset = _fraction(_mapping(video_time["offset_seconds"]))
+    if (
+        int(video_time["source_pts"]) - int(video_time["origin_pts"])
+    ) * time_base != offset:
+        raise ValueError("Canonical Selection Reportのsource PTSが不正です")
+
+
+def _validate_score(score: dict[str, Any]) -> None:
+    expected = (
+        float(score["base_utility"])
+        + float(score["coverage_bonus"])
+        - float(score["spoiler_penalty"])
+        - float(score["temporal_diversity_penalty"])
+    )
+    if not math.isclose(
+        expected,
+        float(score["marginal_utility"]),
+        rel_tol=0,
+        abs_tol=1e-12,
+    ):
+        raise ValueError(
+            "Canonical Selection ReportのMarginal Selection Utilityが不正です"
+        )
+
+
+def _validate_images(report: dict[str, object], staging_folder: Path) -> None:
+    selected = _mapping_list(report["selected"])
+    prefixes: dict[str, int] = {}
+    for item in selected:
+        digest = str(item["image_id"])[4:]
+        prefixes[digest[:12]] = prefixes.get(digest[:12], 0) + 1
+    width = max(4, len(str(len(selected))))
+    for expected_index, item in enumerate(selected, start=1):
+        output = _mapping(item["output"])
+        classification = _mapping(item["classification"])
+        digest = str(item["image_id"])[4:]
+        digest_part = digest if prefixes[digest[:12]] > 1 else digest[:12]
+        expected_path = (
+            f"images/{expected_index:0{width}d}_{classification['scene_slug']}_"
+            f"{digest_part}.webp"
+        )
+        if output["relative_path"] != expected_path:
+            raise ValueError(
+                "Canonical Selection ReportのSelected Image filenameが不正です"
+            )
+        image_path = staging_folder / expected_path
+        if image_path.is_symlink() or not image_path.is_file():
+            raise ValueError(
+                "Canonical Selection ReportのSelected Imageが見つかりません"
+            )
+        content = image_path.read_bytes()
+        if (
+            hashlib.sha256(content).hexdigest() != output["sha256"]
+            or len(content) != output["bytes"]
+        ):
+            raise ValueError(
+                "Canonical Selection ReportのSelected Image hashが不正です"
+            )
+        with Image.open(image_path) as image:
+            if (
+                image.format != "WEBP"
+                or image.size != (output["width"], output["height"])
+                or image.getexif()
+                or {"exif", "icc_profile", "xmp"} & image.info.keys()
+            ):
+                raise ValueError(
+                    "Canonical Selection ReportのSelected Image encodingが不正です"
+                )
+
+
+def _validate_markdown(report: dict[str, object], staging_folder: Path) -> None:
+    expected = render_human_selection_report(report)
+    actual = (staging_folder / "report.md").read_text(encoding="utf-8")
+    if actual != expected:
+        raise ValueError(
+            "Canonical Selection ReportのMarkdown projectionが一致しません"
+        )
+
+
+def _validate_privacy(
+    report: dict[str, object],
+    staging_folder: Path,
+    request: CanonicalPublicationRequest,
+) -> None:
+    serialized = serialize_canonical_selection_report(report) + (
+        staging_folder / "report.md"
+    ).read_text(encoding="utf-8")
+    private_paths = {
+        str(request.video_set.input_folder.resolve(strict=False)),
+        str(request.configuration.output_folder.resolve(strict=False)),
+        str(request.configuration.processing_cache_folder.resolve(strict=False)),
+        str(staging_folder.resolve(strict=False)),
+    }
+    raw_context_texts = {
+        cue.text
+        for stage in request.video_stage_results
+        for cue in stage.context.cues
+        if cue.text
+    }
+    if any(value in serialized for value in (*private_paths, *raw_context_texts)):
+        raise ValueError(
+            "Canonical Selection Reportに非公開pathまたはContext Cueがあります"
+        )
+    for value in _all_strings(report):
+        if string_looks_private(value):
+            raise ValueError(
+                "Canonical Selection Reportに絶対pathまたはendpointがあります"
+            )
+
+
+def _validate_staging_layout(report: dict[str, object], staging_folder: Path) -> None:
+    expected = {
+        "images",
+        "report.json",
+        "report.md",
+        *(
+            str(_mapping(item["output"])["relative_path"])
+            for item in _mapping_list(report["selected"])
+        ),
+    }
+    actual = {
+        path.relative_to(staging_folder).as_posix()
+        for path in staging_folder.rglob("*")
+    }
+    if actual != expected or any(
+        path.is_symlink() for path in staging_folder.rglob("*")
+    ):
+        raise ValueError("Canonical Selection Reportのstaging layoutが不正です")
+
+
+def _all_strings(value: object) -> list[str]:
+    if isinstance(value, dict):
+        return [
+            item for key, child in value.items() for item in (key, *_all_strings(child))
+        ]
+    if isinstance(value, list):
+        return [item for child in value for item in _all_strings(child)]
+    return [value] if isinstance(value, str) else []
+
+
+def _fraction(value: dict[str, Any]) -> Fraction:
+    return Fraction(int(value["numerator"]), int(value["denominator"]))
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    return cast(dict[str, Any], value)
+
+
+def _mapping_list(value: object) -> list[dict[str, Any]]:
+    return cast(list[dict[str, Any]], value)

--- a/src/video_selection/services/validate_canonical_selection_report.py
+++ b/src/video_selection/services/validate_canonical_selection_report.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 from jsonschema import Draft202012Validator
 from PIL import Image
 
+from ..models.candidate_annotation import candidate_annotation_free_text_is_safe
 from ..models.canonical_publication_request import CanonicalPublicationRequest
 from ..models.report_value import string_looks_private
 from .render_human_selection_report import render_human_selection_report
@@ -131,10 +132,10 @@ def _validate_report_relationships(
         raise ValueError(
             "Canonical Selection ReportのSelected Image IDが重複しています"
         )
-    source_ids = {
-        str(item["id"])
-        for item in _mapping_list(_mapping(report["video_set"])["sources"])
-    }
+    sources = _mapping_list(_mapping(report["video_set"])["sources"])
+    source_ids = {str(item["id"]) for item in sources}
+    if len(source_ids) != len(sources):
+        raise ValueError("Canonical Selection ReportのVideo Source IDが重複しています")
     context_cues = _mapping_list(report["context_cues"])
     cue_ids = {str(item["id"]) for item in context_cues}
     if len(cue_ids) != len(context_cues):
@@ -239,7 +240,11 @@ def _validate_context_cue_time(
 def _context_time_offset(value: dict[str, Any], basis: str) -> Fraction:
     if basis == "source_pts":
         if "source_pts" not in value:
-            raise ValueError("Canonical Selection ReportのContext Cue PTSがありません")
+            if "offset_seconds" not in value:
+                raise ValueError(
+                    "Canonical Selection ReportのContext Cue時刻がありません"
+                )
+            return _fraction(_mapping(value["offset_seconds"]))
         time_base = _fraction(_mapping(value["time_base"]))
         offset = _fraction(_mapping(value["offset_seconds"]))
         if (int(value["source_pts"]) - int(value["origin_pts"])) * time_base != offset:
@@ -364,13 +369,17 @@ def _validate_privacy(
         str(request.configuration.processing_cache_folder.resolve(strict=False)),
         str(staging_folder.resolve(strict=False)),
     }
-    raw_context_texts = {
+    raw_context_texts = tuple(
         cue.text
         for stage in request.video_stage_results
         for cue in stage.context.cues
         if cue.text
-    }
-    if any(value in serialized for value in (*private_paths, *raw_context_texts)):
+    )
+    free_text_is_safe = candidate_annotation_free_text_is_safe(
+        tuple(_published_free_text(report)),
+        raw_context_texts,
+    )
+    if any(value in serialized for value in private_paths) or not free_text_is_safe:
         raise ValueError(
             "Canonical Selection Reportに非公開pathまたはContext Cueがあります"
         )
@@ -379,6 +388,26 @@ def _validate_privacy(
             raise ValueError(
                 "Canonical Selection Reportに絶対pathまたはendpointがあります"
             )
+
+
+def _published_free_text(report: dict[str, object]) -> list[str]:
+    """Context Cue由来になり得る公開自由文だけを返す。"""
+    values: list[str] = []
+    for item in (
+        *_mapping_list(report["selected"]),
+        *_mapping_list(report["near_misses"]),
+    ):
+        annotation = _mapping(item["annotation"])
+        values.extend(
+            (
+                str(annotation["summary"]),
+                str(annotation["representative_frame_reason"]),
+            )
+        )
+        spoiler_evidence = _mapping(item["classification"])["spoiler_evidence"]
+        if spoiler_evidence is not None:
+            values.append(str(_mapping(spoiler_evidence)["summary"]))
+    return values
 
 
 def _validate_staging_layout(report: dict[str, object], staging_folder: Path) -> None:

--- a/src/video_selection/services/validate_report_schema_compatibility.py
+++ b/src/video_selection/services/validate_report_schema_compatibility.py
@@ -1,0 +1,26 @@
+"""Canonical Selection Report readerのschema compatibility gate。"""
+
+import re
+from typing import cast
+
+from .build_canonical_selection_report import REPORT_SCHEMA_NAME
+
+SUPPORTED_REPORT_SCHEMA_MAJOR = 1
+_SEMANTIC_VERSION = re.compile(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)")
+
+
+def validate_report_schema_compatibility(report: dict[str, object]) -> None:
+    """対応majorを受理し未知fieldやenumを解釈せず保持可能にする。"""
+    schema_value = report.get("schema")
+    if not isinstance(schema_value, dict):
+        raise ValueError("Canonical Selection Reportにschema objectがありません")
+    schema = cast(dict[object, object], schema_value)
+    name = schema.get("name")
+    version = schema.get("version")
+    match = _SEMANTIC_VERSION.fullmatch(version) if isinstance(version, str) else None
+    if name != REPORT_SCHEMA_NAME or match is None:
+        raise ValueError("Canonical Selection Report schema identityが不正です")
+    if int(match.group(1)) != SUPPORTED_REPORT_SCHEMA_MAJOR:
+        raise ValueError(
+            f"未対応major versionのCanonical Selection Reportです: {version}"
+        )

--- a/tests/video_selection/fakes/canonical_publication_factory.py
+++ b/tests/video_selection/fakes/canonical_publication_factory.py
@@ -1,0 +1,461 @@
+"""Canonical publication test用の実体fixture。"""
+
+from datetime import datetime, timezone
+from fractions import Fraction
+from pathlib import Path
+
+from src.video_selection.models.blog_candidate import BlogCandidate
+from src.video_selection.models.candidate_annotation import CandidateAnnotation
+from src.video_selection.models.candidate_moment import CandidateMoment
+from src.video_selection.models.canonical_publication_request import (
+    CanonicalPublicationRequest,
+)
+from src.video_selection.models.completed_stage import CompletedStage
+from src.video_selection.models.content_reject_reason import ContentRejectReason
+from src.video_selection.models.context_cue import ContextCue
+from src.video_selection.models.context_cue_provenance import ContextCueProvenance
+from src.video_selection.models.context_stage_result import ContextStageResult
+from src.video_selection.models.effective_configuration import EffectiveConfiguration
+from src.video_selection.models.frame_candidate import FrameCandidate
+from src.video_selection.models.frame_candidate_extraction import (
+    FrameCandidateExtraction,
+)
+from src.video_selection.models.frame_candidate_extraction_metrics import (
+    FrameCandidateExtractionMetrics,
+)
+from src.video_selection.models.media_stream import MediaStream
+from src.video_selection.models.neutral_image_analysis import NeutralImageAnalysis
+from src.video_selection.models.neutral_image_metrics import NeutralImageMetrics
+from src.video_selection.models.processing_stage import ProcessingStage
+from src.video_selection.models.rejected_blog_candidate import RejectedBlogCandidate
+from src.video_selection.models.report_provenance import ReportProvenance
+from src.video_selection.models.report_stage_provenance import ReportStageProvenance
+from src.video_selection.models.scene_catalog import SceneCatalog
+from src.video_selection.models.scene_catalog_entry import SceneCatalogEntry
+from src.video_selection.models.selected_blog_image import SelectedBlogImage
+from src.video_selection.models.selection_rejection_reason import (
+    SelectionRejectionReason,
+)
+from src.video_selection.models.selection_score import SelectionScore
+from src.video_selection.models.stage_fingerprint import StageFingerprint
+from src.video_selection.models.timeline_segment import TimelineSegment
+from src.video_selection.models.video_duration import VideoDuration
+from src.video_selection.models.video_scan_metrics import VideoScanMetrics
+from src.video_selection.models.video_scan_result import VideoScanResult
+from src.video_selection.models.video_set_selection_result import (
+    VideoSetSelectionResult,
+)
+from src.video_selection.models.video_source import VideoSource
+from src.video_selection.models.video_stage_result import VideoStageResult
+from src.video_selection.models.video_timeline import VideoTimeline
+from src.video_selection.services.discover_video_set import discover_video_set
+from tests.video_selection.fakes.fake_model_runtime import FakeModelRuntime
+
+
+def build_canonical_publication_request(
+    tmp_path: Path,
+    *,
+    shortfall: bool = True,
+    colliding_digest_prefixes: bool = False,
+) -> CanonicalPublicationRequest:
+    """完全なCanonical Publication Requestを構築する。"""
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    (input_folder / "chapter-01.mkv").write_bytes(b"canonical-video-content")
+    video_set = discover_video_set(input_folder)
+    source = video_set.sources[0]
+    configuration = EffectiveConfiguration(
+        video_input_folder=input_folder,
+        output_folder=tmp_path / "output",
+        image_count=2,
+        spoiler_sensitivity="medium",
+        similarity_threshold=0.72,
+    )
+    cue_id = "cue_" + "c" * 64
+    first_digest = "123456789abc" + "a" * 52 if colliding_digest_prefixes else "a" * 64
+    second_digest = "123456789abc" + "b" * 52 if colliding_digest_prefixes else "b" * 64
+    first = _blog_candidate(
+        source.fingerprint,
+        first_digest,
+        moment_digest="1" * 64,
+        source_pts=15,
+        video_time=Fraction(3, 2),
+        shortlist_rank=1,
+        context_cue_ids=(cue_id,),
+        context_relevance="strong",
+        summary="遺跡の広さとHUDが分かる通常play。",
+    )
+    second = _blog_candidate(
+        source.fingerprint,
+        second_digest,
+        moment_digest="2" * 64,
+        source_pts=30,
+        video_time=Fraction(3),
+        shortlist_rank=2,
+        context_cue_ids=(),
+        context_relevance="none",
+        summary="似た構図の遺跡探索frame。",
+    )
+    selected = (
+        _selected(first, index=1, marginal_utility=0.91),
+        *(() if shortfall else (_selected(second, index=2, marginal_utility=0.82),)),
+    )
+    rejected = (
+        (
+            RejectedBlogCandidate(
+                candidate=second,
+                reason_code=SelectionRejectionReason.SIMILARITY_CEILING,
+                counterfactual_score=_score(0.82),
+                blocked_by_image_id=None,
+                nearest_selected_image_id=first.identifier,
+                similarity=0.985,
+                variant_group_id="variant_" + "2" * 64,
+            ),
+        )
+        if shortfall
+        else ()
+    )
+    selection = VideoSetSelectionResult(
+        selected=selected,
+        rejected=rejected,
+        requested_count=2,
+        blog_image_type_targets={
+            "normal_gameplay": 1,
+            "event": 1,
+            "menu": 0,
+            "title": 0,
+            "other": 0,
+        },
+        blog_image_type_actuals={
+            "normal_gameplay": len(selected),
+            "event": 0,
+            "menu": 0,
+            "title": 0,
+            "other": 0,
+        },
+        final_similarity_ceiling=0.98 if shortfall else 0.72,
+        major_spoiler_limit=None,
+        annotated_candidate_count=2,
+        shortlist_expansion_count=1,
+        all_candidate_moments_exhausted=shortfall,
+    )
+    cue = ContextCue(
+        identifier=cue_id,
+        video_fingerprint=source.fingerprint,
+        source_kind="embedded_subtitle",
+        stream_index=1,
+        start=Fraction(1),
+        end=Fraction(2),
+        timestamp_basis="source_pts",
+        text="公開してはいけない秘密の台詞",
+        language="ja",
+        reliability="usable",
+        provenance=ContextCueProvenance(
+            codec_name="ass",
+            source_pts=10,
+            source_time_base=Fraction(1, 10),
+            stream_language="ja",
+            is_default=True,
+            is_forced=False,
+            language_source="stream_metadata",
+        ),
+    )
+    video_stage = _video_stage_result(source, first, second, cue)
+    models = FakeModelRuntime("canonical-publication").resolve_models(configuration)
+    return CanonicalPublicationRequest(
+        video_set=video_set,
+        video_stage_results=(video_stage,),
+        scene_catalog=_scene_catalog(),
+        selection_result=selection,
+        resolved_models=models,
+        configuration=configuration,
+        run_id="run_20260716T120000Z_fixture",
+        started_at=datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc),
+        completed_at=datetime(2026, 7, 16, 12, 1, tzinfo=timezone.utc),
+        provenance=_provenance(),
+    )
+
+
+def _video_stage_result(
+    source: VideoSource,
+    first: BlogCandidate,
+    second: BlogCandidate,
+    cue: ContextCue,
+) -> VideoStageResult:
+    typed_source = first.annotation.candidate.video_fingerprint
+    if (
+        typed_source is None
+        or typed_source != second.annotation.candidate.video_fingerprint
+    ):
+        raise AssertionError
+    timeline = VideoTimeline(
+        origin_pts=0,
+        time_base=Fraction(1, 10),
+        duration=VideoDuration(Fraction(10)),
+        segments=(
+            TimelineSegment(
+                identifier="seg_" + "9" * 64,
+                start=Fraction(0),
+                end=Fraction(10),
+            ),
+        ),
+    )
+    primary_stream = MediaStream(
+        index=0,
+        kind="video",
+        codec_name="ffv1",
+        time_base=Fraction(1, 10),
+        start_pts=0,
+        duration_ts=100,
+        width=64,
+        height=48,
+        sample_rate=None,
+        channels=None,
+        language=None,
+        is_default=True,
+        is_forced=False,
+    )
+    scan = VideoScanResult(
+        primary_stream=primary_stream,
+        timeline=timeline,
+        heartbeats=(),
+        scene_signals=(),
+        metrics=VideoScanMetrics(
+            input_duration=Fraction(10),
+            wall_seconds=1.0,
+            cpu_seconds=0.5,
+            input_seconds_per_wall_second=10.0,
+            decode_backend="cpu",
+            decode_pass_count=1,
+            heartbeat_count=0,
+            heartbeat_bytes=0,
+            heartbeat_max_gap_seconds=0.0,
+            heartbeat_p95_gap_seconds=0.0,
+            scene_signal_count=0,
+            timeline_segment_count=1,
+        ),
+    )
+    candidates = (first.annotation.candidate, second.annotation.candidate)
+    moments = tuple(
+        CandidateMoment(
+            identifier=item.annotation.candidate_moment_id or "",
+            source_pts=item.annotation.candidate.source_pts or 0,
+            anchor_time=item.annotation.candidate.video_time or Fraction(0),
+            timeline_segment_id=timeline.segments[0].identifier,
+            evidence=("heartbeat",),
+            proxy_quality_score=item.quality_score,
+            frame_candidate_ids=(item.identifier,),
+        )
+        for item in (first, second)
+    )
+    breakdown = ContentRejectReason.empty_breakdown()
+    extraction = FrameCandidateExtraction(
+        moments=moments,
+        candidates=candidates,
+        native_frame_count=2,
+        reject_breakdown=breakdown,
+        deduplicated_frame_count=0,
+        zero_frame_moment_count=0,
+    )
+    metrics = FrameCandidateExtractionMetrics(
+        wall_seconds=0.5,
+        cpu_seconds=0.25,
+        density_cap=2,
+        actual_moment_count=2,
+        native_frame_count=2,
+        reject_breakdown=breakdown,
+        deduplicated_frame_count=0,
+        zero_frame_moment_count=0,
+        frame_candidate_count=2,
+        frame_candidate_bytes=sum(len(item.image_bytes) for item in candidates),
+    )
+    return VideoStageResult(
+        source=source,
+        scan=scan,
+        extraction=extraction,
+        extraction_metrics=metrics,
+        context=ContextStageResult(
+            cues=(cue,),
+            outcomes=(),
+            completed_stage=None,
+        ),
+        completed_stages=(
+            CompletedStage(ProcessingStage.SCAN_VIDEO, StageFingerprint("3" * 64)),
+            CompletedStage(
+                ProcessingStage.EXTRACT_FRAME_CANDIDATES,
+                StageFingerprint("4" * 64),
+            ),
+            CompletedStage(
+                ProcessingStage.COLLECT_CONTEXT,
+                StageFingerprint("5" * 64),
+            ),
+        ),
+    )
+
+
+def _blog_candidate(
+    video_fingerprint: str,
+    frame_digest: str,
+    *,
+    moment_digest: str,
+    source_pts: int,
+    video_time: Fraction,
+    shortlist_rank: int,
+    context_cue_ids: tuple[str, ...],
+    context_relevance: str,
+    summary: str,
+) -> BlogCandidate:
+    frame = FrameCandidate(
+        identifier="frm_" + frame_digest,
+        image_bytes=b"proxy-image",
+        video_fingerprint=video_fingerprint,
+        stream_index=0,
+        source_pts=source_pts,
+        origin_pts=0,
+        time_base=Fraction(1, 10),
+        video_time=video_time,
+        analysis=NeutralImageAnalysis(
+            source_pts=source_pts,
+            metrics=_neutral_metrics(),
+            quality_score=0.9,
+            visual_feature=(1.0, shortlist_rank / 10),
+            grayscale_signature=b"signature",
+            reject_reason=None,
+        ),
+    )
+    annotation = CandidateAnnotation(
+        candidate=frame,
+        candidate_moment_id="mom_" + moment_digest,
+        summary=summary,
+        scene_slug="test-scene",
+        blog_image_type="normal_gameplay",
+        explanation_value="high",
+        frame_choice_reason="構図と情報量が最も明瞭なframe。",
+        screen_text_kind="hud",
+        context_relevance=context_relevance,  # type: ignore[arg-type]
+        supporting_context_cue_ids=context_cue_ids,
+        spoiler_risk="none",
+    )
+    return BlogCandidate(
+        annotation=annotation,
+        scene_selection_role="recurring_gameplay",
+        video_order=0,
+        video_set_progress=video_time / 10,
+        shortlist_rank=shortlist_rank,
+    )
+
+
+def _selected(
+    candidate: BlogCandidate,
+    *,
+    index: int,
+    marginal_utility: float,
+) -> SelectedBlogImage:
+    return SelectedBlogImage(
+        candidate=candidate,
+        selection_index=index,
+        score=_score(marginal_utility),
+        reason_codes=(
+            "high_quality",
+            "high_explanation_value",
+            "normal_gameplay_coverage",
+        ),
+        variant_group_id="variant_" + str(index) * 64,
+        tie_break_applied=False,
+    )
+
+
+def _score(marginal_utility: float) -> SelectionScore:
+    return SelectionScore(
+        base_utility=marginal_utility - 0.1,
+        spoiler_penalty=0.0,
+        coverage_bonus=0.1,
+        temporal_diversity_penalty=0.0,
+        marginal_utility=marginal_utility,
+        similarity_pass=0.72,
+        nearest_selected_similarity=None,
+    )
+
+
+def _scene_catalog() -> SceneCatalog:
+    return SceneCatalog(
+        (
+            SceneCatalogEntry(
+                slug="test-scene",
+                display_name="探索",
+                description="通常の探索画面",
+                selection_role="recurring_gameplay",
+            ),
+            SceneCatalogEntry(
+                slug="event",
+                display_name="イベント",
+                description="物語上のイベント画面",
+                selection_role="cinematic",
+            ),
+            SceneCatalogEntry(
+                slug="other",
+                display_name="その他",
+                description="他のsceneに分類されない画面",
+                selection_role="ordinary",
+            ),
+        )
+    )
+
+
+def _provenance() -> ReportProvenance:
+    stage = ReportStageProvenance(
+        name="final_selection",
+        fingerprint="stg_" + "6" * 64,
+        upstream_fingerprints=(),
+        cache_hits=0,
+        cache_misses=1,
+        recomputed_items=1,
+        attempt_count=1,
+        validation_failures=0,
+        effective_settings={"requested_image_count": 2},
+        tool_refs=(),
+        model_refs=("candidate_annotation",),
+        contract_refs=("video_set_selection_policy",),
+        duration_ms=80,
+    )
+    return ReportProvenance(
+        runtime={
+            "os": "linux",
+            "environment": "wsl2",
+            "python": "3.13",
+            "compute_device": "cuda",
+            "gpu_model": "NVIDIA GeForce RTX 5090",
+        },
+        tools={
+            "ffmpeg": "6.1.1",
+            "ffprobe": "6.1.1",
+            "ollama": "0.31.2",
+            "faster_whisper": "1.2.1",
+            "ctranslate2": "4.8.1",
+        },
+        contracts={
+            "video_set_selection_policy": "video-set-selection-v1",
+        },
+        stages=(stage,),
+    )
+
+
+def _neutral_metrics() -> NeutralImageMetrics:
+    return NeutralImageMetrics(
+        blur_score=100.0,
+        brightness=100.0,
+        contrast=50.0,
+        edge_density=0.2,
+        color_richness=0.5,
+        ui_density=0.2,
+        action_intensity=0.4,
+        visual_balance=0.8,
+        dramatic_score=0.3,
+        luminance_entropy=1.0,
+        luminance_range=100.0,
+        near_black_ratio=0.0,
+        near_white_ratio=0.0,
+        dominant_tone_ratio=0.2,
+        information_score=0.8,
+        visibility_score=0.9,
+    )

--- a/tests/video_selection/fakes/canonical_publication_factory.py
+++ b/tests/video_selection/fakes/canonical_publication_factory.py
@@ -152,8 +152,8 @@ def build_canonical_publication_request(
         reliability="usable",
         provenance=ContextCueProvenance(
             codec_name="ass",
-            source_pts=10,
-            source_time_base=Fraction(1, 10),
+            source_pts=1000,
+            source_time_base=Fraction(1, 1000),
             stream_language="ja",
             is_default=True,
             is_forced=False,

--- a/tests/video_selection/fakes/fake_video_stage_media_runtime.py
+++ b/tests/video_selection/fakes/fake_video_stage_media_runtime.py
@@ -57,6 +57,7 @@ class FakeVideoStageMediaRuntime:
         self._candidate_proxy_write_count = 0
         self.subtitle_calls: list[tuple[Path, int]] = []
         self.audio_calls: list[tuple[Path, int, int, int]] = []
+        self.extracted_frame_calls: list[tuple[Path, int, int, int]] = []
 
     def preflight(self) -> MediaRuntimeIdentity:
         """固定runtime identityを返す。"""
@@ -188,6 +189,19 @@ class FakeVideoStageMediaRuntime:
                     msg = "次のrefinement groupより前にproxyが書かれていません"
                     raise AssertionError(msg)
                 yield self._decoded_frame(stream_index, pts)
+
+    def extract_video_frame(
+        self,
+        media_path: Path,
+        stream_index: int,
+        pts: int,
+        max_dimension: int,
+    ) -> DecodedVideoFrame:
+        """指定PTSの元解像度test frameを返す。"""
+        self.extracted_frame_calls.append(
+            (media_path, stream_index, pts, max_dimension)
+        )
+        return self._decoded_frame(stream_index, pts)
 
     def write_mjpeg_proxy(
         self,

--- a/tests/video_selection/fakes/fake_video_stage_media_runtime.py
+++ b/tests/video_selection/fakes/fake_video_stage_media_runtime.py
@@ -58,6 +58,7 @@ class FakeVideoStageMediaRuntime:
         self.subtitle_calls: list[tuple[Path, int]] = []
         self.audio_calls: list[tuple[Path, int, int, int]] = []
         self.extracted_frame_calls: list[tuple[Path, int, int, int]] = []
+        self.extracted_original_frame_calls: list[tuple[Path, int, int]] = []
 
     def preflight(self) -> MediaRuntimeIdentity:
         """固定runtime identityを返す。"""
@@ -201,6 +202,16 @@ class FakeVideoStageMediaRuntime:
         self.extracted_frame_calls.append(
             (media_path, stream_index, pts, max_dimension)
         )
+        return self._decoded_frame(stream_index, pts)
+
+    def extract_original_video_frame(
+        self,
+        media_path: Path,
+        stream_index: int,
+        pts: int,
+    ) -> DecodedVideoFrame:
+        """指定PTSの元寸法test frameを返す。"""
+        self.extracted_original_frame_calls.append((media_path, stream_index, pts))
         return self._decoded_frame(stream_index, pts)
 
     def write_mjpeg_proxy(

--- a/tests/video_selection/fixtures/canonical_publication/report.md
+++ b/tests/video_selection/fixtures/canonical_publication/report.md
@@ -1,0 +1,91 @@
+# 画像選定レポート
+
+`run_20260716T120000Z_fixture` · 2026-07-16T12:00:00Z
+
+> [!WARNING]
+> 要求2枚に対して1枚を選択しました。
+
+## Summary
+
+| Requested | Selected | Videos | Duration | Candidate Moments |
+|---:|---:|---:|---:|---:|
+| 2 | 1 | 1 | 00:00:10.000 | 2 |
+
+| Blog Image Type | Target | Actual |
+|---|---:|---:|
+| normal_gameplay | 1 | 1 |
+| event | 1 | 0 |
+| menu | 0 | 0 |
+| title | 0 | 0 |
+| other | 0 | 0 |
+
+## Selected images
+
+### 01 — 遺跡の広さとHUDが分かる通常play。
+
+[![01 — 探索](images/0001_test-scene_aaaaaaaaaaaa.webp)](images/0001_test-scene_aaaaaaaaaaaa.webp)
+
+`frm_aaaaaaaaaaaa…` · `images/0001_test-scene_aaaaaaaaaaaa.webp`
+
+- **画像の説明（model）**: 遺跡の広さとHUDが分かる通常play。
+- **Representative Frameの理由（model）**: 構図と情報量が最も明瞭なframe。
+- **採用理由（selector）**: 高い画質、高い説明価値、normal_gameplay coverageにより選択された。
+- **Reason codes**: `high_quality, high_explanation_value, normal_gameplay_coverage`
+- **Source**: Video 1 `chapter-01.mkv` (`vid_9b84276662ce`) · `00:00:01.500`
+- **Classification**: `test-scene` · `recurring_gameplay` · `normal_gameplay` · spoiler `none`
+- **Context**: `strong` · `cue_cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc`
+- **Utility**: 0.910000
+
+## Near misses
+
+| Candidate | Counterfactual utility | Not selected because |
+|---|---:|---|
+| `frm_bbbbbbbb…` 似た構図の遺跡探索frame。 | 0.820000 | `similarity_ceiling (0.985)` |
+
+## Reproduction appendix
+
+### Selection funnel
+
+| Stage | Input | Kept |
+|---|---:|---:|
+| Candidate Moment discovery | 2 | 2 |
+| Frame refinement | 2 | 2 |
+| Candidate Annotation | 2 | 2 |
+| Final selection | 2 | 1 |
+
+Requested 2 / selected 1。 all_candidate_moments_exhausted=`true`。
+
+### Decision ledger
+
+| Frame ID | Decision | Type | Base | Coverage | Spoiler | Temporal | Marginal | Reasons |
+|---|---|---|---:|---:|---:|---:|---:|---|
+| `frm_aaaaaaaaaaaa…` | selected 01 | normal_gameplay | 0.810000 | 0.100000 | 0.000000 | 0.000000 | **0.910000** | `high_quality, high_explanation_value, normal_gameplay_coverage` |
+| `frm_bbbbbbbbbbbb…` | `similarity_ceiling` | normal_gameplay | 0.720000 | 0.100000 | 0.000000 | 0.000000 | 0.820000 | — |
+
+### Stage provenance
+
+| Stage | Fingerprint | Cache | Duration | Contracts |
+|---|---|---|---:|---|
+| `final_selection` | `stg_66666666…` | 0 hit / 1 miss | 0.080s | `video_set_selection_policy` |
+
+### Model and tool provenance
+
+- Report schema: `game-screen-pick/report@1.0.0`
+- candidate_annotation: `qwen3-vl:8b-instruct` @ `ollama:sha256:81bf…` (not_requested)
+- scene_catalog: `qwen3-vl:8b-instruct` @ `ollama:sha256:81bf…` (not_requested)
+- speech_to_text: `dropbox-dash/faster-whisper-large-v3-turbo` @ `hf:b866f3b8500eb44…` (not_requested)
+- ffmpeg: `6.1.1`
+- ffprobe: `6.1.1`
+- ollama: `0.31.2`
+- faster_whisper: `1.2.1`
+- ctranslate2: `4.8.1`
+
+### Deliberately omitted
+
+- absolute input/cache/output paths
+- environment variables and credentials
+- prompt bodies, model reasoning traces, raw model responses, and stack traces
+- generated screen-text quotations
+- raw Context Cue text（processing cacheだけに保持）
+
+完全なscore内訳、PTS/time base、Stage provenanceは[`report.json`](report.json)を参照する。

--- a/tests/video_selection/fixtures/canonical_publication/report.normalized.json
+++ b/tests/video_selection/fixtures/canonical_publication/report.normalized.json
@@ -42,9 +42,9 @@
           "numerator": 2
         },
         "origin_pts": 0,
-        "source_pts": 20,
+        "source_pts": 2000,
         "time_base": {
-          "denominator": 10,
+          "denominator": 1000,
           "numerator": 1
         }
       },
@@ -64,9 +64,9 @@
           "numerator": 1
         },
         "origin_pts": 0,
-        "source_pts": 10,
+        "source_pts": 1000,
         "time_base": {
-          "denominator": 10,
+          "denominator": 1000,
           "numerator": 1
         }
       },

--- a/tests/video_selection/fixtures/canonical_publication/report.normalized.json
+++ b/tests/video_selection/fixtures/canonical_publication/report.normalized.json
@@ -1,0 +1,412 @@
+{
+  "artifacts": {
+    "image_contract": {
+      "color_space": "srgb",
+      "configurable": false,
+      "encoding": "lossy",
+      "filename_pattern": "<selection-index-min-width-4>_<scene-slug>_<frame-digest-prefix-12-or-full>.webp",
+      "format": "webp",
+      "frame_candidate_id_algorithm": "video-fingerprint-video-time-sha256-v1",
+      "frame_candidate_id_format": "frm_<64-lowercase-hex>",
+      "metadata": "stripped",
+      "quality": 95,
+      "size_policy": "source_dimensions",
+      "status": "fixed_for_v1"
+    },
+    "image_directory": "images",
+    "projection_contract": {
+      "alt_text": "selection_index_and_scene_display_name",
+      "cache_or_model_reread": false,
+      "canonical_machine_report": "report.json",
+      "cross_artifact_mismatch": "fatal",
+      "json_key_order_significant": false,
+      "markdown_source": "validated_canonical_report_object",
+      "selected_image_rendering": "clickable_inline_original",
+      "thumbnail_artifacts": false
+    },
+    "publication_contract": {
+      "mode": "atomic_directory_rename",
+      "non_atomic_fallback": false,
+      "staging": "hidden_sibling_same_filesystem",
+      "validated_before_publish": true
+    },
+    "report_json": "report.json",
+    "report_markdown": "report.md"
+  },
+  "context_cues": [
+    {
+      "end": {
+        "display": "00:00:02.000",
+        "offset_seconds": {
+          "denominator": 1,
+          "numerator": 2
+        },
+        "origin_pts": 0,
+        "source_pts": 20,
+        "time_base": {
+          "denominator": 10,
+          "numerator": 1
+        }
+      },
+      "id": "cue_cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "language": {
+        "origin": "stream_metadata",
+        "value": "ja"
+      },
+      "reliability": {
+        "policy": "usable"
+      },
+      "source_kind": "embedded_subtitle",
+      "start": {
+        "display": "00:00:01.000",
+        "offset_seconds": {
+          "denominator": 1,
+          "numerator": 1
+        },
+        "origin_pts": 0,
+        "source_pts": 10,
+        "time_base": {
+          "denominator": 10,
+          "numerator": 1
+        }
+      },
+      "stream_index": 1,
+      "text_included": false,
+      "timestamp_basis": "source_pts",
+      "video_id": "vid_9b84276662ce"
+    }
+  ],
+  "near_miss_publication": {
+    "coverage": "at_least_one_per_rejection_reason",
+    "fill_order": "counterfactual_marginal_utility_desc_then_selection_tie_break",
+    "json_limit_for_this_run": 1,
+    "json_limit_formula": "min(total_rejected, 100, max(20, requested_image_count * 2))",
+    "markdown_limit": 10
+  },
+  "near_misses": [
+    {
+      "annotation": {
+        "context_cue_relevance": "none",
+        "representative_frame_reason": "構図と情報量が最も明瞭なframe。",
+        "summary": "似た構図の遺跡探索frame。",
+        "supporting_context_cue_ids": []
+      },
+      "classification": {
+        "blog_image_type": "normal_gameplay",
+        "explanation_value": "high",
+        "scene_display_name": "探索",
+        "scene_selection_role": "recurring_gameplay",
+        "scene_slug": "test-scene",
+        "screen_text_kind": "hud",
+        "spoiler_evidence": null,
+        "spoiler_risk": "none"
+      },
+      "counterfactual_selection": {
+        "base_utility": 0.72,
+        "coverage_bonus": 0.1,
+        "marginal_utility": 0.82,
+        "nearest_selected_similarity": null,
+        "similarity_pass": 0.72,
+        "spoiler_penalty": 0.0,
+        "temporal_diversity_penalty": 0.0
+      },
+      "image_id": "frm_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "rejection": {
+        "nearest_selected_image_id": "frm_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "reason_code": "similarity_ceiling",
+        "similarity": 0.985
+      },
+      "source": {
+        "candidate_moment_id": "mom_2222222222222222222222222222222222222222222222222222222222222222",
+        "timeline_segment_id": "seg_9999999999999999999999999999999999999999999999999999999999999999",
+        "video_id": "vid_9b84276662ce",
+        "video_set_progress": 0.3,
+        "video_time": {
+          "display": "00:00:03.000",
+          "offset_seconds": {
+            "denominator": 1,
+            "numerator": 3
+          },
+          "origin_pts": 0,
+          "source_pts": 30,
+          "time_base": {
+            "denominator": 10,
+            "numerator": 1
+          }
+        }
+      },
+      "variant_group_id": "variant_2222222222222222222222222222222222222222222222222222222222222222"
+    }
+  ],
+  "privacy": {
+    "absolute_paths": "omitted",
+    "credentials": "omitted",
+    "environment_variables": "omitted",
+    "generated_screen_text_quotations": "omitted",
+    "model_reasoning_trace": "omitted",
+    "prompt_bodies": "omitted",
+    "raw_context_cue_text": "processing_cache_only",
+    "raw_model_responses": "omitted",
+    "relative_source_paths": "included",
+    "stack_traces": "omitted"
+  },
+  "provenance": {
+    "contracts": {
+      "report_schema": "1.0.0",
+      "video_set_selection_policy": "video-set-selection-v1"
+    },
+    "models": {
+      "candidate_annotation": {
+        "canonical_name": "qwen3-vl:8b-instruct",
+        "configured_name": "qwen3-vl:8b-instruct",
+        "execution_identity": "ollama:sha256:81bf08a74b5dfcaa88b7b62cdf0b1505d798fcdfdee9edd0875b9b3282382b63",
+        "local_identity_before_update": "ollama:sha256:81bf08a74b5dfcaa88b7b62cdf0b1505d798fcdfdee9edd0875b9b3282382b63",
+        "runtime_identity": "ollama:fake-1",
+        "store": "ollama",
+        "update_status": "not_requested"
+      },
+      "scene_catalog": {
+        "canonical_name": "qwen3-vl:8b-instruct",
+        "configured_name": "qwen3-vl:8b-instruct",
+        "execution_identity": "ollama:sha256:81bf08a74b5dfcaa88b7b62cdf0b1505d798fcdfdee9edd0875b9b3282382b63",
+        "local_identity_before_update": "ollama:sha256:81bf08a74b5dfcaa88b7b62cdf0b1505d798fcdfdee9edd0875b9b3282382b63",
+        "runtime_identity": "ollama:fake-1",
+        "store": "ollama",
+        "update_status": "not_requested"
+      },
+      "speech_to_text": {
+        "canonical_name": "dropbox-dash/faster-whisper-large-v3-turbo",
+        "configured_name": "dropbox-dash/faster-whisper-large-v3-turbo",
+        "execution_identity": "hf:b866f3b8500eb446ba51f478bcf02f490da29c3e",
+        "local_identity_before_update": "hf:b866f3b8500eb446ba51f478bcf02f490da29c3e",
+        "runtime_identity": "huggingface-hub:fake-1",
+        "store": "hugging_face",
+        "update_status": "not_requested"
+      }
+    },
+    "runtime": {
+      "compute_device": "cuda",
+      "environment": "wsl2",
+      "gpu_model": "NVIDIA GeForce RTX 5090",
+      "os": "linux",
+      "python": "3.13"
+    },
+    "selection": {
+      "blog_image_type_target": {
+        "event": 0.25,
+        "menu": 0.05,
+        "normal_gameplay": 0.7
+      },
+      "policy_version": "video-set-selection-v1",
+      "similarity_base": 0.72,
+      "similarity_final": 0.98,
+      "spoiler_sensitivity": "medium"
+    },
+    "stages": [
+      {
+        "attempt_count": 1,
+        "cache_hits": 0,
+        "cache_misses": 1,
+        "contract_refs": [
+          "video_set_selection_policy"
+        ],
+        "duration_ms": 80,
+        "effective_settings": {
+          "requested_image_count": 2
+        },
+        "fingerprint": "stg_6666666666666666666666666666666666666666666666666666666666666666",
+        "model_refs": [
+          "candidate_annotation"
+        ],
+        "name": "final_selection",
+        "recomputed_items": 1,
+        "status": "completed",
+        "tool_refs": [],
+        "upstream_fingerprints": [],
+        "validation_failures": 0
+      }
+    ],
+    "tools": {
+      "ctranslate2": "4.8.1",
+      "faster_whisper": "1.2.1",
+      "ffmpeg": "6.1.1",
+      "ffprobe": "6.1.1",
+      "ollama": "0.31.2"
+    }
+  },
+  "rejection_summary": {
+    "by_reason": {
+      "similarity_ceiling": 1
+    },
+    "total": 1
+  },
+  "run": {
+    "completed_at": "2026-07-16T12:01:00Z",
+    "id": "run_20260716T120000Z_fixture",
+    "requested_image_count": 2,
+    "selected_image_count": 1,
+    "started_at": "2026-07-16T12:00:00Z",
+    "status": "completed_with_warnings",
+    "warnings": [
+      {
+        "code": "selection_shortfall",
+        "details": {
+          "similarity_ceiling": 1
+        },
+        "message": "要求2枚に対して1枚を選択しました。"
+      }
+    ]
+  },
+  "schema": {
+    "name": "game-screen-pick/report",
+    "version": "1.0.0"
+  },
+  "selected": [
+    {
+      "annotation": {
+        "context_cue_relevance": "strong",
+        "representative_frame_reason": "構図と情報量が最も明瞭なframe。",
+        "summary": "遺跡の広さとHUDが分かる通常play。",
+        "supporting_context_cue_ids": [
+          "cue_cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        ]
+      },
+      "classification": {
+        "blog_image_type": "normal_gameplay",
+        "explanation_value": "high",
+        "scene_display_name": "探索",
+        "scene_selection_role": "recurring_gameplay",
+        "scene_slug": "test-scene",
+        "screen_text_kind": "hud",
+        "spoiler_evidence": null,
+        "spoiler_risk": "none"
+      },
+      "image_id": "frm_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "output": {
+        "bytes": "<bytes>",
+        "height": 48,
+        "relative_path": "images/0001_test-scene_aaaaaaaaaaaa.webp",
+        "sha256": "<sha256>",
+        "width": 64
+      },
+      "selection": {
+        "base_utility": 0.81,
+        "coverage_bonus": 0.1,
+        "decision_explanation": {
+          "renderer": "selection-explanation-ja-v1",
+          "text": "高い画質、高い説明価値、normal_gameplay coverageにより選択された。"
+        },
+        "marginal_utility": 0.91,
+        "nearest_selected_similarity": null,
+        "reason_codes": [
+          "high_quality",
+          "high_explanation_value",
+          "normal_gameplay_coverage"
+        ],
+        "similarity_pass": 0.72,
+        "spoiler_penalty": 0.0,
+        "temporal_diversity_penalty": 0.0,
+        "tie_break_applied": false,
+        "variant_group_id": "variant_1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "selection_index": 1,
+      "source": {
+        "candidate_moment_id": "mom_1111111111111111111111111111111111111111111111111111111111111111",
+        "timeline_segment_id": "seg_9999999999999999999999999999999999999999999999999999999999999999",
+        "video_id": "vid_9b84276662ce",
+        "video_set_progress": 0.15,
+        "video_time": {
+          "display": "00:00:01.500",
+          "offset_seconds": {
+            "denominator": 2,
+            "numerator": 3
+          },
+          "origin_pts": 0,
+          "source_pts": 15,
+          "time_base": {
+            "denominator": 10,
+            "numerator": 1
+          }
+        }
+      }
+    }
+  ],
+  "selection_summary": {
+    "blog_image_type": {
+      "event": {
+        "actual": 0,
+        "target": 1
+      },
+      "menu": {
+        "actual": 0,
+        "target": 0
+      },
+      "normal_gameplay": {
+        "actual": 1,
+        "target": 1
+      },
+      "other": {
+        "actual": 0,
+        "target": 0
+      },
+      "title": {
+        "actual": 0,
+        "target": 0
+      }
+    },
+    "candidate_annotation_failures": 0,
+    "candidate_annotations": 2,
+    "candidate_moments": 2,
+    "final_similarity_ceiling": 0.98,
+    "moments_without_valid_frame": 0,
+    "not_selected": 1,
+    "selected": 1,
+    "shortfall": {
+      "all_candidate_moments_exhausted": true,
+      "requested": 2,
+      "selected": 1
+    },
+    "shortlist_expansion_count": 1
+  },
+  "video_set": {
+    "duration": {
+      "display": "00:00:10.000",
+      "exact_seconds": "10"
+    },
+    "fingerprint_algorithm": "ordered-video-sha256-v1",
+    "id": "vset_50863fa66e43",
+    "source_path_policy": {
+      "absolute_paths": "omitted",
+      "base": "video_input_folder",
+      "parent_segments": "forbidden",
+      "separator": "/"
+    },
+    "sources": [
+      {
+        "duration": {
+          "display": "00:00:10.000",
+          "exact_seconds": "10",
+          "origin_pts": 0,
+          "source_pts": 100,
+          "time_base": {
+            "denominator": 10,
+            "numerator": 1
+          }
+        },
+        "fingerprint": {
+          "algorithm": "sha256-whole-file",
+          "value": "9b84276662cea119c50238c7254b2196c22a4802c35e3e6f7c0800208b919c15"
+        },
+        "id": "vid_9b84276662ce",
+        "order": 1,
+        "relative_path": "chapter-01.mkv"
+      }
+    ],
+    "time_contract": {
+      "authoritative_value": "offset_seconds_rational",
+      "display_format": "unbounded_hours_HH:MM:SS.mmm",
+      "display_rounding": "half_up",
+      "frame_index": "omitted"
+    }
+  }
+}

--- a/tests/video_selection/models/test_canonical_publication_request.py
+++ b/tests/video_selection/models/test_canonical_publication_request.py
@@ -1,0 +1,73 @@
+"""Canonical Publication Request modelのtest。"""
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from src.video_selection.models.canonical_publication_request import (
+    CanonicalPublicationRequest,
+)
+from tests.video_selection.fakes.canonical_publication_factory import (
+    build_canonical_publication_request,
+)
+
+
+def test_complete_domain_graph_is_accepted(tmp_path: Path) -> None:
+    """Video Set、Stage、selection、Catalog、Cueが整合すると受理されること。
+
+    Arrange:
+        - 完全なcanonical publication domain graphが用意される
+    Act:
+        - Canonical Publication Requestが構築される
+    Assert:
+        - run IDとVideo Set selectionが保持されること
+    """
+    # Arrange / Act
+    request = build_canonical_publication_request(tmp_path)
+
+    # Assert
+    assert isinstance(request, CanonicalPublicationRequest)
+    assert request.run_id == "run_20260716T120000Z_fixture"
+    assert request.selection_result.shortfall is True
+
+
+def test_requested_count_mismatch_is_rejected(tmp_path: Path) -> None:
+    """Effective Configurationとselectionの要求枚数不一致が拒否されること。
+
+    Arrange:
+        - 正常requestと異なるimage_countのconfigurationが用意される
+    Act:
+        - Canonical Publication Requestが再構築される
+    Assert:
+        - runとVideo Setの整合違反として拒否されること
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+    configuration = replace(request.configuration, image_count=3)
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="runまたはVideo Set"):
+        replace(request, configuration=configuration)
+
+
+def test_context_cue_from_another_video_source_is_rejected(tmp_path: Path) -> None:
+    """Video Stageと異なるVideo Sourceを指すContext Cueが拒否されること。
+
+    Arrange:
+        - 正常requestのContext Cueだけが別Video Fingerprintへ変更される
+    Act:
+        - Canonical Publication Requestが再構築される
+    Assert:
+        - Context Cue graphの不整合として拒否されること
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+    stage = request.video_stage_results[0]
+    cue = replace(stage.context.cues[0], video_fingerprint="f" * 64)
+    context = replace(stage.context, cues=(cue,))
+    changed_stage = replace(stage, context=context)
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="Context Cueが不正"):
+        replace(request, video_stage_results=(changed_stage,))

--- a/tests/video_selection/models/test_report_provenance.py
+++ b/tests/video_selection/models/test_report_provenance.py
@@ -1,0 +1,69 @@
+"""Report Provenance modelのtest。"""
+
+import pytest
+
+from src.video_selection.models.report_provenance import ReportProvenance
+from src.video_selection.models.report_stage_provenance import ReportStageProvenance
+
+
+def _stage(**overrides: object) -> ReportStageProvenance:
+    values: dict[str, object] = {
+        "name": "final_selection",
+        "fingerprint": "stg_" + "1" * 64,
+        "upstream_fingerprints": (),
+        "cache_hits": 0,
+        "cache_misses": 1,
+        "recomputed_items": 1,
+        "attempt_count": 1,
+        "validation_failures": 0,
+        "effective_settings": {},
+        "tool_refs": ("ffmpeg",),
+        "model_refs": ("candidate_annotation",),
+        "contract_refs": ("selection_policy",),
+        "duration_ms": 12,
+    }
+    values.update(overrides)
+    return ReportStageProvenance(**values)  # type: ignore[arg-type]
+
+
+def test_registry_references_are_validated_as_one_provenance_graph() -> None:
+    """解決可能なtool、model、contract参照が受理されること。
+
+    Arrange:
+        - runtime、tool、contract registryと一つのStageが用意される
+    Act:
+        - Report Provenanceが構築される
+    Assert:
+        - Stage graphとregistry値が保持されること
+    """
+    # Arrange / Act
+    provenance = ReportProvenance(
+        runtime={"os": "linux"},
+        tools={"ffmpeg": "6.1.1"},
+        contracts={"selection_policy": "v1"},
+        stages=(_stage(),),
+    )
+
+    # Assert
+    assert provenance.stages[0].name == "final_selection"
+    assert provenance.tools == {"ffmpeg": "6.1.1"}
+
+
+def test_unresolved_tool_reference_is_rejected() -> None:
+    """Stageから未登録toolへの参照が拒否されること。
+
+    Arrange:
+        - registryに存在しないtoolを参照するStageが用意される
+    Act:
+        - Report Provenanceが構築される
+    Assert:
+        - 解決不能なregistry参照として拒否されること
+    """
+    # Arrange / Act / Assert
+    with pytest.raises(ValueError, match="registry参照"):
+        ReportProvenance(
+            runtime={"os": "linux"},
+            tools={"ffprobe": "6.1.1"},
+            contracts={"selection_policy": "v1"},
+            stages=(_stage(),),
+        )

--- a/tests/video_selection/models/test_report_stage_provenance.py
+++ b/tests/video_selection/models/test_report_stage_provenance.py
@@ -1,0 +1,59 @@
+"""Report Stage Provenance modelのtest。"""
+
+import pytest
+
+from src.video_selection.models.report_stage_provenance import ReportStageProvenance
+
+
+def _stage(**overrides: object) -> ReportStageProvenance:
+    values: dict[str, object] = {
+        "name": "final_selection",
+        "fingerprint": "stg_" + "1" * 64,
+        "upstream_fingerprints": (),
+        "cache_hits": 0,
+        "cache_misses": 1,
+        "recomputed_items": 1,
+        "attempt_count": 1,
+        "validation_failures": 0,
+        "effective_settings": {"requested_image_count": 10},
+        "tool_refs": (),
+        "model_refs": ("candidate_annotation",),
+        "contract_refs": ("selection_policy",),
+        "duration_ms": 12,
+    }
+    values.update(overrides)
+    return ReportStageProvenance(**values)  # type: ignore[arg-type]
+
+
+def test_privacy_safe_stage_diagnostics_are_accepted() -> None:
+    """再現に必要な有限値とregistry参照が保持されること。
+
+    Arrange:
+        - 完全fingerprintとprivacy-safeなStage診断が用意される
+    Act:
+        - Report Stage Provenanceが構築される
+    Assert:
+        - 設定とtoken件数が変更されず保持されること
+    """
+    # Arrange / Act
+    stage = _stage(prompt_eval_tokens=42, eval_tokens=7)
+
+    # Assert
+    assert stage.effective_settings == {"requested_image_count": 10}
+    assert stage.prompt_eval_tokens == 42
+    assert stage.eval_tokens == 7
+
+
+def test_absolute_path_in_effective_settings_is_rejected() -> None:
+    """Stage effective settingsの絶対pathが公開前に拒否されること。
+
+    Arrange:
+        - absolute cache pathを含むStage設定が用意される
+    Act:
+        - Report Stage Provenanceが構築される
+    Assert:
+        - 非公開pathを含む設定として拒否されること
+    """
+    # Arrange / Act / Assert
+    with pytest.raises(ValueError, match="絶対path"):
+        _stage(effective_settings={"cache_root": "/private/cache"})

--- a/tests/video_selection/models/test_selected_image_artifact.py
+++ b/tests/video_selection/models/test_selected_image_artifact.py
@@ -1,0 +1,52 @@
+"""Selected Image Artifact modelのtest。"""
+
+import pytest
+
+from src.video_selection.models.selected_image_artifact import SelectedImageArtifact
+
+
+def test_relative_webp_with_complete_identity_is_accepted() -> None:
+    """完全ID、relative WebP path、hash、寸法が保持されること。
+
+    Arrange:
+        - staging済みWebPの公開診断が用意される
+    Act:
+        - Selected Image Artifactが構築される
+    Assert:
+        - relative pathとbyte数が保持されること
+    """
+    # Arrange / Act
+    artifact = SelectedImageArtifact(
+        image_id="frm_" + "a" * 64,
+        relative_path="images/0001_test_aaaaaaaaaaaa.webp",
+        sha256="b" * 64,
+        width=3840,
+        height=2160,
+        size_bytes=1024,
+    )
+
+    # Assert
+    assert artifact.relative_path == "images/0001_test_aaaaaaaaaaaa.webp"
+    assert artifact.size_bytes == 1024
+
+
+def test_parent_segment_in_image_path_is_rejected() -> None:
+    """images外へ出るparent segment pathが拒否されること。
+
+    Arrange:
+        - parent segmentを持つWebP pathが用意される
+    Act:
+        - Selected Image Artifactが構築される
+    Assert:
+        - 公開path契約違反として拒否されること
+    """
+    # Arrange / Act / Assert
+    with pytest.raises(ValueError, match="path"):
+        SelectedImageArtifact(
+            image_id="frm_" + "a" * 64,
+            relative_path="images/../outside.webp",
+            sha256="b" * 64,
+            width=1,
+            height=1,
+            size_bytes=1,
+        )

--- a/tests/video_selection/services/test_build_video_source_ids.py
+++ b/tests/video_selection/services/test_build_video_source_ids.py
@@ -1,0 +1,68 @@
+"""Video Source ID構築のtest。"""
+
+from pathlib import Path
+
+from src.video_selection.models.video_source import VideoSource
+from src.video_selection.services.build_video_source_ids import build_video_source_ids
+
+
+def _source(path: str, fingerprint: str) -> VideoSource:
+    return VideoSource(
+        path=Path(path),
+        relative_path=path,
+        fingerprint=fingerprint,
+        size_bytes=1,
+        modified_at_ns=1,
+        device=1,
+        inode=1,
+    )
+
+
+def test_unique_prefixes_use_short_video_source_ids() -> None:
+    """一意なfingerprint prefixが12文字Video Source IDへ短縮されること。
+
+    Arrange:
+        - 異なる12文字prefixを持つVideo Sourceが用意される
+    Act:
+        - Video Source IDが構築される
+    Assert:
+        - 両sourceが12文字digest IDを持つこと
+    """
+    # Arrange
+    first = _source("first.mkv", "a" * 64)
+    second = _source("second.mkv", "b" * 64)
+
+    # Act
+    identifiers = build_video_source_ids((first, second))
+
+    # Assert
+    assert identifiers == {
+        first.fingerprint: "vid_" + "a" * 12,
+        second.fingerprint: "vid_" + "b" * 12,
+    }
+
+
+def test_colliding_prefixes_expand_only_affected_video_source_ids() -> None:
+    """衝突したVideo Source IDだけが完全digestへ拡張されること。
+
+    Arrange:
+        - 同じ12文字prefixの2 sourceと一意な1 sourceが用意される
+    Act:
+        - Video Source IDが構築される
+    Assert:
+        - 衝突した2 sourceだけが64文字digestを持つこと
+    """
+    # Arrange
+    first = _source("first.mkv", "123456789abc" + "a" * 52)
+    second = _source("second.mkv", "123456789abc" + "b" * 52)
+    third = _source("third.mkv", "c" * 64)
+
+    # Act
+    identifiers = build_video_source_ids((first, second, third))
+
+    # Assert
+    assert identifiers == {
+        first.fingerprint: "vid_" + first.fingerprint,
+        second.fingerprint: "vid_" + second.fingerprint,
+        third.fingerprint: "vid_" + "c" * 12,
+    }

--- a/tests/video_selection/services/test_canonical_output_publisher.py
+++ b/tests/video_selection/services/test_canonical_output_publisher.py
@@ -1,0 +1,479 @@
+"""Canonical Selection Reportとatomic publicationのtest。"""
+
+import json
+from copy import deepcopy
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from PIL import Image
+
+from src.video_selection.models.model_role import ModelRole
+from src.video_selection.services.canonical_output_publisher import (
+    CanonicalOutputPublisher,
+)
+from tests.video_selection.fakes.canonical_publication_factory import (
+    build_canonical_publication_request,
+)
+from tests.video_selection.fakes.fake_model_runtime import FakeModelRuntime
+from tests.video_selection.fakes.fake_video_stage_media_runtime import (
+    FakeVideoStageMediaRuntime,
+)
+
+
+def test_selected_webp_and_reports_are_published_from_one_canonical_object(
+    tmp_path: Path,
+) -> None:
+    """WebP、JSON、Markdownが同じCanonical Selection Reportから公開されること。
+
+    Arrange:
+        - 2枚要求に対して1枚を選択したVideo Set選定結果が用意される
+        - raw Context Cue本文と絶対pathを持つ内部入力が用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - 元解像度、quality 95、metadataなしのWebPが公開されること
+        - JSONのID、path、count、hash、reasonとMarkdown投影が一致すること
+        - Selection Shortfallだけがwarning付き正常成果物として示されること
+        - raw Context Cue本文と絶対pathが成果物へ含まれないこと
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+    runtime = FakeVideoStageMediaRuntime()
+
+    # Act
+    report = cast(dict[str, Any], CanonicalOutputPublisher(runtime).publish(request))
+
+    # Assert
+    output_folder = request.configuration.output_folder
+    assert sorted(
+        path.relative_to(output_folder).as_posix() for path in output_folder.rglob("*")
+    ) == [
+        "images",
+        "images/0001_test-scene_aaaaaaaaaaaa.webp",
+        "report.json",
+        "report.md",
+    ]
+    report_from_disk = json.loads(
+        (output_folder / "report.json").read_text(encoding="utf-8")
+    )
+    assert report_from_disk == report
+    assert report["schema"] == {
+        "name": "game-screen-pick/report",
+        "version": "1.0.0",
+    }
+    assert report["run"]["status"] == "completed_with_warnings"
+    assert report["run"]["warnings"] == [
+        {
+            "code": "selection_shortfall",
+            "message": "要求2枚に対して1枚を選択しました。",
+            "details": {"similarity_ceiling": 1},
+        }
+    ]
+    selected = report["selected"][0]
+    image_path = output_folder / selected["output"]["relative_path"]
+    image_bytes = image_path.read_bytes()
+    assert selected["image_id"] == "frm_" + "a" * 64
+    assert selected["output"]["bytes"] == len(image_bytes)
+    assert selected["output"]["sha256"]
+    assert selected["selection"]["reason_codes"] == [
+        "high_quality",
+        "high_explanation_value",
+        "normal_gameplay_coverage",
+    ]
+    with Image.open(image_path) as image:
+        assert image.format == "WEBP"
+        assert image.size == (64, 48)
+        assert not image.getexif()
+        assert not ({"exif", "icc_profile", "xmp"} & image.info.keys())
+    markdown = (output_folder / "report.md").read_text(encoding="utf-8")
+    assert (
+        "[![01 — 探索](images/0001_test-scene_aaaaaaaaaaaa.webp)]"
+        "(images/0001_test-scene_aaaaaaaaaaaa.webp)"
+    ) in markdown
+    assert "`similarity_ceiling`" in markdown
+    serialized = (output_folder / "report.json").read_text(encoding="utf-8") + markdown
+    assert "公開してはいけない秘密の台詞" not in serialized
+    assert str(tmp_path) not in serialized
+    golden_folder = Path(__file__).parents[1] / "fixtures" / "canonical_publication"
+    normalized = deepcopy(report)
+    for item in cast(list[dict[str, Any]], normalized["selected"]):
+        output = cast(dict[str, Any], item["output"])
+        output["sha256"] = "<sha256>"
+        output["bytes"] = "<bytes>"
+    assert normalized == json.loads(
+        (golden_folder / "report.normalized.json").read_text(encoding="utf-8")
+    )
+    assert markdown == (golden_folder / "report.md").read_text(encoding="utf-8")
+
+
+def test_colliding_digest_prefixes_expand_only_affected_output_names(
+    tmp_path: Path,
+) -> None:
+    """同じ12文字prefixの選択IDだけが完全digest filenameへ拡張されること。
+
+    Arrange:
+        - Frame Candidate IDの先頭12文字が衝突する2枚の完全選定結果が用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - 両方のfilenameだけが完全64文字digestへ拡張されること
+        - warningなしのcompleted reportが公開されること
+    """
+    # Arrange
+    request = build_canonical_publication_request(
+        tmp_path,
+        shortfall=False,
+        colliding_digest_prefixes=True,
+    )
+
+    # Act
+    report = cast(
+        dict[str, Any],
+        CanonicalOutputPublisher(FakeVideoStageMediaRuntime()).publish(request),
+    )
+
+    # Assert
+    paths = [item["output"]["relative_path"] for item in report["selected"]]
+    assert paths == [
+        "images/0001_test-scene_" + "123456789abc" + "a" * 52 + ".webp",
+        "images/0002_test-scene_" + "123456789abc" + "b" * 52 + ".webp",
+    ]
+    assert report["run"]["status"] == "completed"
+    assert report["run"]["warnings"] == []
+
+
+@pytest.mark.parametrize(
+    ("checkpoint", "error"),
+    [
+        ("before-image-write", PermissionError("permission denied")),
+        ("before-report-json-write", OSError("disk full")),
+        ("before-markdown-render", RuntimeError("renderer failed")),
+        ("before-flush", OSError("flush failed")),
+        ("before-rename", OSError("rename failed")),
+        (
+            "after-rename-before-parent-flush",
+            OSError("parent directory flush failed"),
+        ),
+    ],
+)
+def test_publication_faults_leave_no_output_folder(
+    tmp_path: Path,
+    checkpoint: str,
+    error: Exception,
+) -> None:
+    """書込み、権限、rename faultでfinal Output Folderが残されないこと。
+
+    Arrange:
+        - 公開途中の指定checkpointで失敗するfault injectorが用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - faultが呼出元へ返されること
+        - final Output Folderとstaging Folderが残されないこと
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+
+    def inject(actual: str, _staging_folder: Path) -> None:
+        if actual == checkpoint:
+            raise error
+
+    # Act / Assert
+    with pytest.raises(type(error), match=str(error)):
+        CanonicalOutputPublisher(
+            FakeVideoStageMediaRuntime(),
+            fault_injector=inject,
+        ).publish(request)
+    assert not request.configuration.output_folder.exists()
+    assert not tuple(tmp_path.glob(".output.*.staging"))
+
+
+@pytest.mark.parametrize("artifact", ["report.json", "report.md"])
+def test_schema_or_renderer_mismatch_leaves_no_output_folder(
+    tmp_path: Path,
+    artifact: str,
+) -> None:
+    """schema不正またはMarkdown projection不一致が公開前に拒否されること。
+
+    Arrange:
+        - 最終validation直前にJSONまたはMarkdownを破損するfaultが用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - cross-artifact validationが失敗すること
+        - final Output Folderとstaging Folderが残されないこと
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+
+    def corrupt(actual: str, staging_folder: Path) -> None:
+        if actual != "before-validation":
+            return
+        path = staging_folder / artifact
+        path.write_text("{}\n" if artifact.endswith("json") else "broken\n")
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="Canonical Selection Report"):
+        CanonicalOutputPublisher(
+            FakeVideoStageMediaRuntime(),
+            fault_injector=corrupt,
+        ).publish(request)
+    assert not request.configuration.output_folder.exists()
+    assert not tuple(tmp_path.glob(".output.*.staging"))
+
+
+def test_unknown_nested_field_is_rejected_by_exact_producer_schema(
+    tmp_path: Path,
+) -> None:
+    """report@1.0.0の既知objectへ追加された未知fieldが拒否されること。
+
+    Arrange:
+        - validation直前にVideo Time契約へ未知fieldを追加するfaultが用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - exact producer schema不一致として失敗すること
+        - final Output Folderが残されないこと
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+
+    def add_unknown_field(actual: str, staging_folder: Path) -> None:
+        if actual != "before-validation":
+            return
+        path = staging_folder / "report.json"
+        report = cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+        video_set = cast(dict[str, Any], report["video_set"])
+        time_contract = cast(dict[str, Any], video_set["time_contract"])
+        time_contract["future_field"] = "not-in-report-1.0.0"
+        path.write_text(
+            json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="schema不一致"):
+        CanonicalOutputPublisher(
+            FakeVideoStageMediaRuntime(),
+            fault_injector=add_unknown_field,
+        ).publish(request)
+    assert not request.configuration.output_folder.exists()
+
+
+def test_publication_uses_one_final_directory_rename(tmp_path: Path) -> None:
+    """検証済みstaging Folderが一回のdirectory renameだけで公開されること。
+
+    Arrange:
+        - rename呼出しを記録して実際のrenameを行う境界が用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - hidden sibling stagingからfinal Output Folderへのrenameが一回だけ行われること
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+    calls: list[tuple[Path, Path]] = []
+
+    def rename(source: Path, destination: Path) -> None:
+        calls.append((source, destination))
+        source.rename(destination)
+
+    # Act
+    CanonicalOutputPublisher(
+        FakeVideoStageMediaRuntime(),
+        directory_renamer=rename,
+    ).publish(request)
+
+    # Assert
+    assert len(calls) == 1
+    source, destination = calls[0]
+    assert source.parent == destination.parent
+    assert source.name.startswith(".output.")
+    assert source.name.endswith(".staging")
+    assert destination == request.configuration.output_folder
+
+
+@pytest.mark.parametrize("move_before_failure", [False, True])
+def test_directory_rename_failure_leaves_no_output_folder(
+    tmp_path: Path,
+    move_before_failure: bool,
+) -> None:
+    """実rename境界が移動前後に失敗してもfinal成果物が除去されること。
+
+    Arrange:
+        - staging移動前または移動直後に失敗するdirectory renamerが用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - rename errorが呼出元へ返されること
+        - final Output Folderとstaging Folderが残されないこと
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+
+    def fail_rename(source: Path, destination: Path) -> None:
+        if move_before_failure:
+            source.rename(destination)
+        raise OSError("directory rename failed")
+
+    # Act / Assert
+    with pytest.raises(OSError, match="directory rename failed"):
+        CanonicalOutputPublisher(
+            FakeVideoStageMediaRuntime(),
+            directory_renamer=fail_rename,
+        ).publish(request)
+    assert not request.configuration.output_folder.exists()
+    assert not tuple(tmp_path.glob(".output.*.staging"))
+
+
+def test_nonempty_output_is_rejected_before_frame_extraction(tmp_path: Path) -> None:
+    """非空Output Folderがframe再抽出より前に拒否されること。
+
+    Arrange:
+        - 既存fileを持つOutput Folderが用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - Output Folder契約違反が返されること
+        - selected frameが再抽出されないこと
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+    output_folder = request.configuration.output_folder
+    output_folder.mkdir()
+    (output_folder / "existing.txt").write_text("existing", encoding="utf-8")
+    runtime = FakeVideoStageMediaRuntime()
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="存在しないか空"):
+        CanonicalOutputPublisher(runtime).publish(request)
+    assert runtime.extracted_frame_calls == []
+
+
+def test_empty_output_is_removed_and_replaced_by_atomic_publication(
+    tmp_path: Path,
+) -> None:
+    """既存の空Output Folderが処理前に除かれ正常成果物へ置換されること。
+
+    Arrange:
+        - 既存する空Output Folderと完全なpublication requestが用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - 空Folderが検証後に除かれ完全な成果物だけが公開されること
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+    output_folder = request.configuration.output_folder
+    output_folder.mkdir()
+
+    # Act
+    CanonicalOutputPublisher(FakeVideoStageMediaRuntime()).publish(request)
+
+    # Assert
+    assert (output_folder / "report.json").is_file()
+    assert (output_folder / "report.md").is_file()
+    assert len(tuple((output_folder / "images").glob("*.webp"))) == 1
+
+
+def test_atomic_rename_unavailable_fails_before_frame_extraction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """directory rename不能filesystemがartifact生成前に拒否されること。
+
+    Arrange:
+        - atomic rename probeだけが失敗するfilesystem faultが用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - atomic rename不能として失敗すること
+        - selected frameが再抽出されずOutput Folderが残らないこと
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+    runtime = FakeVideoStageMediaRuntime()
+
+    def fail_rename(_source: Path, _destination: Path) -> None:
+        raise OSError("unsupported")
+
+    monkeypatch.setattr(
+        "src.video_selection.services.canonical_output_publisher.os.rename",
+        fail_rename,
+    )
+
+    # Act / Assert
+    with pytest.raises(OSError, match="atomic directory rename"):
+        CanonicalOutputPublisher(runtime).publish(request)
+    assert runtime.extracted_frame_calls == []
+    assert not request.configuration.output_folder.exists()
+
+
+def test_video_set_change_before_rename_discards_staging(tmp_path: Path) -> None:
+    """frame抽出後のVideo Set変更がfinal rename前に検知されること。
+
+    Arrange:
+        - validation checkpointでsource videoを書き換えるfaultが用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - Video Set snapshot変更として失敗すること
+        - final Output Folderとstaging Folderが残らないこと
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+
+    def mutate_source(actual: str, _staging_folder: Path) -> None:
+        if actual == "before-validation":
+            request.video_set.sources[0].path.write_bytes(b"changed-video")
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="Video Set snapshotが変更"):
+        CanonicalOutputPublisher(
+            FakeVideoStageMediaRuntime(),
+            fault_injector=mutate_source,
+        ).publish(request)
+    assert not request.configuration.output_folder.exists()
+    assert not tuple(tmp_path.glob(".output.*.staging"))
+
+
+def test_verified_local_model_after_update_failure_is_reported_as_warning(
+    tmp_path: Path,
+) -> None:
+    """更新不能でも検証済みlocal modelを使ったroleがwarningへ記録されること。
+
+    Arrange:
+        - 全枚数を選択しCandidate Annotation model更新だけが不能なrunが用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - model_update_unavailableが対象role付きで公開されること
+        - 選定自体はcompleted_with_warningsとしてatomicに公開されること
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path, shortfall=False)
+    models = FakeModelRuntime(
+        "canonical-publication",
+        unavailable_roles=frozenset({ModelRole.CANDIDATE_ANNOTATION}),
+    ).resolve_models(request.configuration)
+    request = replace(request, resolved_models=models)
+
+    # Act
+    report = cast(
+        dict[str, Any],
+        CanonicalOutputPublisher(FakeVideoStageMediaRuntime()).publish(request),
+    )
+
+    # Assert
+    assert report["run"]["status"] == "completed_with_warnings"
+    assert report["run"]["warnings"] == [
+        {
+            "code": "model_update_unavailable",
+            "message": (
+                "model更新確認を完了できず検証済みlocal artifactを使用しました。"
+            ),
+            "details": {"roles": ["candidate_annotation"]},
+        }
+    ]

--- a/tests/video_selection/services/test_canonical_output_publisher.py
+++ b/tests/video_selection/services/test_canonical_output_publisher.py
@@ -3,6 +3,7 @@
 import json
 from copy import deepcopy
 from dataclasses import replace
+from fractions import Fraction
 from pathlib import Path
 from typing import Any, cast
 
@@ -12,6 +13,12 @@ from PIL import Image
 from src.video_selection.models.model_role import ModelRole
 from src.video_selection.services.canonical_output_publisher import (
     CanonicalOutputPublisher,
+)
+from src.video_selection.services.serialize_canonical_selection_report import (
+    serialize_canonical_selection_report,
+)
+from src.video_selection.services.validate_canonical_selection_report import (
+    validate_canonical_selection_report,
 )
 from tests.video_selection.fakes.canonical_publication_factory import (
     build_canonical_publication_request,
@@ -85,6 +92,9 @@ def test_selected_webp_and_reports_are_published_from_one_canonical_object(
         "high_explanation_value",
         "normal_gameplay_coverage",
     ]
+    assert runtime.extracted_original_frame_calls == [
+        (request.video_set.sources[0].path, 0, 15)
+    ]
     with Image.open(image_path) as image:
         assert image.format == "WEBP"
         assert image.size == (64, 48)
@@ -145,6 +155,164 @@ def test_colliding_digest_prefixes_expand_only_affected_output_names(
     ]
     assert report["run"]["status"] == "completed"
     assert report["run"]["warnings"] == []
+
+
+def test_duplicate_video_source_ids_are_rejected_before_publication(
+    tmp_path: Path,
+) -> None:
+    """重複したVideo Source IDを持つCanonical reportが拒否されること。
+
+    Arrange:
+        - 正常公開済みreportへ同じIDのVideo Source recordが追加される
+    Act:
+        - Canonical Selection Reportの公開前検証が実行される
+    Assert:
+        - Video Source ID重複として拒否されること
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+    output_folder = request.configuration.output_folder
+    report = cast(
+        dict[str, Any],
+        CanonicalOutputPublisher(FakeVideoStageMediaRuntime()).publish(request),
+    )
+    video_set = cast(dict[str, Any], report["video_set"])
+    sources = cast(list[dict[str, Any]], video_set["sources"])
+    sources.append(deepcopy(sources[0]))
+    (output_folder / "report.json").write_text(
+        serialize_canonical_selection_report(report),
+        encoding="utf-8",
+    )
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="Video Source IDが重複"):
+        validate_canonical_selection_report(report, output_folder, request)
+
+
+def test_short_context_cue_text_does_not_trigger_privacy_false_positive(
+    tmp_path: Path,
+) -> None:
+    """短いContext Cue本文が構造化値との偶然一致で拒否されないこと。
+
+    Arrange:
+        - 本文が1文字だけのContext Cueを持つpublication requestが用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - 公開free textへ逐語転載されていない成果物が正常公開されること
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+    stage = request.video_stage_results[0]
+    cue = replace(stage.context.cues[0], text="1")
+    request = replace(
+        request,
+        video_stage_results=(
+            replace(stage, context=replace(stage.context, cues=(cue,))),
+        ),
+    )
+
+    # Act
+    report = cast(
+        dict[str, Any],
+        CanonicalOutputPublisher(FakeVideoStageMediaRuntime()).publish(request),
+    )
+
+    # Assert
+    assert report["run"]["status"] == "completed_with_warnings"
+    assert request.configuration.output_folder.is_dir()
+
+
+def test_near_miss_free_text_is_escaped_in_markdown_table(tmp_path: Path) -> None:
+    """Near Missのmodel自由文に含まれる表区切り文字がescapeされること。
+
+    Arrange:
+        - summaryに縦棒を含むNear Missが用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - Markdown表へescape済みsummaryが描画されること
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+    rejected = request.selection_result.rejected[0]
+    annotation = replace(
+        rejected.candidate.annotation,
+        summary="HP | MPを比較する画面。",
+    )
+    candidate = replace(rejected.candidate, annotation=annotation)
+    request = replace(
+        request,
+        selection_result=replace(
+            request.selection_result,
+            rejected=(replace(rejected, candidate=candidate),),
+        ),
+    )
+
+    # Act
+    CanonicalOutputPublisher(FakeVideoStageMediaRuntime()).publish(request)
+
+    # Assert
+    markdown = (request.configuration.output_folder / "report.md").read_text(
+        encoding="utf-8"
+    )
+    assert "HP \\| MPを比較する画面。" in markdown
+    assert "HP | MPを比較する画面。" not in markdown
+
+
+def test_non_aligned_source_pts_context_cue_uses_exact_offset_fallback(
+    tmp_path: Path,
+) -> None:
+    """source PTS gridに非整列のCue時刻がexact offsetで公開されること。
+
+    Arrange:
+        - source PTSから整数origin PTSを復元できないContext Cueが用意される
+    Act:
+        - Canonical Output Publisherが実行される
+    Assert:
+        - timestamp basisを保ったままlosslessなoffset時刻が公開されること
+    """
+    # Arrange
+    request = build_canonical_publication_request(tmp_path)
+    stage = request.video_stage_results[0]
+    original_cue = stage.context.cues[0]
+    provenance = original_cue.provenance
+    if provenance is None:
+        raise AssertionError("fixtureにContext Cue provenanceが必要です")
+    cue = replace(
+        original_cue,
+        start=Fraction(29, 30),
+        end=Fraction(59, 30),
+        provenance=replace(
+            provenance,
+            source_pts=1000,
+            source_time_base=Fraction(1, 1000),
+        ),
+    )
+    request = replace(
+        request,
+        video_stage_results=(
+            replace(stage, context=replace(stage.context, cues=(cue,))),
+        ),
+    )
+
+    # Act
+    report = cast(
+        dict[str, Any],
+        CanonicalOutputPublisher(FakeVideoStageMediaRuntime()).publish(request),
+    )
+
+    # Assert
+    context = report["context_cues"][0]
+    assert context["timestamp_basis"] == "source_pts"
+    assert context["start"] == {
+        "offset_seconds": {"numerator": 29, "denominator": 30},
+        "display": "00:00:00.967",
+    }
+    assert context["end"] == {
+        "offset_seconds": {"numerator": 59, "denominator": 30},
+        "display": "00:00:01.967",
+    }
 
 
 @pytest.mark.parametrize(
@@ -352,7 +520,7 @@ def test_nonempty_output_is_rejected_before_frame_extraction(tmp_path: Path) -> 
     # Act / Assert
     with pytest.raises(ValueError, match="存在しないか空"):
         CanonicalOutputPublisher(runtime).publish(request)
-    assert runtime.extracted_frame_calls == []
+    assert runtime.extracted_original_frame_calls == []
 
 
 def test_empty_output_is_removed_and_replaced_by_atomic_publication(
@@ -410,7 +578,7 @@ def test_atomic_rename_unavailable_fails_before_frame_extraction(
     # Act / Assert
     with pytest.raises(OSError, match="atomic directory rename"):
         CanonicalOutputPublisher(runtime).publish(request)
-    assert runtime.extracted_frame_calls == []
+    assert runtime.extracted_original_frame_calls == []
     assert not request.configuration.output_folder.exists()
 
 

--- a/tests/video_selection/services/test_canonical_output_publisher.py
+++ b/tests/video_selection/services/test_canonical_output_publisher.py
@@ -71,6 +71,9 @@ def test_selected_webp_and_reports_are_published_from_one_canonical_object(
             "details": {"similarity_ceiling": 1},
         }
     ]
+    context_start = report["context_cues"][0]["start"]
+    assert context_start["source_pts"] == 1000
+    assert context_start["time_base"] == {"numerator": 1, "denominator": 1000}
     selected = report["selected"][0]
     image_path = output_folder / selected["output"]["relative_path"]
     image_bytes = image_path.read_bytes()

--- a/tests/video_selection/services/test_report_time.py
+++ b/tests/video_selection/services/test_report_time.py
@@ -1,0 +1,65 @@
+"""Canonical report exact time projectionのtest。"""
+
+from fractions import Fraction
+
+from src.video_selection.services.report_time import (
+    display_report_time,
+    exact_seconds_string,
+    rational_report_value,
+)
+
+
+def test_display_time_uses_half_up_without_wrapping_at_24_hours() -> None:
+    """24時間超のexact秒がhalf-upで折り返さず表示されること。
+
+    Arrange:
+        - 25時間と59.9995秒を表す既約分数が用意される
+    Act:
+        - Report Video Time表示へ投影される
+    Assert:
+        - millisecondがhalf-upされ25時間を維持した表示になること
+    """
+    # Arrange
+    value = Fraction(25 * 3600 + 59) + Fraction(9995, 10000)
+
+    # Act
+    result = display_report_time(value)
+
+    # Assert
+    assert result == "25:01:00.000"
+
+
+def test_exact_seconds_keeps_integer_zeroes_and_nonterminating_fraction() -> None:
+    """exact secondsが整数zeroを失わず非有限小数を分数で保持すること。
+
+    Arrange:
+        - 10秒、1.25秒、1/3秒が用意される
+    Act:
+        - losslessなJSON文字列表現へ投影される
+    Assert:
+        - 整数、有限小数、既約分数として正確に返されること
+    """
+    # Arrange / Act / Assert
+    assert exact_seconds_string(Fraction(10)) == "10"
+    assert exact_seconds_string(Fraction(5, 4)) == "1.25"
+    assert exact_seconds_string(Fraction(1, 3)) == "1/3"
+
+
+def test_rational_value_is_reduced_by_fraction_boundary() -> None:
+    """report rational objectへ既約な分子と分母が渡されること。
+
+    Arrange:
+        - 約分可能な入力から作られたFractionが用意される
+    Act:
+        - report rational objectへ投影される
+    Assert:
+        - 既約な分子と正の分母が返されること
+    """
+    # Arrange
+    value = Fraction(6, 8)
+
+    # Act
+    result = rational_report_value(value)
+
+    # Assert
+    assert result == {"numerator": 3, "denominator": 4}

--- a/tests/video_selection/services/test_validate_report_schema_compatibility.py
+++ b/tests/video_selection/services/test_validate_report_schema_compatibility.py
@@ -1,0 +1,81 @@
+"""Canonical Selection Report reader schema compatibilityのtest。"""
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from src.video_selection.services.build_canonical_selection_report import (
+    REPORT_SCHEMA_VERSION,
+)
+from src.video_selection.services.validate_report_schema_compatibility import (
+    validate_report_schema_compatibility,
+)
+
+
+def test_same_major_accepts_unknown_fields_and_enum_values() -> None:
+    """対応major内の未知fieldと未知enum値がreader gateで拒否されないこと。
+
+    Arrange:
+        - report@1の将来minorと未知field、未知enum値を持つobjectが用意される
+    Act:
+        - reader schema compatibility gateが実行される
+    Assert:
+        - schema identityだけが検証されobjectが変更されないこと
+    """
+    # Arrange
+    report: dict[str, object] = {
+        "schema": {"name": "game-screen-pick/report", "version": "1.8.0"},
+        "future_field": {"future_enum": "new_value"},
+    }
+    expected = dict(report)
+
+    # Act
+    validate_report_schema_compatibility(report)
+
+    # Assert
+    assert report == expected
+
+
+def test_unknown_major_is_rejected() -> None:
+    """未対応major versionがreader gateで拒否されること。
+
+    Arrange:
+        - report@2のschema identityを持つobjectが用意される
+    Act:
+        - reader schema compatibility gateが実行される
+    Assert:
+        - 未対応major versionとして拒否されること
+    """
+    # Arrange
+    report: dict[str, object] = {
+        "schema": {"name": "game-screen-pick/report", "version": "2.0.0"}
+    }
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="未対応major"):
+        validate_report_schema_compatibility(report)
+
+
+def test_report_schema_version_is_independent_from_package_version() -> None:
+    """report schema versionがproject package versionと独立していること。
+
+    Arrange:
+        - source treeのproject metadataとreport producer versionが用意される
+    Act:
+        - 両方のversionが読み取られる
+    Assert:
+        - report schemaが1.0.0のままpackage versionとは異なること
+    """
+    # Arrange
+    project_root = Path(__file__).parents[3]
+
+    # Act
+    project = tomllib.loads(
+        (project_root / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    package_version = project["project"]["version"]
+
+    # Assert
+    assert REPORT_SCHEMA_VERSION == "1.0.0"
+    assert package_version != REPORT_SCHEMA_VERSION

--- a/tests_ffmpeg/support/ffmpeg_fixture_factory.py
+++ b/tests_ffmpeg/support/ffmpeg_fixture_factory.py
@@ -33,6 +33,33 @@ def generate_cfr_video(output_path: Path) -> Path:
     return output_path
 
 
+def generate_odd_dimension_video(output_path: Path) -> Path:
+    """奇数の幅と高さを持つsource frameを生成する。"""
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=size=65x49:rate=1:duration=1",
+            "-map",
+            "0:v:0",
+            "-c:v",
+            "ffv1",
+            "-pix_fmt",
+            "yuv444p",
+            str(output_path),
+        ],
+        check=True,
+    )
+    return output_path
+
+
 def generate_vfr_video(output_path: Path) -> Path:
     """不均一なsource PTSを持つVFR test patternを生成する。"""
     subprocess.run(

--- a/tests_ffmpeg/video_selection/media/test_ffmpeg_media_runtime.py
+++ b/tests_ffmpeg/video_selection/media/test_ffmpeg_media_runtime.py
@@ -23,6 +23,7 @@ from tests_ffmpeg.support.ffmpeg_fixture_factory import (
     generate_av1_aac_video,
     generate_cfr_video,
     generate_corrupt_video,
+    generate_odd_dimension_video,
     generate_scene_change_video,
     generate_stream_matrix_video,
     generate_vfr_video,
@@ -642,6 +643,35 @@ def test_extract_video_frame_returns_exact_requested_pts(tmp_path: Path) -> None
     assert Fraction(frame.pts) * frame.time_base == Fraction(1, 2)
     assert (frame.width, frame.height, frame.pixel_format) == (64, 48, "rgb24")
     assert len(frame.pixels) == 64 * 48 * 3
+
+
+def test_extract_original_video_frame_preserves_odd_source_dimensions(
+    tmp_path: Path,
+) -> None:
+    """奇数寸法のsource frameがscaleされず抽出されること。
+
+    Arrange:
+        - 65x49のsource frameを持つfixtureが用意される
+    Act:
+        - original frame extractionがexact PTSで実行される
+    Assert:
+        - 幅と高さが偶数へ丸められずRGB24で返されること
+    """
+    # Arrange
+    video_path = generate_odd_dimension_video(tmp_path / "odd-dimension.mkv")
+    runtime = FfmpegMediaRuntime()
+    stream = runtime.probe(video_path).streams[0]
+
+    # Act
+    frame = runtime.extract_original_video_frame(
+        video_path,
+        stream_index=stream.index,
+        pts=0,
+    )
+
+    # Assert
+    assert (frame.width, frame.height, frame.pixel_format) == (65, 49, "rgb24")
+    assert len(frame.pixels) == 65 * 49 * 3
 
 
 def test_scan_video_frame_ranges_preserves_vfr_frames_inside_half_open_ranges(

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "av"
 version = "18.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -259,6 +268,7 @@ dependencies = [
     { name = "click" },
     { name = "faster-whisper" },
     { name = "huggingface-hub" },
+    { name = "jsonschema" },
     { name = "numpy" },
     { name = "opencv-python" },
     { name = "pillow" },
@@ -274,6 +284,7 @@ dev = [
     { name = "python-decouple-stubs" },
     { name = "ruff" },
     { name = "taskipy" },
+    { name = "types-jsonschema" },
     { name = "types-requests" },
     { name = "vulture" },
 ]
@@ -283,6 +294,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
     { name = "faster-whisper", specifier = ">=1.2.1,<2.0.0" },
     { name = "huggingface-hub", specifier = ">=0.36.2,<1.0.0" },
+    { name = "jsonschema", specifier = ">=4.23.0,<5.0.0" },
     { name = "numpy", specifier = ">=2.3.1" },
     { name = "opencv-python", specifier = ">=4.11.0.86" },
     { name = "pillow", specifier = ">=12.1.0" },
@@ -298,6 +310,7 @@ dev = [
     { name = "python-decouple-stubs", specifier = ">=0.1" },
     { name = "ruff", specifier = ">=0.14.10" },
     { name = "taskipy", specifier = ">=1.14.1" },
+    { name = "types-jsonschema", specifier = ">=4.23.0.20240813" },
     { name = "types-requests", specifier = ">=2.32.4.20250913" },
     { name = "vulture", specifier = ">=2.14" },
 ]
@@ -381,6 +394,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -1008,6 +1048,19 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "regex"
 version = "2026.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1092,6 +1145,87 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
 ]
 
 [[package]]
@@ -1324,6 +1458,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
     { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+]
+
+[[package]]
+name = "types-jsonschema"
+version = "4.26.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/46/73b6a5d61a61015c4248030a8cb07e5bdddb4041430fae9e585a68692578/types_jsonschema-4.26.0.20260518.tar.gz", hash = "sha256:e1dd53dc97a64f5eccdd6fa9839666e09bb500a8ebba2db6fdaf1789faea81a6", size = 16638, upload-time = "2026-05-18T06:06:44.106Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/d5/134f8a147dcecda10db7f60cfc6af0578a25a5c53c87b3907a64385e0184/types_jsonschema-4.26.0.20260518-py3-none-any.whl", hash = "sha256:30b30a518c7fe335df85c919fcbcc631b69c03d4a4b5b632fa916bea03065307", size = 16072, upload-time = "2026-05-18T06:06:43.264Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

- selected frameをexact PTSから元解像度で再抽出し、metadataなしlossy WebP quality 95へ固定変換
- `game-screen-pick/report@1.0.0`の厳密なJSON Schema、canonical JSON producer、deterministicなgallery-first Markdown rendererを追加
- selected／near miss／Context Cue metadata／selection・model・Stage provenance／privacy omissionを一つのcanonical objectから投影
- hidden same-filesystem staging、file・directory flush、schema・cross-artifact・privacy・layout検証、一回のfinal directory renameを実装
- rename前後、disk、permission、schema、renderer failureでfinal Output Folderを残さないcleanupを実装
- Selection Shortfallと検証済みlocal model利用時の`model_update_unavailable`をwarning付き正常成果物として公開
- READMEと成果物ドキュメントを内部実装済みの状態へ更新

## 主な仕様判断

- Frame Candidate IDをstable identityとし、通常はdigest先頭12文字、同一run内の衝突時だけ完全digestをfilenameへ使用
- Video Source IDも通常はdigest先頭12文字とし、衝突したsourceだけ完全digestへ拡張
- source寸法を変更しない専用FFmpeg抽出境界を使い、奇数幅・奇数高さもそのままWebPへ保持
- source PTS gridへlosslessに対応しないContext Cue時刻は、timestamp basisを維持してexact rational offsetへfallback
- raw Context Cue本文、absolute path、environment variable、credential、prompt、raw response、stack traceを成果物へ含めない
- Context Cue転載検査は公開自由文を対象とし、独立生成と区別できない1〜2文字の一般語は引用判定から除外
- producerはreport@1.0.0を厳密検証し、reader compatibility gateは同じmajorの未知field／enumを受理
- report schema versionをpackage versionから独立させ、schema実体をwheelへ同梱
- public CLI、package version、旧OutputRecord/reportは変更しない

## 検証

- `uv run task test`: 515 passed
- Ruff check / format: 成功
- strict mypy: 370 source files成功
- normalized JSON／Markdown golden: 成功
- publication fault matrix（write、disk、permission、renderer、schema、flush、rename前後）: 成功
- FFmpeg奇数寸法fixture（65x49）の元寸法抽出: 成功
- built wheelへの`report-1.0.0.schema.json`同梱確認: 成功

## Follow-up

- structured progress、reason code、中断・再開は#188
- real model capacityとtarget性能受け入れは#189
- public video CLI cutoverとlegacy削除は#190

関連: #187
