### PR TITLE
feat: 構造化進捗と中断再開契約を実装する

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,6 +48,18 @@ _Avoid_: path hash, file stat, stage setting hash
 再開可能な画像選定を構成する、入力と再利用可能な成果物の境界が明示された処理単位。
 _Avoid_: arbitrary function, progress message, whole run
 
+**Progress Event**:
+一回のrunとProcessing Stageの開始、観測可能な進行、cache利用、完了、中断、失敗をrenderer非依存の型付き値で表す通知。表示文、外部toolの生出力、raw Context Cue、prompt、model responseは含めない。
+_Avoid_: log line, renderer message, model trace, exception text
+
+**Comparable Work Series**:
+一回のrun内でStage種別、work-unit種別、reuseまたはrecomputeの処理方法が等しく、Stage ETAのsampleを共有できる作業系列。runをまたぐ実績や、今後の処理方法が未確定なunitを推定へ混ぜない。
+_Avoid_: whole-run average, persisted benchmark, cache hit ratio forecast
+
+**Run Failure**:
+runを終了させる失敗をstable reason code、安全な観測値、修復方法、Completed Stageの再利用案内、終了codeで表した利用者向け結果。元の例外や外部toolの生出力そのものではない。
+_Avoid_: traceback, raw exception, Progress Event message, partial success
+
 **Stage Resource Metric**:
 Completed Stageを初回計算するときの処理開始からartifact構築までを対象にしたwall時間とCPU時間。CPU時間はcurrent processとchild processの合計で、cache再利用時は初回に保存された値を復元する。
 _Avoid_: FFmpeg-only metric, cache lookup duration, current-run reuse overhead
@@ -127,6 +139,10 @@ _Avoid_: model fallback, cache reset, model identity, notification-only update c
 **Completed Stage**:
 成果物と完了manifestがatomicに確定し、再利用できる Processing Stage。完了manifestのない部分成果物は含まない。
 _Avoid_: partial cache, in-progress stage, progress checkpoint
+
+**Recognized Partial Stage**:
+Completed Stageとして確定する前に中断・失敗したことをcache構造から安全に識別できる一時成果物。再利用せず、Input Lock取得後に削除して同じProcessing Stageを再計算する。
+_Avoid_: Completed Stage, Legacy Cache, unknown directory, resume checkpoint
 
 **Video Stage**:
 一つのVideo Identityだけを対象とし、Video Setの構成やVideo Orderから独立して再利用できる Processing Stage。同一動画内で完結する時間構造、候補密度、frame refinement、Neutral Image Analysis、Context Cue収集を所有する。複数VideoはVideo Order順に各Videoのscan、candidate extraction、context collectionを直列実行し、Video Orderは実行順にだけ使ってfingerprintへ含めない。

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## 動画入力版の設計と内部実装（公開前）
 
-複数のゲーム録画を一つのVideo Setとして扱う次期interfaceは、次の一つのcommandへ置き換える設計です。探索・content identity・Input Lock・Completed Stage cache、system FFmpeg/ffprobeを閉じ込めるMediaRuntimeに加え、動画単位のscan、exact timeline、Candidate Moment、native frame refinement、model-free Neutral Image Analysis、embedded subtitle/audio STTからのContext Cue収集、Ollama/Hugging Faceのmodel lifecycleとrun単位のidentity freeze、共有Scene Catalog、Moment単位のCandidate Annotation、soft coverage・spoiler・動画横断diversityを扱う決定的な最終selector、固定WebP、`game-screen-pick/report@1.0.0`、gallery-first Markdown、atomic publisherまで内部実装済みです。Video Set applicationへのcanonical publisher接続とpublic CLI切り替えは後続Issueで行うため、このcommandはまだ実行できません。
+複数のゲーム録画を一つのVideo Setとして扱う次期interfaceは、次の一つのcommandへ置き換える設計です。探索・content identity・Input Lock・Completed Stage cache、system FFmpeg/ffprobeを閉じ込めるMediaRuntimeに加え、動画単位のscan、exact timeline、Candidate Moment、native frame refinement、model-free Neutral Image Analysis、embedded subtitle/audio STTからのContext Cue収集、Ollama/Hugging Faceのmodel lifecycleとrun単位のidentity freeze、共有Scene Catalog、Moment単位のCandidate Annotation、soft coverage・spoiler・動画横断diversityを扱う決定的な最終selector、固定WebP、`game-screen-pick/report@1.0.0`、gallery-first Markdown、atomic publisher、structured progress、RunFailure、Completed Stage単位の再開まで内部実装済みです。Video Set applicationへのcanonical publisher接続とpublic CLI切り替えは後続Issueで行うため、このcommandはまだ実行できません。
 
 ```bash
 game-screen-pick \

--- a/docs/migration-acceptance.md
+++ b/docs/migration-acceptance.md
@@ -118,7 +118,7 @@ rename失敗、disk full、permission denied、不正manifest、artifact欠落�
 検証する不変条件は次の通り。
 
 - 完了manifestと成果物がatomicに確定したCompleted Stageだけを再利用する。
-- partial/in-progress Stageは無視して再計算し、fatal runはOutput Folderを公開しない。
+- recognized partial/in-progress StageはInput Lock取得後に削除して再計算し、Completed Stageと未知のdirectoryは削除しない。fatal runはOutput Folderを公開しない。
 - Ctrl+Cはexit 130、operation errorはexit 1であり、どちらも完了済み上流Stageを保持する。
 - 同じVideo内のfirst/middle/lastおよび複数Videoの一部失敗で、成功済み独立Video Stageを
   再計算しない。
@@ -132,16 +132,30 @@ cache hit/miss/recompute、elapsed、任意のETA、severity、reason codeを持
 absolute path、raw Context Cue、prompt、model responseを含めない。domain testは日本語の表示
 文字列ではなくeventを検証する。
 
+一回のrunでactiveなProcessing Stageは一つだけとし、`run_started`からStageの開始・進行・完了を
+繰り返して、一つのterminal eventで終了する。Stage番号はatomicなCompleted Stage候補ごとに増やし、
+総Stage数は判明した場合だけeventと表示へ含める。cache lookupのhit/missと実処理の
+reuse/recomputeは別の観測値とし、miss後に実処理したunitはmissとrecomputeの双方へ数える。
+
 ETAは次の全部を満たすときだけ表示する。
 
-- 比較可能なwork unitの総数が判明している。
-- 少なくとも5 unitのsampleがある。
-- Stageが通常30秒以上続く。
-- cache hitとrecomputeのsampleを別系列で推定している。
+- 残りのreuse/recompute件数が別々に判明している。
+- 同じrun内の`Stage種別 × work-unit種別 × reuse/recompute`ごとに少なくとも5 unitのsampleがある。
+- Stage開始から実時間で30秒以上経過している。
+- runをまたぐ実績や観測済みcache hit率から今後のcache結果を推測していない。
 
 安定したfake workloadでは最終実績の20%以内へ収束させる。新しいsampleで予測が50%を
-超えて変動したときはETAを一時的に隠し、`estimating`とする。根拠のない0%、0秒、全runの
-擬似percentageは表示しない。
+超えて変動した系列はresetし、新しい5 sampleが集まるまでETAを隠して`estimating`とする。
+根拠のない0%、0秒、全runの擬似percentageは表示しない。
+
+TTY/line rendererは`stderr.isatty()`で自動選択し、line rendererはrelative path内の制御文字を
+escapeして1 event 1行を守る。外部処理は開始eventを直ちに発行し、完了まで30秒ごとにelapsed
+だけのheartbeatを発行する。同じCLI process内ではOllamaとSTTのGPU-heavy処理を共有coordinatorで
+直列化し、別process間のGPU排他は行わない。
+
+最外周の内部run controllerだけがStage例外を安全な`RunFailure`へ正規化し、terminal event、
+resume guidance、exit 1/2/130を決める。Ctrl+Cは`run_interrupted / user_interrupt / 130`とし、
+public CLIへの接続はIMP-13まで行わない。
 
 ## Target acceptance profileと記録
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -72,7 +72,7 @@ processing cacheはcontent-addressedな次のnamespaceを使います。
 通常実行は常に再開可能です。`--resume`はありません。
 
 - 完了manifestと成果物がatomicに確定したCompleted Stageだけを再利用します。
-- 中断・失敗したStageの部分成果物は再利用せず、そのStageから再実行します。
+- 中断・失敗したStageの部分成果物は再利用しません。認識可能なtemporary StageはInput Lock取得後に削除し、そのStageから再実行します。Completed Stageと未知のdirectoryは削除しません。
 - 同じVideoのVideo StageはpathやVideo Orderが変わっても再利用できます。
 - Videoの追加・削除・並べ替えでは再利用可能なVideo Stageを残し、Video Set Stageだけを新しいVideo Set Fingerprintで再実行します。
 - model identity、prompt、schema、policy、Stage固有設定が変わった場合は影響するStageだけを再計算します。
@@ -81,18 +81,22 @@ processing cacheはcontent-addressedな次のnamespaceを使います。
 
 ## 進捗表示
 
-全体の根拠のないpercentは表示せず、現在のProcessing Stageに対する観測可能な進捗を表示します。
+全体の根拠のないpercentは表示せず、現在のProcessing Stageに対する観測可能な進捗をrenderer非依存の`ProgressEvent`として発行します。1回のrunではProcessing Stageを直列に扱い、`run_started`、Stageの開始・進行・完了、最後の`run_completed`、`run_failed`、`run_interrupted`の順序を守ります。
 
-- `Stage i/N`とStage名
+- atomicなProcessing Stage候補ごとのStage番号とStage名。総Stage数が判明した場合だけ`Stage i/N`とする
 - Video Order、総動画数、正規化済み相対path
 - 処理済み件数と現在判明している総件数
-- cache hit、miss、recompute
+- cache lookupのhit/missと、実処理のreuse/recompute
 - Stage経過時間
 - 信頼できるsampleがある場合だけStage ETA
 - model downloadのartifact、bytes、percent
 - Stage開始、完了、warning、再試行、cache再利用などのevent
 
-TTYでは更新型表示、redirect/CIでは一行event logにします。進捗、warning、errorはstderrへ出し、v1ではstdoutにmachine-readable reportを流しません。60秒以上沈黙し得る外部処理でもStage eventまたはheartbeatを出します。
+Stage ETAは同じrun内の`Stage種別 × work-unit種別 × reuse/recompute`が同じsampleだけから求めます。残りのreuse/recompute件数が別々に判明し、各系列に5件以上のsampleがあり、Stage開始から30秒以上経過した場合だけ表示します。新しいsampleで予測が50%を超えて変動した系列は破棄し、5件の新しいsampleが集まるまで`estimating`へ戻します。runをまたぐ実績や観測済みcache hit率から今後のcache結果を推測しません。
+
+TTYでは更新型表示、redirect/CIでは一行event logにします。`stderr.isatty()`で自動選択し、v1では強制切替optionを設けません。relative pathの制御文字をescapeし、line rendererの1 event 1行を維持します。進捗、warning、errorはstderrへ出し、stdoutにmachine-readable reportを流しません。60秒以上沈黙し得る外部処理は開始eventを直ちに発行し、その後30秒ごとにelapsedだけのheartbeatを出します。
+
+同じCLI process内では共有GPU coordinatorがOllamaとSTTのGPU-heavy処理を直列化します。別々に起動したCLI process間のGPU排他は行いません。
 
 ## 終了codeとエラー表示
 
@@ -103,7 +107,9 @@ TTYでは更新型表示、redirect/CIでは一行event logにします。進捗
 | 2 | CLIまたはTOMLのusage/validation error |
 | 130 | Ctrl+C |
 
-エラーはstable reason code、秘密を含まない観測値、修復方法、再実行時に再利用できるcacheを示します。通常はstack traceを表示しません。`--debug`時だけ安全化済みstack traceを加えますが、credential、環境変数一覧、絶対path、prompt本文、raw model response、Context Cue本文は出しません。
+最外周のrun controllerがStageの型付き例外を`RunFailure`へ正規化し、stable reason code、allowlistで許可した安全な観測値、修復方法、再実行時に再利用できるcacheを示します。未知の例外は`internal_error`とし、元の例外は内部causeとしてだけ保持します。通常はstack traceを表示しません。`--debug`時だけ安全化済みstack traceを加えますが、credential、環境変数一覧、絶対path、prompt本文、raw model response、Context Cue本文は出しません。
+
+Ctrl+Cはfailureではなく`run_interrupted`、reason `user_interrupt`、exit 130として扱い、処理中のpartial Stageを再利用しません。
 
 fatal errorではOutput Folderを公開しません。Selection Shortfallと、検証済みlocal modelを使えたmodel更新不能はexit 0の`completed_with_warnings`として理由をatomicに公開します。後者は`model_update_unavailable`と対象roleを`report.json`へ記録し、model storeのpathやtokenは含めません。
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -47,7 +47,7 @@ PRでは通常quality checkと別のUbuntu 24.04 jobとして実行されます�
 
 ## preflightとcache reset
 
-処理前に、CLI/TOML、入力・出力path、Video Set snapshot、cache書き込み、同一inputの非待機lock、外部tool、stream、model解決と能力を検査します。異常時はcache処理やOutput Folder公開を始めません。
+処理前に、CLI/TOML、入力・出力path、Video Set snapshot、cache書き込み、同一inputの非待機lock、外部tool、stream、model解決と能力を検査します。異常時はcache処理やOutput Folder公開を始めません。不存在・動画なし・Duplicate Video・不正なOutput Folderなど、実行前に利用者が修正できる入力不備はexit 2と`fix_configuration`で返します。fingerprint計算中を含む実行時のsnapshot変更やI/O障害はoperation failureとしてexit 1にし、usage errorへ分類しません。
 
 `--reset-cache`は上記の安全なpreflightとlock取得が成功した後に、`<VIDEO_INPUT_FOLDER>/.game-screen-pick/cache/`全体だけを削除します。Output Folder、Ollama model store、Hugging Face model cacheには触れません。Stage単位またはVideo単位の手動reset、自動削除、保持期限、容量上限はv1に含めません。
 
@@ -92,7 +92,7 @@ processing cacheはcontent-addressedな次のnamespaceを使います。
 - model downloadのartifact、bytes、percent
 - Stage開始、完了、warning、再試行、cache再利用などのevent
 
-Stage ETAは同じrun内の`Stage種別 × work-unit種別 × reuse/recompute`が同じsampleだけから求めます。残りのreuse/recompute件数が別々に判明し、各系列に5件以上のsampleがあり、Stage開始から30秒以上経過した場合だけ表示します。新しいsampleで予測が50%を超えて変動した系列は破棄し、5件の新しいsampleが集まるまで`estimating`へ戻します。runをまたぐ実績や観測済みcache hit率から今後のcache結果を推測しません。
+Stage ETAは同じrun内の`Stage種別 × work-unit種別 × reuse/recompute`が同じsampleだけから求めます。各sampleはcache lookup前のStage開始から、recomputeではartifactとmanifestのatomic completion、reuseでは検証済みcacheの復元完了までのcurrent-run実時間を記録し、0秒のsampleは除外します。残りのreuse/recompute件数が別々に判明し、各系列に5件以上のsampleがあり、Stage開始から30秒以上経過した場合だけ表示します。新しいsampleで予測が50%を超えて変動した系列は破棄し、5件の新しいsampleが集まるまで`estimating`へ戻します。runをまたぐ実績や観測済みcache hit率から今後のcache結果を推測しません。
 
 TTYでは更新型表示、redirect/CIでは一行event logにします。`stderr.isatty()`で自動選択し、v1では強制切替optionを設けません。relative pathの制御文字をescapeし、line rendererの1 event 1行を維持します。進捗、warning、errorはstderrへ出し、stdoutにmachine-readable reportを流しません。60秒以上沈黙し得る外部処理は開始eventを直ちに発行し、その後30秒ごとにelapsedだけのheartbeatを出します。
 

--- a/src/video_selection/application/internal_run_controller.py
+++ b/src/video_selection/application/internal_run_controller.py
@@ -47,7 +47,7 @@ class InternalRunController:
             return (failure.exit_code, failure)
         except ConfigurationError as error:
             failure = _safe_run_failure(
-                reason_code=error.reason_code,
+                reason_code=error.reason_code.lower(),
                 exit_code=2,
                 remediation_code="fix_configuration",
                 resume_guidance="run_not_started",

--- a/src/video_selection/application/internal_run_controller.py
+++ b/src/video_selection/application/internal_run_controller.py
@@ -1,0 +1,147 @@
+"""内部application runのterminal result境界。"""
+
+from collections.abc import Callable
+from typing import Literal, TypeVar
+
+from ..configuration.configuration_error import ConfigurationError
+from ..models.context_stage_error import ContextStageError
+from ..models.media_runtime_error import MediaRuntimeError
+from ..models.model_runtime_error import ModelRuntimeError
+from ..models.run_failure import (
+    ResumeGuidance,
+    RunFailure,
+    RunFailureExitCode,
+    SafeObservedValue,
+)
+from ..models.vision_runtime_error import VisionRuntimeError
+from ..services.run_progress_tracker import RunProgressTracker
+
+RunExitCode = Literal[0, 1, 2, 130]
+RunValue = TypeVar("RunValue")
+
+
+class InternalRunController:
+    """operation errorを安全なRun Failureとexit codeへ変換する。"""
+
+    def __init__(self, progress: RunProgressTracker) -> None:
+        self._progress = progress
+
+    def execute(
+        self,
+        operation: Callable[[], RunValue],
+    ) -> tuple[RunExitCode, RunValue | RunFailure]:
+        """内部operationを一つのrun lifecycleとして実行する。"""
+        self._progress.start_run()
+        try:
+            outcome = operation()
+            self._progress.complete_run()
+        except KeyboardInterrupt as error:
+            failure = _safe_run_failure(
+                reason_code="user_interrupt",
+                exit_code=130,
+                remediation_code="rerun_command",
+                resume_guidance="completed_stages_reusable",
+                cause=error,
+            )
+            self._progress.interrupt_run()
+            return (failure.exit_code, failure)
+        except ConfigurationError as error:
+            failure = _safe_run_failure(
+                reason_code=error.reason_code,
+                exit_code=2,
+                remediation_code="fix_configuration",
+                resume_guidance="run_not_started",
+                cause=error,
+            )
+            self._progress.fail_run(failure.reason_code)
+            return (failure.exit_code, failure)
+        except MediaRuntimeError as error:
+            failure = _safe_run_failure(
+                reason_code=error.reason.value,
+                exit_code=1,
+                remediation_code="check_media_runtime",
+                resume_guidance="completed_stages_reusable",
+                cause=error,
+            )
+            self._progress.fail_run(failure.reason_code)
+            return (failure.exit_code, failure)
+        except ModelRuntimeError as error:
+            failure = _safe_run_failure(
+                reason_code=error.reason.value,
+                exit_code=1,
+                remediation_code="check_model_runtime",
+                resume_guidance="completed_stages_reusable",
+                observed_values=(("model_role", error.role.value),),
+                cause=error,
+            )
+            self._progress.fail_run(failure.reason_code)
+            return (failure.exit_code, failure)
+        except VisionRuntimeError as error:
+            observed_values: tuple[tuple[str, str | int], ...] = (
+                (("attempt_count", error.attempt_count),)
+                if error.validation_code is None
+                else (
+                    ("attempt_count", error.attempt_count),
+                    ("validation_code", error.validation_code),
+                )
+            )
+            failure = _safe_run_failure(
+                reason_code=error.reason.value,
+                exit_code=1,
+                remediation_code="check_vision_runtime",
+                resume_guidance="completed_stages_reusable",
+                observed_values=observed_values,
+                cause=error,
+            )
+            self._progress.fail_run(failure.reason_code)
+            return (failure.exit_code, failure)
+        except ContextStageError as error:
+            failure = _safe_run_failure(
+                reason_code=error.reason.value,
+                exit_code=1,
+                remediation_code="check_context_source",
+                resume_guidance="completed_stages_reusable",
+                cause=error,
+            )
+            self._progress.fail_run(failure.reason_code)
+            return (failure.exit_code, failure)
+        except Exception as error:
+            failure = _safe_run_failure(
+                reason_code="internal_error",
+                exit_code=1,
+                remediation_code="report_internal_error",
+                resume_guidance="completed_stages_reusable",
+                cause=error,
+            )
+            self._progress.fail_run(failure.reason_code)
+            return (failure.exit_code, failure)
+        return (0, outcome)
+
+
+def _safe_run_failure(
+    *,
+    reason_code: str,
+    exit_code: RunFailureExitCode,
+    remediation_code: str,
+    resume_guidance: ResumeGuidance,
+    cause: BaseException,
+    observed_values: tuple[tuple[str, SafeObservedValue], ...] = (),
+) -> RunFailure:
+    """unsafeなtyped metadataも最外周から漏らさずRun Failureへ変換する。"""
+    try:
+        return RunFailure(
+            reason_code=reason_code,
+            exit_code=exit_code,
+            remediation_code=remediation_code,
+            resume_guidance=resume_guidance,
+            observed_values=observed_values,
+            cause=cause,
+        )
+    except (TypeError, ValueError):
+        return RunFailure(
+            reason_code="internal_error",
+            exit_code=1,
+            remediation_code="report_internal_error",
+            resume_guidance="completed_stages_reusable",
+            cause=cause,
+        )

--- a/src/video_selection/application/video_selection_application.py
+++ b/src/video_selection/application/video_selection_application.py
@@ -24,6 +24,7 @@ from ..services.discover_video_set import discover_video_set
 from ..services.input_folder_lock import InputFolderLock
 from ..services.prepare_processing_cache import prepare_processing_cache
 from ..services.processing_stage_runner import ProcessingStageRunner
+from ..services.run_progress_tracker import RunProgressTracker
 from ..services.select_images import select_images
 from ..services.snapshot_frame_candidates import snapshot_frame_candidates
 from ..services.snapshot_video_set import snapshot_video_set
@@ -48,12 +49,14 @@ class VideoSelectionApplication:
         model_runtime: ModelRuntime,
         vision_runtime: CandidateBatchAnnotator,
         observer: RunObserver,
+        progress: RunProgressTracker | None = None,
     ) -> None:
         self._media_runtime = media_runtime
         self._speech_runtime = speech_runtime
         self._model_runtime = model_runtime
         self._vision_runtime = vision_runtime
         self._observer = observer
+        self._progress = progress
 
     def run(self, configuration: EffectiveConfiguration) -> RunOutcome:
         """内部Video Set選定を実行してRunOutcomeを返す。"""
@@ -94,6 +97,7 @@ class VideoSelectionApplication:
             subject_namespace="video-sets",
             subject_fingerprint=video_set.fingerprint,
             before_stage=lambda: validate_video_set_snapshot(video_set),
+            progress=self._progress,
         )
         stage_runner.complete(
             ProcessingStage.DISCOVER_VIDEO_SET,

--- a/src/video_selection/application/video_selection_application.py
+++ b/src/video_selection/application/video_selection_application.py
@@ -2,6 +2,7 @@
 
 from contextlib import suppress
 
+from ..configuration.configuration_error import ConfigurationError
 from ..models.effective_configuration import EffectiveConfiguration
 from ..models.model_role import ModelRole
 from ..models.processing_stage import ProcessingStage
@@ -60,10 +61,16 @@ class VideoSelectionApplication:
 
     def run(self, configuration: EffectiveConfiguration) -> RunOutcome:
         """内部Video Set選定を実行してRunOutcomeを返す。"""
-        validate_output_folder(
-            configuration.video_input_folder,
-            configuration.output_folder,
-        )
+        try:
+            validate_output_folder(
+                configuration.video_input_folder,
+                configuration.output_folder,
+            )
+        except ValueError as error:
+            raise ConfigurationError(
+                "OUTPUT_FOLDER_INVALID",
+                str(error),
+            ) from None
 
         video_set = discover_video_set(
             configuration.video_input_folder,

--- a/src/video_selection/models/progress_event.py
+++ b/src/video_selection/models/progress_event.py
@@ -1,0 +1,124 @@
+"""renderer非依存のProgress Event。"""
+
+import math
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Literal
+
+from .processing_stage import ProcessingStage
+
+ProgressEventKind = Literal[
+    "run_started",
+    "stage_started",
+    "progress",
+    "cache",
+    "external_work_started",
+    "heartbeat",
+    "retrying",
+    "warning",
+    "stage_completed",
+    "run_completed",
+    "run_failed",
+    "run_interrupted",
+]
+ProgressSeverity = Literal["info", "warning", "error"]
+EstimationState = Literal["unavailable", "estimating", "available"]
+
+_STABLE_CODE = re.compile(r"[a-z][a-z0-9_-]*\Z")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ProgressEvent:
+    """runとProcessing Stageの安全な観測値を保持する。"""
+
+    kind: ProgressEventKind
+    severity: ProgressSeverity
+    stage: ProcessingStage | None = None
+    stage_index: int | None = None
+    stage_count: int | None = None
+    video_order: int | None = None
+    video_count: int | None = None
+    video_relative_path: str | None = None
+    processed_count: int | None = None
+    total_count: int | None = None
+    cache_hit_count: int = 0
+    cache_miss_count: int = 0
+    reuse_count: int = 0
+    recompute_count: int = 0
+    elapsed_seconds: float | None = None
+    eta_seconds: float | None = None
+    estimation_state: EstimationState = "unavailable"
+    work_unit_kind: str | None = None
+    reason_code: str | None = None
+
+    def __post_init__(self) -> None:
+        """path、count、時間、stable codeの不変条件を検証する。"""
+        _validate_position("stage", self.stage_index, self.stage_count)
+        _validate_position("video", self.video_order, self.video_count)
+        _validate_progress_count(self.processed_count, self.total_count)
+        for label, value in (
+            ("cache hit", self.cache_hit_count),
+            ("cache miss", self.cache_miss_count),
+            ("reuse", self.reuse_count),
+            ("recompute", self.recompute_count),
+        ):
+            if value < 0:
+                msg = f"{label} countは0以上である必要があります"
+                raise ValueError(msg)
+        _validate_seconds("elapsed", self.elapsed_seconds, allow_zero=True)
+        _validate_seconds("ETA", self.eta_seconds, allow_zero=False)
+        if (self.eta_seconds is None) == (self.estimation_state == "available"):
+            msg = "ETA stateとETA secondsが一致していません"
+            raise ValueError(msg)
+        if self.video_relative_path is not None:
+            _validate_relative_path(self.video_relative_path)
+        _validate_stable_code("work unit", self.work_unit_kind)
+        _validate_stable_code("reason", self.reason_code)
+
+
+def _validate_position(label: str, index: int | None, total: int | None) -> None:
+    if index is not None and index < 1:
+        msg = f"{label} indexは1以上である必要があります"
+        raise ValueError(msg)
+    if total is not None and total < 1:
+        msg = f"{label} countは1以上である必要があります"
+        raise ValueError(msg)
+    if index is not None and total is not None and index > total:
+        msg = f"{label} indexはcount以下である必要があります"
+        raise ValueError(msg)
+
+
+def _validate_progress_count(processed: int | None, total: int | None) -> None:
+    if processed is not None and processed < 0:
+        msg = "processed countは0以上である必要があります"
+        raise ValueError(msg)
+    if total is not None and total < 0:
+        msg = "total countは0以上である必要があります"
+        raise ValueError(msg)
+    if processed is not None and total is not None and processed > total:
+        msg = "processed countはtotal count以下である必要があります"
+        raise ValueError(msg)
+
+
+def _validate_seconds(label: str, value: float | None, *, allow_zero: bool) -> None:
+    if value is None:
+        return
+    minimum_is_valid = value >= 0 if allow_zero else value > 0
+    if not math.isfinite(value) or not minimum_is_valid:
+        qualifier = "0以上" if allow_zero else "0より大きい有限値"
+        msg = f"{label} secondsは{qualifier}である必要があります"
+        raise ValueError(msg)
+
+
+def _validate_relative_path(value: str) -> None:
+    path = PurePosixPath(value)
+    if not value or path.is_absolute() or ".." in path.parts or "\0" in value:
+        msg = "video relative pathにabsolute pathまたは親参照は指定できません"
+        raise ValueError(msg)
+
+
+def _validate_stable_code(label: str, value: str | None) -> None:
+    if value is not None and _STABLE_CODE.fullmatch(value) is None:
+        msg = f"{label} codeはstable code形式である必要があります"
+        raise ValueError(msg)

--- a/src/video_selection/models/run_failure.py
+++ b/src/video_selection/models/run_failure.py
@@ -1,0 +1,59 @@
+"""利用者へ安全に通知できるrun terminal failure。"""
+
+import math
+import re
+from dataclasses import dataclass, field
+from typing import Literal
+
+RunFailureExitCode = Literal[1, 2, 130]
+ResumeGuidance = Literal[
+    "completed_stages_reusable",
+    "run_not_started",
+]
+SafeObservedValue = str | int | float | bool
+
+_STABLE_CODE = re.compile(r"[a-z][a-z0-9_-]*\Z")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RunFailure:
+    """stable codeとallowlist値だけを公開する失敗結果。"""
+
+    reason_code: str
+    exit_code: RunFailureExitCode
+    remediation_code: str
+    resume_guidance: ResumeGuidance
+    observed_values: tuple[tuple[str, SafeObservedValue], ...] = ()
+    cause: BaseException | None = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        """公開値がstableかつ秘密を持ち込めない形式であることを検証する。"""
+        _validate_code("reason", self.reason_code)
+        _validate_code("remediation", self.remediation_code)
+        keys: set[str] = set()
+        for key, value in self.observed_values:
+            _validate_code("observed value", key)
+            if key in keys:
+                msg = "observed value keyは重複できません"
+                raise ValueError(msg)
+            keys.add(key)
+            _validate_observed_value(value)
+
+    def __str__(self) -> str:
+        """raw causeを含めずstable reasonだけを返す。"""
+        return self.reason_code
+
+
+def _validate_code(label: str, value: str) -> None:
+    if _STABLE_CODE.fullmatch(value) is None:
+        msg = f"{label} codeはstable code形式である必要があります"
+        raise ValueError(msg)
+
+
+def _validate_observed_value(value: SafeObservedValue) -> None:
+    if isinstance(value, str):
+        _validate_code("observed string", value)
+        return
+    if isinstance(value, float) and not math.isfinite(value):
+        msg = "observed numberは有限値である必要があります"
+        raise ValueError(msg)

--- a/src/video_selection/protocols/run_observer.py
+++ b/src/video_selection/protocols/run_observer.py
@@ -4,10 +4,14 @@ from typing import Protocol
 
 from ..models.completed_stage import CompletedStage
 from ..models.legacy_cache_cleanup_diagnostic import LegacyCacheCleanupDiagnostic
+from ..models.progress_event import ProgressEvent
 
 
 class RunObserver(Protocol):
-    """Processing Stageの完了を外部へ通知する境界。"""
+    """runのstructured observationを外部へ通知する境界。"""
+
+    def observe(self, event: ProgressEvent) -> None:
+        """renderer非依存のProgress Eventを通知する。"""
 
     def stage_completed(self, completed_stage: CompletedStage) -> None:
         """atomicに完了したStageを通知する。"""

--- a/src/video_selection/services/collect_speech_context.py
+++ b/src/video_selection/services/collect_speech_context.py
@@ -3,6 +3,7 @@
 import unicodedata
 from collections.abc import Iterable, Iterator
 from fractions import Fraction
+from functools import partial
 
 from ..models.context_cue import ContextCue
 from ..models.context_cue_diagnostics import ContextCueDiagnostics
@@ -21,6 +22,7 @@ from ..models.video_source import VideoSource
 from ..protocols.speech_runtime import SpeechRuntime
 from ..protocols.video_stage_media_runtime import VideoStageMediaRuntime
 from .build_context_cue_id import build_context_cue_id
+from .external_work_monitor import ExternalWorkMonitor
 from .iter_overlapping_pcm_chunks import iter_overlapping_pcm_chunks
 from .normalize_context_language import normalize_context_language
 
@@ -38,6 +40,7 @@ def collect_speech_context(
     scan: VideoScanResult,
     stream: MediaStream,
     configuration: EffectiveConfiguration,
+    external_work_monitor: ExternalWorkMonitor | None = None,
 ) -> ContextStageResult:
     """選択audioをSTTしCue、低reliability診断、outcomeを返す。"""
     chunk_samples = int(configuration.speech_chunk_seconds * _AUDIO_SAMPLE_RATE)
@@ -65,11 +68,20 @@ def collect_speech_context(
         overlapping_chunks
     ):
         try:
-            recognition = speech_runtime.transcribe(
+            transcribe = partial(
+                speech_runtime.transcribe,
                 chunk,
                 language=speech_language,
                 vad_filter=configuration.speech_vad_filter,
                 beam_size=configuration.speech_to_text_beam_size,
+            )
+            recognition = (
+                transcribe()
+                if external_work_monitor is None
+                else external_work_monitor.run(
+                    transcribe,
+                    reason_code="speech_recognition_started",
+                )
             )
         except Exception:
             raise ContextStageError(

--- a/src/video_selection/services/completed_stage_writer.py
+++ b/src/video_selection/services/completed_stage_writer.py
@@ -105,6 +105,7 @@ class CompletedStageWriter:
     ) -> CompletedStage:
         """fingerprint lockの内側でStageを一度だけ確定する。"""
         stage_folder = stage_root / fingerprint.value
+        _remove_recognized_temporary_stages(stage_root, fingerprint)
         if (
             self.read_bundle(
                 stage,
@@ -287,6 +288,28 @@ def _is_timezone_aware_iso_datetime(value: object) -> bool:
 
 def _ignore_fault_checkpoint(_checkpoint: str) -> None:
     return
+
+
+def _remove_recognized_temporary_stages(
+    stage_root: Path,
+    fingerprint: StageFingerprint,
+) -> None:
+    """同じfingerprintの正規形式temporary entryだけを削除する。"""
+    prefix = f".{fingerprint.value}."
+    suffix = ".tmp"
+    for path in stage_root.iterdir():
+        name = path.name
+        if not name.startswith(prefix) or not name.endswith(suffix):
+            continue
+        token = name[len(prefix) : -len(suffix)]
+        if len(token) != 32 or any(
+            character not in "0123456789abcdef" for character in token
+        ):
+            continue
+        if path.is_symlink() or path.is_file():
+            path.unlink()
+        elif path.is_dir():
+            shutil.rmtree(path)
 
 
 def _artifact_records(stage_folder: Path) -> list[dict[str, object]]:

--- a/src/video_selection/services/context_stage_processor.py
+++ b/src/video_selection/services/context_stage_processor.py
@@ -32,7 +32,9 @@ from .build_context_stage_semantic_input import (
 )
 from .collect_speech_context import collect_speech_context
 from .context_stage_artifacts import restore_context_stage, serialize_context_stage
+from .external_work_monitor import ExternalWorkMonitor
 from .processing_stage_runner import ProcessingStageRunner
+from .run_progress_tracker import RunProgressTracker
 from .select_context_audio_stream import select_context_audio_stream
 from .select_context_subtitle_stream import select_context_subtitle_stream
 from .validate_video_set_snapshot import validate_video_source_snapshot
@@ -46,10 +48,16 @@ class ContextStageProcessor:
         media_runtime: VideoStageMediaRuntime,
         speech_runtime: SpeechRuntime,
         observer: RunObserver,
+        *,
+        progress: RunProgressTracker | None = None,
     ) -> None:
         self._media_runtime = media_runtime
         self._speech_runtime = speech_runtime
         self._observer = observer
+        self._progress = progress
+        self._external_work_monitor = (
+            ExternalWorkMonitor(progress) if progress is not None else None
+        )
 
     def process(
         self,
@@ -95,6 +103,11 @@ class ContextStageProcessor:
             subject_fingerprint=source.fingerprint,
             before_stage=lambda: validate_video_source_snapshot(video_set, source),
             stage_order=(ProcessingStage.COLLECT_CONTEXT,),
+            progress=self._progress,
+            video_order=video_set.sources.index(source) + 1,
+            video_count=len(video_set.sources),
+            video_relative_path=source.relative_path,
+            work_unit_kind="video",
         )
         cached = runner.reuse(
             ProcessingStage.COLLECT_CONTEXT,
@@ -190,6 +203,7 @@ class ContextStageProcessor:
             scan=scan,
             stream=audio_stream,
             configuration=configuration,
+            external_work_monitor=self._external_work_monitor,
         )
         cues.extend(speech_result.cues)
         outcomes.extend(speech_result.outcomes)

--- a/src/video_selection/services/discover_video_set.py
+++ b/src/video_selection/services/discover_video_set.py
@@ -4,6 +4,7 @@ import hashlib
 import os
 from pathlib import Path
 
+from ..configuration.configuration_error import ConfigurationError
 from ..models.video_set import VideoSet
 from ..models.video_source import VideoSource
 from .discover_video_paths import discover_video_paths
@@ -13,11 +14,11 @@ def discover_video_set(input_folder: Path, recursive: bool = False) -> VideoSet:
     """対応videoを自然順で発見し内容identityを確定する。"""
     if not input_folder.is_dir():
         msg = "Video Input Folderが存在しません"
-        raise ValueError(msg)
+        raise ConfigurationError("VIDEO_INPUT_FOLDER_NOT_FOUND", msg)
     video_paths = discover_video_paths(input_folder, recursive)
     if not video_paths:
         msg = "Video Input Folderに対応videoがありません"
-        raise ValueError(msg)
+        raise ConfigurationError("VIDEO_INPUT_FOLDER_EMPTY", msg)
     sources = tuple(_build_video_source(input_folder, path) for path in video_paths)
     _reject_duplicate_videos(sources)
     return VideoSet(
@@ -60,7 +61,7 @@ def _reject_duplicate_videos(sources: tuple[VideoSource, ...]) -> None:
         if len(relative_paths) > 1:
             displayed_paths = ", ".join(relative_paths)
             msg = f"Duplicate Videoが見つかりました: {displayed_paths}"
-            raise ValueError(msg)
+            raise ConfigurationError("DUPLICATE_VIDEO", msg)
 
 
 def _build_video_set_fingerprint(sources: tuple[VideoSource, ...]) -> str:

--- a/src/video_selection/services/external_work_monitor.py
+++ b/src/video_selection/services/external_work_monitor.py
@@ -1,0 +1,54 @@
+"""blocking external workのProgress Event watchdog。"""
+
+from collections.abc import Callable
+from threading import Event, Thread
+from typing import TypeVar
+
+from .run_progress_tracker import RunProgressTracker
+
+WaitForStop = Callable[[Event, float], bool]
+WorkValue = TypeVar("WorkValue")
+_HEARTBEAT_INTERVAL_SECONDS = 30.0
+
+
+class ExternalWorkMonitor:
+    """external operation中に30秒間隔のheartbeatを発行する。"""
+
+    def __init__(
+        self,
+        progress: RunProgressTracker,
+        *,
+        wait_for_stop: WaitForStop | None = None,
+    ) -> None:
+        self._progress = progress
+        self._wait_for_stop = wait_for_stop or _wait_for_stop
+
+    def run(
+        self,
+        operation: Callable[[], WorkValue],
+        *,
+        reason_code: str,
+    ) -> WorkValue:
+        """開始eventから完了までheartbeat watchdog付きで実行する。"""
+        self._progress.external_work_started(reason_code)
+        stop = Event()
+        thread = Thread(
+            target=self._emit_heartbeats,
+            args=(stop,),
+            daemon=True,
+            name="progress-heartbeat",
+        )
+        thread.start()
+        try:
+            return operation()
+        finally:
+            stop.set()
+            thread.join()
+
+    def _emit_heartbeats(self, stop: Event) -> None:
+        while not self._wait_for_stop(stop, _HEARTBEAT_INTERVAL_SECONDS):
+            self._progress.heartbeat()
+
+
+def _wait_for_stop(stop: Event, timeout_seconds: float) -> bool:
+    return stop.wait(timeout_seconds)

--- a/src/video_selection/services/gpu_work_coordinator.py
+++ b/src/video_selection/services/gpu_work_coordinator.py
@@ -1,0 +1,27 @@
+"""同一process内のGPU-heavy work scheduling boundary。"""
+
+from collections.abc import Callable
+from threading import Lock
+from typing import Literal, TypeVar
+
+GpuWorkKind = Literal["speech_to_text", "vision_inference"]
+WorkValue = TypeVar("WorkValue")
+
+
+class GpuWorkCoordinator:
+    """共有されたSTTとVision GPU workを直列実行する。"""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+
+    def run(
+        self,
+        work_kind: GpuWorkKind,
+        operation: Callable[[], WorkValue],
+    ) -> WorkValue:
+        """GPU leaseを一つだけ取得してoperationを実行する。"""
+        if work_kind not in {"speech_to_text", "vision_inference"}:
+            msg = "GPU work kindが不正です"
+            raise ValueError(msg)
+        with self._lock:
+            return operation()

--- a/src/video_selection/services/line_progress_renderer.py
+++ b/src/video_selection/services/line_progress_renderer.py
@@ -1,0 +1,63 @@
+"""Progress Eventの一行renderer。"""
+
+import json
+
+from ..models.progress_event import ProgressEvent
+
+
+class LineProgressRenderer:
+    """redirectとCI向けにProgress Eventを一行へ描画する。"""
+
+    def render(self, event: ProgressEvent) -> str:
+        """制御文字をescapeしたstable field列を返す。"""
+        parts = [f"[{event.severity}]", f"event={event.kind}"]
+        if event.reason_code is not None:
+            parts.append(f"reason={event.reason_code}")
+        if event.stage is not None:
+            parts.append(f"stage={event.stage.value}")
+        if event.stage_index is not None:
+            parts.append(
+                f"stage_index={_position(event.stage_index, event.stage_count)}"
+            )
+        if event.video_order is not None:
+            parts.append(f"video={_position(event.video_order, event.video_count)}")
+        if event.video_relative_path is not None:
+            escaped_path = json.dumps(
+                event.video_relative_path,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            parts.append(f"path={escaped_path}")
+        if event.processed_count is not None:
+            parts.append(
+                f"progress={_position(event.processed_count, event.total_count)}"
+            )
+        if any(
+            (
+                event.cache_hit_count,
+                event.cache_miss_count,
+                event.reuse_count,
+                event.recompute_count,
+            )
+        ):
+            parts.extend(
+                (
+                    f"cache_hit={event.cache_hit_count}",
+                    f"cache_miss={event.cache_miss_count}",
+                    f"reuse={event.reuse_count}",
+                    f"recompute={event.recompute_count}",
+                )
+            )
+        if event.elapsed_seconds is not None:
+            parts.append(f"elapsed={event.elapsed_seconds:.1f}s")
+        if event.eta_seconds is not None:
+            parts.append(f"eta={event.eta_seconds:.1f}s")
+        elif event.estimation_state == "estimating":
+            parts.append("eta=estimating")
+        if event.work_unit_kind is not None:
+            parts.append(f"unit={event.work_unit_kind}")
+        return " ".join(parts)
+
+
+def _position(index: int, total: int | None) -> str:
+    return str(index) if total is None else f"{index}/{total}"

--- a/src/video_selection/services/processing_stage_runner.py
+++ b/src/video_selection/services/processing_stage_runner.py
@@ -243,6 +243,7 @@ class ProcessingStageRunner:
     ) -> None:
         """Stage完了をrun stateへ追加して通知する。"""
         if self._progress is not None:
+            self._progress.record_work_sample("reuse" if reused else "recompute")
             self._progress.cache_observed(
                 cache_hit_count=1 if reused else 0,
                 cache_miss_count=0 if reused else 1,

--- a/src/video_selection/services/processing_stage_runner.py
+++ b/src/video_selection/services/processing_stage_runner.py
@@ -16,6 +16,7 @@ from .completed_stage_writer import (
     CompletedStageWriter,
     FaultInjector,
 )
+from .run_progress_tracker import RunProgressTracker
 
 StageResult = TypeVar("StageResult")
 
@@ -33,6 +34,12 @@ class ProcessingStageRunner:
         before_stage: Callable[[], None] | None = None,
         fault_injector: FaultInjector | None = None,
         stage_order: tuple[ProcessingStage, ...] = VIDEO_SET_STAGE_ORDER,
+        progress: RunProgressTracker | None = None,
+        total_stage_count: int | None = None,
+        video_order: int | None = None,
+        video_count: int | None = None,
+        video_relative_path: str | None = None,
+        work_unit_kind: str = "processing_stage",
     ) -> None:
         self._writer = CompletedStageWriter(
             cache_folder,
@@ -44,6 +51,14 @@ class ProcessingStageRunner:
         self._before_stage = before_stage or _skip_before_stage
         self._stage_order = stage_order
         self._completed_stages: list[CompletedStage] = []
+        self._progress = progress
+        self._total_stage_count = total_stage_count
+        self._video_order = video_order
+        self._video_count = video_count
+        self._video_relative_path = video_relative_path
+        self._work_unit_kind = work_unit_kind
+        self._progress_stage: ProcessingStage | None = None
+        self._cache_miss_observed = False
         if not stage_order or len(stage_order) != len(set(stage_order)):
             msg = "stage_orderには重複のない1件以上のStageが必要です"
             raise ValueError(msg)
@@ -74,7 +89,7 @@ class ProcessingStageRunner:
             semantic_input,
             artifact,
         )
-        self._record_completion(completed_stage)
+        self._record_completion(completed_stage, reused=False)
         return completed_stage
 
     def reuse(
@@ -98,9 +113,13 @@ class ProcessingStageRunner:
             semantic_input,
         )
         if artifact is None:
+            self._record_cache_miss()
             return None
         restored = restore(artifact)
-        self._record_completion(CompletedStage(stage=stage, fingerprint=fingerprint))
+        self._record_completion(
+            CompletedStage(stage=stage, fingerprint=fingerprint),
+            reused=True,
+        )
         return restored
 
     def complete_artifacts(
@@ -133,7 +152,7 @@ class ProcessingStageRunner:
         if bundle is None:
             msg = "確定直後のCompleted Stage artifactを検証できませんでした"
             raise RuntimeError(msg)
-        self._record_completion(completed_stage)
+        self._record_completion(completed_stage, reused=False)
         return bundle
 
     def reuse_bundle(
@@ -156,8 +175,12 @@ class ProcessingStageRunner:
             semantic_input,
         )
         if bundle is None:
+            self._record_cache_miss()
             return None
-        self._record_completion(CompletedStage(stage=stage, fingerprint=fingerprint))
+        self._record_completion(
+            CompletedStage(stage=stage, fingerprint=fingerprint),
+            reused=True,
+        )
         return bundle
 
     def _prepare_stage(
@@ -178,11 +201,13 @@ class ProcessingStageRunner:
             raise ValueError(msg)
         self._before_stage()
         upstream_fingerprints = self._select_upstream_fingerprints(upstream_stages)
-        return upstream_fingerprints, build_stage_fingerprint(
+        fingerprint = build_stage_fingerprint(
             stage,
             upstream_fingerprints,
             semantic_input,
         )
+        self._start_progress_stage(stage)
+        return upstream_fingerprints, fingerprint
 
     def _select_upstream_fingerprints(
         self,
@@ -210,10 +235,56 @@ class ProcessingStageRunner:
             if item.stage in selected
         )
 
-    def _record_completion(self, completed_stage: CompletedStage) -> None:
+    def _record_completion(
+        self,
+        completed_stage: CompletedStage,
+        *,
+        reused: bool,
+    ) -> None:
         """Stage完了をrun stateへ追加して通知する。"""
+        if self._progress is not None:
+            self._progress.cache_observed(
+                cache_hit_count=1 if reused else 0,
+                cache_miss_count=0 if reused else 1,
+                reuse_count=1 if reused else 0,
+                recompute_count=0 if reused else 1,
+                reason_code="cache_reused" if reused else "stage_recomputed",
+            )
+            self._progress.complete_stage()
+            self._progress_stage = None
+            self._cache_miss_observed = False
         self._completed_stages.append(completed_stage)
         self._observer.stage_completed(completed_stage)
+
+    def _start_progress_stage(self, stage: ProcessingStage) -> None:
+        if self._progress is None:
+            return
+        if self._progress_stage is stage:
+            return
+        if self._progress_stage is not None:
+            msg = "別のProcessing Stageがprogress上でactiveです"
+            raise RuntimeError(msg)
+        self._progress.start_stage(
+            stage,
+            stage_count=self._total_stage_count,
+            video_order=self._video_order,
+            video_count=self._video_count,
+            video_relative_path=self._video_relative_path,
+            work_unit_kind=self._work_unit_kind,
+        )
+        self._progress_stage = stage
+
+    def _record_cache_miss(self) -> None:
+        if self._progress is None or self._cache_miss_observed:
+            return
+        self._progress.cache_observed(
+            cache_hit_count=0,
+            cache_miss_count=1,
+            reuse_count=0,
+            recompute_count=0,
+            reason_code="cache_miss",
+        )
+        self._cache_miss_observed = True
 
 
 def _skip_before_stage() -> None:

--- a/src/video_selection/services/progress_stream_observer.py
+++ b/src/video_selection/services/progress_stream_observer.py
@@ -1,0 +1,41 @@
+"""Progress Eventをstderr互換streamへ描画するobserver。"""
+
+import sys
+from threading import Lock
+from typing import TextIO
+
+from ..models.completed_stage import CompletedStage
+from ..models.legacy_cache_cleanup_diagnostic import LegacyCacheCleanupDiagnostic
+from ..models.progress_event import ProgressEvent
+from .line_progress_renderer import LineProgressRenderer
+from .tty_progress_renderer import TtyProgressRenderer
+
+
+class ProgressStreamObserver:
+    """streamのTTY状態に対応するrendererを自動選択する。"""
+
+    def __init__(self, stream: TextIO | None = None) -> None:
+        self._stream = stream if stream is not None else sys.stderr
+        self._is_tty = self._stream.isatty()
+        self._renderer = (
+            TtyProgressRenderer() if self._is_tty else LineProgressRenderer()
+        )
+        self._lock = Lock()
+
+    def observe(self, event: ProgressEvent) -> None:
+        """一つのProgress Eventをatomicにstreamへ書く。"""
+        rendered = self._renderer.render(event)
+        if not self._is_tty:
+            rendered = f"{rendered}\n"
+        with self._lock:
+            self._stream.write(rendered)
+            self._stream.flush()
+
+    def stage_completed(self, _completed_stage: CompletedStage) -> None:
+        """legacy Stage callbackはProgress Eventへ統合するため描画しない。"""
+
+    def legacy_cache_cleaned(
+        self,
+        _diagnostic: LegacyCacheCleanupDiagnostic,
+    ) -> None:
+        """legacy cleanup callbackはProgress Eventへ統合するため描画しない。"""

--- a/src/video_selection/services/run_progress_tracker.py
+++ b/src/video_selection/services/run_progress_tracker.py
@@ -116,15 +116,20 @@ class RunProgressTracker:
     def record_work_sample(
         self,
         disposition: WorkDisposition,
-        duration_seconds: float,
+        duration_seconds: float | None = None,
     ) -> None:
         """active Comparable Work Seriesへ完了sampleを記録する。"""
         stage, work_unit_kind = self._active_work_series()
+        observed_duration = (
+            self._stage_elapsed() if duration_seconds is None else duration_seconds
+        )
+        if observed_duration == 0:
+            return
         self._eta_estimator.record_sample(
             stage,
             work_unit_kind,
             disposition,
-            duration_seconds,
+            observed_duration,
         )
 
     def external_work_started(self, reason_code: str) -> None:

--- a/src/video_selection/services/run_progress_tracker.py
+++ b/src/video_selection/services/run_progress_tracker.py
@@ -1,0 +1,296 @@
+"""runとProcessing StageのProgress Event lifecycle。"""
+
+import time
+from collections.abc import Callable
+
+from ..models.processing_stage import ProcessingStage
+from ..models.progress_event import (
+    EstimationState,
+    ProgressEvent,
+    ProgressEventKind,
+    ProgressSeverity,
+)
+from ..protocols.run_observer import RunObserver
+from .stage_eta_estimator import StageEtaEstimator, WorkDisposition
+
+MonotonicClock = Callable[[], float]
+
+
+class RunProgressTracker:
+    """一つのrunで直列なProcessing Stage eventを発行する。"""
+
+    def __init__(
+        self,
+        observer: RunObserver,
+        *,
+        clock: MonotonicClock = time.monotonic,
+    ) -> None:
+        self._observer = observer
+        self._clock = clock
+        self._state = "idle"
+        self._stage_index = 0
+        self._active_stage: ProcessingStage | None = None
+        self._stage_started_at: float | None = None
+        self._stage_count: int | None = None
+        self._video_order: int | None = None
+        self._video_count: int | None = None
+        self._video_relative_path: str | None = None
+        self._work_unit_kind: str | None = None
+        self._eta_estimator = StageEtaEstimator()
+
+    def start_run(self) -> None:
+        """runを開始して最初のeventを発行する。"""
+        if self._state != "idle":
+            msg = "runは一度だけ開始できます"
+            raise RuntimeError(msg)
+        self._state = "running"
+        self._observer.observe(
+            ProgressEvent(
+                kind="run_started",
+                severity="info",
+                reason_code="run_started",
+            )
+        )
+
+    def start_stage(
+        self,
+        stage: ProcessingStage,
+        *,
+        stage_count: int | None = None,
+        video_order: int | None = None,
+        video_count: int | None = None,
+        video_relative_path: str | None = None,
+        work_unit_kind: str | None = None,
+    ) -> None:
+        """次のatomicなProcessing Stageを開始する。"""
+        self._require_running_without_stage()
+        self._stage_index += 1
+        self._active_stage = stage
+        self._stage_started_at = self._clock()
+        self._stage_count = stage_count
+        self._video_order = video_order
+        self._video_count = video_count
+        self._video_relative_path = video_relative_path
+        self._work_unit_kind = work_unit_kind
+        self._observer.observe(
+            self._stage_event(
+                kind="stage_started",
+                reason_code="stage_started",
+                elapsed_seconds=0.0,
+            )
+        )
+
+    def progress(
+        self,
+        *,
+        processed_count: int | None = None,
+        total_count: int | None = None,
+        remaining_reuse_count: int | None = None,
+        remaining_recompute_count: int | None = None,
+    ) -> None:
+        """active Stageの観測可能な件数を通知する。"""
+        elapsed_seconds = self._stage_elapsed()
+        estimation_state: EstimationState = "unavailable"
+        eta_seconds: float | None = None
+        if self._work_unit_kind is not None:
+            stage, work_unit_kind = self._active_work_series()
+            estimation_state, eta_seconds = self._eta_estimator.estimate(
+                stage,
+                work_unit_kind,
+                remaining_reuse_count=remaining_reuse_count,
+                remaining_recompute_count=remaining_recompute_count,
+                stage_elapsed_seconds=elapsed_seconds,
+            )
+        self._observer.observe(
+            self._stage_event(
+                kind="progress",
+                reason_code="stage_progress",
+                elapsed_seconds=elapsed_seconds,
+                processed_count=processed_count,
+                total_count=total_count,
+                estimation_state=estimation_state,
+                eta_seconds=eta_seconds,
+            )
+        )
+
+    def record_work_sample(
+        self,
+        disposition: WorkDisposition,
+        duration_seconds: float,
+    ) -> None:
+        """active Comparable Work Seriesへ完了sampleを記録する。"""
+        stage, work_unit_kind = self._active_work_series()
+        self._eta_estimator.record_sample(
+            stage,
+            work_unit_kind,
+            disposition,
+            duration_seconds,
+        )
+
+    def external_work_started(self, reason_code: str) -> None:
+        """active Stage内のblocking external work開始を通知する。"""
+        self._observer.observe(
+            self._stage_event(
+                kind="external_work_started",
+                reason_code=reason_code,
+                elapsed_seconds=self._stage_elapsed(),
+            )
+        )
+
+    def heartbeat(self) -> None:
+        """active Stageが継続中であることを経過時間だけで通知する。"""
+        self._observer.observe(
+            self._stage_event(
+                kind="heartbeat",
+                reason_code="external_work_heartbeat",
+                elapsed_seconds=self._stage_elapsed(),
+            )
+        )
+
+    def cache_observed(
+        self,
+        *,
+        cache_hit_count: int,
+        cache_miss_count: int,
+        reuse_count: int,
+        recompute_count: int,
+        reason_code: str,
+    ) -> None:
+        """active Stageのcache lookupと実処理結果を通知する。"""
+        self._observer.observe(
+            self._stage_event(
+                kind="cache",
+                reason_code=reason_code,
+                elapsed_seconds=self._stage_elapsed(),
+                cache_hit_count=cache_hit_count,
+                cache_miss_count=cache_miss_count,
+                reuse_count=reuse_count,
+                recompute_count=recompute_count,
+            )
+        )
+
+    def complete_stage(self) -> None:
+        """active Stageを完了して次のStage開始を許可する。"""
+        event = self._stage_event(
+            kind="stage_completed",
+            reason_code="stage_completed",
+            elapsed_seconds=self._stage_elapsed(),
+        )
+        self._observer.observe(event)
+        self._clear_active_stage()
+
+    def complete_run(self) -> None:
+        """active Stageのないrunを正常完了する。"""
+        self._require_running_without_stage()
+        self._state = "terminal"
+        self._observer.observe(
+            ProgressEvent(
+                kind="run_completed",
+                severity="info",
+                reason_code="run_completed",
+            )
+        )
+
+    def fail_run(self, reason_code: str) -> None:
+        """runをoperation failureとして終了する。"""
+        self._terminate_run("run_failed", "error", reason_code)
+
+    def interrupt_run(self) -> None:
+        """runを利用者による中断として終了する。"""
+        self._terminate_run("run_interrupted", "warning", "user_interrupt")
+
+    def _stage_event(
+        self,
+        *,
+        kind: ProgressEventKind,
+        severity: ProgressSeverity = "info",
+        reason_code: str,
+        elapsed_seconds: float,
+        processed_count: int | None = None,
+        total_count: int | None = None,
+        cache_hit_count: int = 0,
+        cache_miss_count: int = 0,
+        reuse_count: int = 0,
+        recompute_count: int = 0,
+        estimation_state: EstimationState = "unavailable",
+        eta_seconds: float | None = None,
+    ) -> ProgressEvent:
+        if self._state != "running" or self._active_stage is None:
+            msg = "activeなProcessing Stageがありません"
+            raise RuntimeError(msg)
+        return ProgressEvent(
+            kind=kind,
+            severity=severity,
+            stage=self._active_stage,
+            stage_index=self._stage_index,
+            stage_count=self._stage_count,
+            video_order=self._video_order,
+            video_count=self._video_count,
+            video_relative_path=self._video_relative_path,
+            processed_count=processed_count,
+            total_count=total_count,
+            cache_hit_count=cache_hit_count,
+            cache_miss_count=cache_miss_count,
+            reuse_count=reuse_count,
+            recompute_count=recompute_count,
+            elapsed_seconds=elapsed_seconds,
+            eta_seconds=eta_seconds,
+            estimation_state=estimation_state,
+            work_unit_kind=self._work_unit_kind,
+            reason_code=reason_code,
+        )
+
+    def _terminate_run(
+        self,
+        kind: ProgressEventKind,
+        severity: ProgressSeverity,
+        reason_code: str,
+    ) -> None:
+        if self._state != "running":
+            msg = "runが開始されていません"
+            raise RuntimeError(msg)
+        if self._active_stage is None:
+            event = ProgressEvent(
+                kind=kind,
+                severity=severity,
+                reason_code=reason_code,
+            )
+        else:
+            event = self._stage_event(
+                kind=kind,
+                severity=severity,
+                reason_code=reason_code,
+                elapsed_seconds=self._stage_elapsed(),
+            )
+            self._clear_active_stage()
+        self._state = "terminal"
+        self._observer.observe(event)
+
+    def _stage_elapsed(self) -> float:
+        if self._stage_started_at is None:
+            msg = "activeなProcessing Stageがありません"
+            raise RuntimeError(msg)
+        return self._clock() - self._stage_started_at
+
+    def _active_work_series(self) -> tuple[ProcessingStage, str]:
+        if self._active_stage is None or self._work_unit_kind is None:
+            msg = "activeなComparable Work Seriesがありません"
+            raise RuntimeError(msg)
+        return self._active_stage, self._work_unit_kind
+
+    def _require_running_without_stage(self) -> None:
+        if self._state != "running":
+            msg = "runが開始されていません"
+            raise RuntimeError(msg)
+        if self._active_stage is not None:
+            msg = "Processing Stageは同時に一つだけ開始できます"
+            raise RuntimeError(msg)
+
+    def _clear_active_stage(self) -> None:
+        self._active_stage = None
+        self._stage_started_at = None
+        self._stage_count = None
+        self._video_order = None
+        self._video_count = None
+        self._video_relative_path = None
+        self._work_unit_kind = None

--- a/src/video_selection/services/stage_eta_estimator.py
+++ b/src/video_selection/services/stage_eta_estimator.py
@@ -1,0 +1,87 @@
+"""Comparable Work SeriesからStage ETAを求める。"""
+
+import math
+from statistics import fmean
+from typing import Literal
+
+from ..models.processing_stage import ProcessingStage
+from ..models.progress_event import EstimationState
+
+WorkDisposition = Literal["reuse", "recompute"]
+EtaEstimate = tuple[EstimationState, float | None]
+_MINIMUM_SAMPLE_COUNT = 5
+_MINIMUM_STAGE_SECONDS = 30.0
+_MAXIMUM_STABLE_SWING = 0.5
+
+
+class StageEtaEstimator:
+    """一回のrun内で比較可能なwork sampleだけを集計する。"""
+
+    def __init__(self) -> None:
+        self._samples: dict[
+            tuple[ProcessingStage, str, WorkDisposition],
+            list[float],
+        ] = {}
+
+    def record_sample(
+        self,
+        stage: ProcessingStage,
+        work_unit_kind: str,
+        disposition: WorkDisposition,
+        duration_seconds: float,
+    ) -> None:
+        """完了した一つのwork unitを現在のrunへ記録する。"""
+        if not work_unit_kind:
+            msg = "work unit kindが必要です"
+            raise ValueError(msg)
+        if not math.isfinite(duration_seconds) or duration_seconds <= 0:
+            msg = "work unit durationは0より大きい有限値である必要があります"
+            raise ValueError(msg)
+        key = (stage, work_unit_kind, disposition)
+        samples = self._samples.setdefault(key, [])
+        if len(samples) < _MINIMUM_SAMPLE_COUNT:
+            samples.append(duration_seconds)
+            return
+        previous_mean = fmean(samples)
+        candidate_samples = [*samples[1:], duration_seconds]
+        candidate_mean = fmean(candidate_samples)
+        if abs(candidate_mean - previous_mean) / previous_mean > _MAXIMUM_STABLE_SWING:
+            samples[:] = [duration_seconds]
+            return
+        samples[:] = candidate_samples
+
+    def estimate(
+        self,
+        stage: ProcessingStage,
+        work_unit_kind: str,
+        *,
+        remaining_reuse_count: int | None,
+        remaining_recompute_count: int | None,
+        stage_elapsed_seconds: float,
+    ) -> EtaEstimate:
+        """系列別の残件数が既知な場合だけStage ETAを返す。"""
+        if remaining_reuse_count is None or remaining_recompute_count is None:
+            return ("unavailable", None)
+        if remaining_reuse_count < 0 or remaining_recompute_count < 0:
+            msg = "remaining work countは0以上である必要があります"
+            raise ValueError(msg)
+        if stage_elapsed_seconds < _MINIMUM_STAGE_SECONDS:
+            return ("estimating", None)
+        remaining: tuple[tuple[WorkDisposition, int], ...] = (
+            ("reuse", remaining_reuse_count),
+            ("recompute", remaining_recompute_count),
+        )
+        if sum(count for _, count in remaining) == 0:
+            return ("unavailable", None)
+        eta_seconds = 0.0
+        for disposition, count in remaining:
+            if count == 0:
+                continue
+            samples = self._samples.get(
+                (stage, work_unit_kind, disposition),
+                [],
+            )
+            if len(samples) < _MINIMUM_SAMPLE_COUNT:
+                return ("estimating", None)
+            eta_seconds += fmean(samples) * count
+        return ("available", eta_seconds)

--- a/src/video_selection/services/tty_progress_renderer.py
+++ b/src/video_selection/services/tty_progress_renderer.py
@@ -1,0 +1,18 @@
+"""Progress EventのTTY更新renderer。"""
+
+from ..models.progress_event import ProgressEvent
+from .line_progress_renderer import LineProgressRenderer
+
+_TERMINAL_KINDS = {"run_completed", "run_failed", "run_interrupted"}
+
+
+class TtyProgressRenderer:
+    """Progress Eventを同じTTY行へ描画する。"""
+
+    def __init__(self) -> None:
+        self._line_renderer = LineProgressRenderer()
+
+    def render(self, event: ProgressEvent) -> str:
+        """行頭へ戻して描画し、run terminal eventだけ改行する。"""
+        suffix = "\x1b[K\n" if event.kind in _TERMINAL_KINDS else "\x1b[K"
+        return f"\r{self._line_renderer.render(event)}{suffix}"

--- a/src/video_selection/services/video_set_vision_processor.py
+++ b/src/video_selection/services/video_set_vision_processor.py
@@ -39,6 +39,8 @@ from ..vision.vision_contract import (
 )
 from .build_stage_fingerprint import build_stage_fingerprint
 from .completed_stage_writer import CompletedStageWriter
+from .external_work_monitor import ExternalWorkMonitor
+from .run_progress_tracker import RunProgressTracker
 from .snapshot_frame_candidates import snapshot_frame_candidates
 from .validate_video_set_snapshot import validate_video_set_snapshot
 from .vision_stage_artifacts import (
@@ -54,9 +56,19 @@ VisionStageValue = TypeVar("VisionStageValue")
 class VideoSetVisionProcessor:
     """VisionRuntimeとMoment単位atomic cacheを一つの深いmoduleに保つ。"""
 
-    def __init__(self, runtime: VisionRuntime, observer: RunObserver) -> None:
+    def __init__(
+        self,
+        runtime: VisionRuntime,
+        observer: RunObserver,
+        *,
+        progress: RunProgressTracker | None = None,
+    ) -> None:
         self._runtime = runtime
         self._observer = observer
+        self._progress = progress
+        self._external_work = (
+            ExternalWorkMonitor(progress) if progress is not None else None
+        )
 
     def process(
         self,
@@ -136,21 +148,29 @@ class VideoSetVisionProcessor:
             upstream_fingerprints,
             semantic_input,
         )
-        (catalog, diagnostics), completed = _execute_cached_vision_stage(
+        self._start_progress_stage(
+            ProcessingStage.BUILD_SCENE_CATALOG,
+            "scene_catalog",
+        )
+        (catalog, diagnostics), completed, reused = _execute_cached_vision_stage(
             writer=writer,
             stage=ProcessingStage.BUILD_SCENE_CATALOG,
             fingerprint=fingerprint,
             upstream_fingerprints=upstream_fingerprints,
             semantic_input=semantic_input,
-            generate=lambda: self._runtime.create_scene_catalog(
-                request,
-                model,
-                num_ctx=num_ctx,
+            generate=lambda: self._run_external(
+                lambda: self._runtime.create_scene_catalog(
+                    request,
+                    model,
+                    num_ctx=num_ctx,
+                ),
+                reason_code="scene_catalog_inference_started",
             ),
             serialize=lambda value: serialize_scene_catalog(*value),
             restore=restore_scene_catalog,
             artifact_label="Scene Catalog",
         )
+        self._complete_progress_stage(reused)
         self._observer.stage_completed(completed)
         return catalog, diagnostics, completed
 
@@ -180,17 +200,24 @@ class VideoSetVisionProcessor:
         )
 
         def generate() -> tuple[CandidateAnnotation, VisionInferenceDiagnostics]:
-            generated = self._runtime.annotate_candidate(
-                request,
-                catalog,
-                model,
-                num_ctx=num_ctx,
+            generated = self._run_external(
+                lambda: self._runtime.annotate_candidate(
+                    request,
+                    catalog,
+                    model,
+                    num_ctx=num_ctx,
+                ),
+                reason_code="candidate_annotation_inference_started",
             )
             annotation, diagnostics = generated
             _validate_runtime_annotation(annotation, request, catalog)
             return generated
 
-        (annotation, diagnostics), completed = _execute_cached_vision_stage(
+        self._start_progress_stage(
+            ProcessingStage.ANNOTATE_CANDIDATE,
+            "candidate",
+        )
+        (annotation, diagnostics), completed, reused = _execute_cached_vision_stage(
             writer=writer,
             stage=ProcessingStage.ANNOTATE_CANDIDATE,
             fingerprint=fingerprint,
@@ -205,8 +232,39 @@ class VideoSetVisionProcessor:
             ),
             artifact_label="Candidate Annotation",
         )
+        self._complete_progress_stage(reused)
         self._observer.stage_completed(completed)
         return annotation, diagnostics, completed
+
+    def _start_progress_stage(
+        self,
+        stage: ProcessingStage,
+        work_unit_kind: str,
+    ) -> None:
+        if self._progress is not None:
+            self._progress.start_stage(stage, work_unit_kind=work_unit_kind)
+
+    def _complete_progress_stage(self, reused: bool) -> None:
+        if self._progress is None:
+            return
+        self._progress.cache_observed(
+            cache_hit_count=1 if reused else 0,
+            cache_miss_count=0 if reused else 1,
+            reuse_count=1 if reused else 0,
+            recompute_count=0 if reused else 1,
+            reason_code="cache_reused" if reused else "stage_recomputed",
+        )
+        self._progress.complete_stage()
+
+    def _run_external(
+        self,
+        operation: Callable[[], VisionStageValue],
+        *,
+        reason_code: str,
+    ) -> VisionStageValue:
+        if self._external_work is None:
+            return operation()
+        return self._external_work.run(operation, reason_code=reason_code)
 
 
 def _execute_cached_vision_stage(
@@ -220,7 +278,7 @@ def _execute_cached_vision_stage(
     serialize: Callable[[VisionStageValue], dict[str, object]],
     restore: Callable[[Mapping[str, object]], VisionStageValue],
     artifact_label: str,
-) -> tuple[VisionStageValue, CompletedStage]:
+) -> tuple[VisionStageValue, CompletedStage, bool]:
     """同じfingerprintの生成と復元を一つのlock lifecycleで確定する。"""
     generated: VisionStageValue | None = None
 
@@ -237,7 +295,7 @@ def _execute_cached_vision_stage(
         produce,
     )
     if generated is not None:
-        return generated, completed
+        return generated, completed, False
     artifact = writer.read(
         stage,
         fingerprint,
@@ -246,7 +304,7 @@ def _execute_cached_vision_stage(
     )
     if artifact is None:
         raise RuntimeError(f"確定した{artifact_label} artifactを復元できません")
-    return restore(artifact), completed
+    return restore(artifact), completed, True
 
 
 def _validate_inputs(

--- a/src/video_selection/services/video_set_vision_processor.py
+++ b/src/video_selection/services/video_set_vision_processor.py
@@ -247,6 +247,7 @@ class VideoSetVisionProcessor:
     def _complete_progress_stage(self, reused: bool) -> None:
         if self._progress is None:
             return
+        self._progress.record_work_sample("reuse" if reused else "recompute")
         self._progress.cache_observed(
             cache_hit_count=1 if reused else 0,
             cache_miss_count=0 if reused else 1,

--- a/src/video_selection/services/video_stage_processor.py
+++ b/src/video_selection/services/video_stage_processor.py
@@ -36,6 +36,7 @@ from .refine_candidate_moments import (
     combine_refined_candidate_groups,
     iter_refined_candidate_groups,
 )
+from .run_progress_tracker import RunProgressTracker
 from .select_primary_video_stream import select_primary_video_stream
 from .validate_video_set_snapshot import (
     validate_video_set_snapshot,
@@ -67,14 +68,18 @@ class VideoStageProcessor:
         media_runtime: VideoStageMediaRuntime,
         speech_runtime: SpeechRuntime,
         observer: RunObserver,
+        *,
+        progress: RunProgressTracker | None = None,
     ) -> None:
         self._media_runtime = media_runtime
         self._context_processor = ContextStageProcessor(
             media_runtime,
             speech_runtime,
             observer,
+            progress=progress,
         )
         self._observer = observer
+        self._progress = progress
 
     def process(
         self,
@@ -85,11 +90,12 @@ class VideoStageProcessor:
         validate_video_set_snapshot(video_set)
         runtime_identity = self._media_runtime.preflight()
         results: list[VideoStageResult] = []
-        for source in video_set.sources:
+        for video_order, source in enumerate(video_set.sources, start=1):
             results.append(
                 self._process_source(
                     video_set,
                     source,
+                    video_order,
                     configuration,
                     runtime_identity,
                 )
@@ -100,6 +106,7 @@ class VideoStageProcessor:
         self,
         video_set: VideoSet,
         source: VideoSource,
+        video_order: int,
         configuration: EffectiveConfiguration,
         runtime_identity: MediaRuntimeIdentity,
     ) -> VideoStageResult:
@@ -114,6 +121,11 @@ class VideoStageProcessor:
             subject_fingerprint=source.fingerprint,
             before_stage=lambda: validate_video_source_snapshot(video_set, source),
             stage_order=VIDEO_STAGE_ORDER,
+            progress=self._progress,
+            video_order=video_order,
+            video_count=len(video_set.sources),
+            video_relative_path=source.relative_path,
+            work_unit_kind="video",
         )
         scan_input = _scan_semantic_input(
             source,

--- a/src/video_selection/speech/faster_whisper_speech_runtime.py
+++ b/src/video_selection/speech/faster_whisper_speech_runtime.py
@@ -5,6 +5,7 @@ import json
 import math
 from collections.abc import Callable, Iterable
 from decimal import ROUND_HALF_EVEN, Decimal
+from functools import partial
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import cast
@@ -18,6 +19,7 @@ from ..models.speech_recognition_result import SpeechRecognitionResult
 from ..models.speech_segment import SpeechSegment
 from ..models.speech_word import SpeechWord
 from ..protocols.faster_whisper_model import FasterWhisperModel
+from ..services.gpu_work_coordinator import GpuWorkCoordinator
 
 FasterWhisperModelLoader = Callable[
     [Path, str, str, bool],
@@ -41,10 +43,12 @@ class FasterWhisperSpeechRuntime:
         *,
         runtime_identity: str,
         resolved_model_identity: str,
+        gpu_coordinator: GpuWorkCoordinator | None = None,
     ) -> None:
         self._model = model
         self._runtime_identity = runtime_identity
         self._resolved_model_identity = resolved_model_identity
+        self._gpu_coordinator = gpu_coordinator
 
     @classmethod
     def load_local(
@@ -55,6 +59,7 @@ class FasterWhisperSpeechRuntime:
         device: str,
         compute_type: str,
         model_loader: FasterWhisperModelLoader | None = None,
+        gpu_coordinator: GpuWorkCoordinator | None = None,
     ) -> "FasterWhisperSpeechRuntime":
         """ModelRuntimeが解決したlocal artifactだけをloadして構築する。"""
         if not model_artifact.is_dir():
@@ -66,6 +71,7 @@ class FasterWhisperSpeechRuntime:
             model,
             runtime_identity=_build_runtime_identity(device),
             resolved_model_identity=resolved_model_identity,
+            gpu_coordinator=gpu_coordinator,
         )
 
     @property
@@ -87,6 +93,27 @@ class FasterWhisperSpeechRuntime:
         beam_size: int,
     ) -> SpeechRecognitionResult:
         """mono s16le PCMをbackend非依存のsample timestampへ変換する。"""
+        operation = partial(
+            self._transcribe,
+            chunk,
+            language=language,
+            vad_filter=vad_filter,
+            beam_size=beam_size,
+        )
+
+        if self._gpu_coordinator is None:
+            return operation()
+        return self._gpu_coordinator.run("speech_to_text", operation)
+
+    def _transcribe(
+        self,
+        chunk: PcmAudioChunk,
+        *,
+        language: str,
+        vad_filter: bool,
+        beam_size: int,
+    ) -> SpeechRecognitionResult:
+        """model呼び出しとlazy segment変換を一つのGPU workとして実行する。"""
         waveform = np.frombuffer(chunk.pcm_bytes, dtype="<i2").astype(np.float32)
         waveform /= 32768.0
         segments, info = self._model.transcribe(

--- a/src/video_selection/vision/ollama_vision_runtime.py
+++ b/src/video_selection/vision/ollama_vision_runtime.py
@@ -7,6 +7,7 @@ import re
 import time
 from collections.abc import Callable, Mapping
 from fractions import Fraction
+from functools import partial
 from typing import Literal, TypeVar, cast
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
@@ -42,6 +43,7 @@ from ..models.scene_catalog_request import SceneCatalogRequest
 from ..models.vision_inference_diagnostics import VisionInferenceDiagnostics
 from ..models.vision_runtime_error import VisionRuntimeError
 from ..models.vision_runtime_failure_reason import VisionRuntimeFailureReason
+from ..services.gpu_work_coordinator import GpuWorkCoordinator
 from ..utils.http_retry_delay import http_retry_delay
 from .vision_contract import (
     CANDIDATE_ANNOTATION_PROMPT_VERSION,
@@ -103,6 +105,7 @@ class OllamaVisionRuntime:
         requester: JsonRequester | None = None,
         sleeper: Sleeper = time.sleep,
         model_state_resolver: ModelStateResolver | None = None,
+        gpu_coordinator: GpuWorkCoordinator | None = None,
     ) -> None:
         if not host.strip() or timeout_seconds <= 0:
             raise ValueError("Ollama VisionRuntimeの接続設定が不正です")
@@ -118,6 +121,7 @@ class OllamaVisionRuntime:
         self._model_state_resolver = (
             model_state_resolver or self._resolve_current_model_state
         )
+        self._gpu_coordinator = gpu_coordinator
 
     def create_scene_catalog(
         self,
@@ -258,11 +262,17 @@ class OllamaVisionRuntime:
     def _request(self, payload: Mapping[str, object]) -> Mapping[str, object]:
         """transport detailをstable failureへ変換する。"""
         try:
-            response = self._requester(
+            request = partial(
+                self._requester,
                 "POST",
                 f"{self._host}/api/chat",
                 payload,
                 self._timeout_seconds,
+            )
+            response = (
+                request()
+                if self._gpu_coordinator is None
+                else self._gpu_coordinator.run("vision_inference", request)
             )
         except HTTPError as error:
             retry_after = (

--- a/tests/video_selection/application/test_internal_run_controller.py
+++ b/tests/video_selection/application/test_internal_run_controller.py
@@ -1,0 +1,500 @@
+from pathlib import Path
+
+import pytest
+
+from src.video_selection.application.internal_run_controller import (
+    InternalRunController,
+)
+from src.video_selection.configuration.configuration_error import ConfigurationError
+from src.video_selection.models.context_stage_error import ContextStageError
+from src.video_selection.models.context_stage_failure_reason import (
+    ContextStageFailureReason,
+)
+from src.video_selection.models.media_runtime_error import MediaRuntimeError
+from src.video_selection.models.media_runtime_failure_reason import (
+    MediaRuntimeFailureReason,
+)
+from src.video_selection.models.model_role import ModelRole
+from src.video_selection.models.model_runtime_error import ModelRuntimeError
+from src.video_selection.models.model_runtime_failure_reason import (
+    ModelRuntimeFailureReason,
+)
+from src.video_selection.models.processing_stage import ProcessingStage
+from src.video_selection.models.run_failure import RunFailure
+from src.video_selection.models.vision_runtime_error import VisionRuntimeError
+from src.video_selection.models.vision_runtime_failure_reason import (
+    VisionRuntimeFailureReason,
+)
+from src.video_selection.services.processing_stage_runner import (
+    ProcessingStageRunner,
+)
+from src.video_selection.services.run_progress_tracker import RunProgressTracker
+from tests.video_selection.fakes.recording_run_observer import RecordingRunObserver
+
+
+def test_internal_run_controller_maps_typed_operation_failure() -> None:
+    """reason-coded operation errorが安全なexit 1結果へ変換されること。
+
+    Arrange:
+        - raw absolute pathをmessageに含むMedia Runtime errorが用意される
+    Act:
+        - internal run controllerから失敗するoperationが実行される
+    Assert:
+        - stable reasonだけのRun Failureとrun_failed eventが返されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    tracker = RunProgressTracker(observer)
+    controller = InternalRunController(tracker)
+    error = MediaRuntimeError(
+        MediaRuntimeFailureReason.DECODER_FAILURE,
+        "/private/video.mkv: ffmpeg raw output",
+    )
+
+    def fail_operation() -> object:
+        raise error
+
+    # Act
+    exit_code, result = controller.execute(fail_operation)
+
+    # Assert
+    assert isinstance(result, RunFailure)
+    assert (
+        exit_code,
+        result.reason_code,
+        result.remediation_code,
+        result.resume_guidance,
+        result.cause,
+        tuple(event.kind for event in observer.progress_events),
+        tuple(event.reason_code for event in observer.progress_events),
+    ) == (
+        1,
+        "decoder_failure",
+        "check_media_runtime",
+        "completed_stages_reusable",
+        error,
+        ("run_started", "run_failed"),
+        ("run_started", "decoder_failure"),
+    )
+    assert "/private" not in repr(result)
+
+
+def test_internal_run_controller_maps_keyboard_interrupt() -> None:
+    """active Stage中のCtrl+Cがrun_interruptedとexit 130へ変換されること。
+
+    Arrange:
+        - Processing Stage開始後にKeyboardInterruptとなるoperationが用意される
+    Act:
+        - internal run controllerからoperationが実行される
+    Assert:
+        - active Stage付きuser_interrupt eventと安全なRun Failureが返されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    tracker = RunProgressTracker(observer, clock=lambda: 10.0)
+    controller = InternalRunController(tracker)
+
+    def interrupt_operation() -> object:
+        tracker.start_stage(
+            ProcessingStage.SCAN_VIDEO,
+            video_order=2,
+            video_count=3,
+            video_relative_path="chapter-02.mkv",
+            work_unit_kind="video",
+        )
+        raise KeyboardInterrupt
+
+    # Act
+    exit_code, result = controller.execute(interrupt_operation)
+
+    # Assert
+    assert isinstance(result, RunFailure)
+    terminal = observer.progress_events[-1]
+    assert (
+        exit_code,
+        result.reason_code,
+        result.resume_guidance,
+        terminal.kind,
+        terminal.reason_code,
+        terminal.stage,
+        terminal.stage_index,
+        terminal.video_relative_path,
+    ) == (
+        130,
+        "user_interrupt",
+        "completed_stages_reusable",
+        "run_interrupted",
+        "user_interrupt",
+        ProcessingStage.SCAN_VIDEO,
+        1,
+        "chapter-02.mkv",
+    )
+
+
+def test_internal_run_controller_maps_configuration_error() -> None:
+    """設定errorがraw messageを使わずexit 2へ変換されること。
+
+    Arrange:
+        - secret相当文字列をmessageに含むConfiguration Errorが用意される
+    Act:
+        - internal run controllerから失敗するoperationが実行される
+    Assert:
+        - stable reasonとrun_not_started guidanceだけが返されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    tracker = RunProgressTracker(observer)
+    controller = InternalRunController(tracker)
+    error = ConfigurationError(
+        "invalid_configuration",
+        "token=/private/secret",
+    )
+
+    def fail_configuration() -> object:
+        raise error
+
+    # Act
+    exit_code, result = controller.execute(fail_configuration)
+
+    # Assert
+    assert isinstance(result, RunFailure)
+    assert (
+        exit_code,
+        result.reason_code,
+        result.remediation_code,
+        result.resume_guidance,
+        observer.progress_events[-1].kind,
+    ) == (
+        2,
+        "invalid_configuration",
+        "fix_configuration",
+        "run_not_started",
+        "run_failed",
+    )
+    assert "secret" not in repr(result)
+
+
+def test_internal_run_controller_hides_unexpected_error_detail() -> None:
+    """未知例外がraw detailを出さずinternal_errorへ変換されること。
+
+    Arrange:
+        - absolute pathとraw textを含む未知のRuntimeErrorが用意される
+    Act:
+        - internal run controllerから失敗するoperationが実行される
+    Assert:
+        - internal_errorと安全なterminal eventだけが返されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    tracker = RunProgressTracker(observer)
+    controller = InternalRunController(tracker)
+    error = RuntimeError("/private/cache: raw transcript")
+
+    def fail_unexpectedly() -> object:
+        raise error
+
+    # Act
+    exit_code, result = controller.execute(fail_unexpectedly)
+
+    # Assert
+    assert isinstance(result, RunFailure)
+    assert (
+        exit_code,
+        result.reason_code,
+        result.remediation_code,
+        result.cause,
+        observer.progress_events[-1].reason_code,
+    ) == (
+        1,
+        "internal_error",
+        "report_internal_error",
+        error,
+        "internal_error",
+    )
+    assert "private" not in repr(result)
+
+
+def test_internal_run_controller_rejects_unsafe_typed_error_metadata() -> None:
+    """typed errorに混入したraw metadataがinternal errorへ安全化されること。
+
+    Arrange:
+        - absolute pathとraw responseをvalidation codeに持つVision errorが用意される
+    Act:
+        - internal run controllerから失敗するoperationが実行される
+    Assert:
+        - raw値を捨てたinternal_errorだけがeventとRun Failureへ返されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    tracker = RunProgressTracker(observer)
+    controller = InternalRunController(tracker)
+    error = VisionRuntimeError(
+        VisionRuntimeFailureReason.SCHEMA_INVALID,
+        validation_code="/private/model: raw response",
+    )
+
+    def fail_with_unsafe_metadata() -> object:
+        raise error
+
+    # Act
+    exit_code, result = controller.execute(fail_with_unsafe_metadata)
+
+    # Assert
+    assert isinstance(result, RunFailure)
+    assert (
+        exit_code,
+        result.reason_code,
+        result.observed_values,
+        result.cause,
+        observer.progress_events[-1].reason_code,
+    ) == (1, "internal_error", (), error, "internal_error")
+    assert "private" not in repr(result)
+
+
+def test_internal_run_controller_normalizes_unclosed_stage_on_success() -> None:
+    """active Stageを残した正常returnがinternal errorへ変換されること。
+
+    Arrange:
+        - Stage開始後に完了通知せず値を返すoperationが用意される
+    Act:
+        - internal run controllerがrun完了を試行する
+    Assert:
+        - lifecycle例外が漏れずactive Stage付きrun_failedへ変換されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    tracker = RunProgressTracker(observer)
+    controller = InternalRunController(tracker)
+
+    def leave_stage_active() -> str:
+        tracker.start_stage(
+            ProcessingStage.SELECT_IMAGES,
+            work_unit_kind="candidate",
+        )
+        return "incomplete"
+
+    # Act
+    exit_code, result = controller.execute(leave_stage_active)
+
+    # Assert
+    assert isinstance(result, RunFailure)
+    terminal = observer.progress_events[-1]
+    assert (
+        exit_code,
+        result.reason_code,
+        terminal.kind,
+        terminal.reason_code,
+        terminal.stage,
+    ) == (
+        1,
+        "internal_error",
+        "run_failed",
+        "internal_error",
+        ProcessingStage.SELECT_IMAGES,
+    )
+
+
+@pytest.mark.parametrize(
+    ("error", "reason_code", "remediation_code", "observed_values"),
+    [
+        (
+            ModelRuntimeError(
+                ModelRuntimeFailureReason.MODEL_NOT_AVAILABLE,
+                ModelRole.CANDIDATE_ANNOTATION,
+            ),
+            "model_not_available",
+            "check_model_runtime",
+            (("model_role", "candidate_annotation"),),
+        ),
+        (
+            VisionRuntimeError(
+                VisionRuntimeFailureReason.SCHEMA_INVALID,
+                validation_code="required_field_missing",
+                attempt_count=2,
+            ),
+            "schema_invalid",
+            "check_vision_runtime",
+            (("attempt_count", 2), ("validation_code", "required_field_missing")),
+        ),
+        (
+            ContextStageError(ContextStageFailureReason.TIMESTAMP_DRIFT),
+            "timestamp_drift",
+            "check_context_source",
+            (),
+        ),
+    ],
+)
+def test_internal_run_controller_preserves_typed_runtime_reason(
+    error: Exception,
+    reason_code: str,
+    remediation_code: str,
+    observed_values: tuple[tuple[str, str | int], ...],
+) -> None:
+    """各typed runtime errorのstable reasonと安全な観測値が保持されること。
+
+    Arrange:
+        - Model、Vision、Contextいずれかのtyped errorが用意される
+    Act:
+        - internal run controllerから失敗するoperationが実行される
+    Assert:
+        - runtime境界固有のreason、remediation、安全な観測値が返されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    tracker = RunProgressTracker(observer)
+    controller = InternalRunController(tracker)
+
+    def fail_runtime() -> object:
+        raise error
+
+    # Act
+    exit_code, result = controller.execute(fail_runtime)
+
+    # Assert
+    assert isinstance(result, RunFailure)
+    assert (
+        exit_code,
+        result.reason_code,
+        result.remediation_code,
+        result.observed_values,
+        result.cause,
+    ) == (
+        1,
+        reason_code,
+        remediation_code,
+        observed_values,
+        error,
+    )
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_exit_code"),
+    [
+        (RuntimeError("/private/raw operation failure"), 1),
+        (KeyboardInterrupt(), 130),
+    ],
+)
+def test_rerun_reuses_only_completed_stages_after_terminal_failure(
+    tmp_path: Path,
+    failure: BaseException,
+    expected_exit_code: int,
+) -> None:
+    """運用errorまたはCtrl+C後にCompleted Stageだけが再利用されること。
+
+    Arrange:
+        - 最初のStage完了後、次Stage途中で終了するrunが用意される
+    Act:
+        - 同じcacheとsemantic inputで新しいrunが実行される
+    Assert:
+        - 完了済みStageだけが再利用され、未完了Stageが再計算されること
+    """
+    # Arrange
+    cache_folder = tmp_path / "cache"
+    subject_fingerprint = "a" * 64
+    stage_order = (
+        ProcessingStage.DISCOVER_VIDEO_SET,
+        ProcessingStage.RESOLVE_MODELS,
+    )
+    recomputed_stages: list[ProcessingStage] = []
+    first_observer = RecordingRunObserver()
+    first_progress = RunProgressTracker(first_observer)
+    first_controller = InternalRunController(first_progress)
+
+    def fail_during_second_stage() -> str:
+        runner = ProcessingStageRunner(
+            cache_folder,
+            first_observer,
+            subject_namespace="video-sets",
+            subject_fingerprint=subject_fingerprint,
+            stage_order=stage_order,
+            progress=first_progress,
+        )
+        assert (
+            runner.reuse(
+                ProcessingStage.DISCOVER_VIDEO_SET,
+                {"input": "same"},
+                lambda artifact: artifact["value"],
+            )
+            is None
+        )
+        recomputed_stages.append(ProcessingStage.DISCOVER_VIDEO_SET)
+        runner.complete(
+            ProcessingStage.DISCOVER_VIDEO_SET,
+            {"input": "same"},
+            {"value": "completed"},
+        )
+        assert (
+            runner.reuse(
+                ProcessingStage.RESOLVE_MODELS,
+                {"model": "same"},
+                lambda artifact: artifact["value"],
+            )
+            is None
+        )
+        raise failure
+
+    # Act
+    first_exit_code, first_result = first_controller.execute(fail_during_second_stage)
+    second_observer = RecordingRunObserver()
+    second_progress = RunProgressTracker(second_observer)
+    second_controller = InternalRunController(second_progress)
+
+    def resume() -> str:
+        runner = ProcessingStageRunner(
+            cache_folder,
+            second_observer,
+            subject_namespace="video-sets",
+            subject_fingerprint=subject_fingerprint,
+            stage_order=stage_order,
+            progress=second_progress,
+        )
+        restored = runner.reuse(
+            ProcessingStage.DISCOVER_VIDEO_SET,
+            {"input": "same"},
+            lambda artifact: artifact["value"],
+        )
+        if restored is None:
+            recomputed_stages.append(ProcessingStage.DISCOVER_VIDEO_SET)
+        assert (
+            runner.reuse(
+                ProcessingStage.RESOLVE_MODELS,
+                {"model": "same"},
+                lambda artifact: artifact["value"],
+            )
+            is None
+        )
+        recomputed_stages.append(ProcessingStage.RESOLVE_MODELS)
+        runner.complete(
+            ProcessingStage.RESOLVE_MODELS,
+            {"model": "same"},
+            {"value": "resolved"},
+        )
+        assert restored == "completed"
+        return "resumed"
+
+    second_exit_code, second_result = second_controller.execute(resume)
+
+    # Assert
+    assert isinstance(first_result, RunFailure)
+    assert (
+        first_exit_code,
+        second_exit_code,
+        second_result,
+        recomputed_stages,
+        tuple(
+            event.reason_code
+            for event in second_observer.progress_events
+            if event.kind == "cache"
+        ),
+        second_observer.progress_events[-1].kind,
+    ) == (
+        expected_exit_code,
+        0,
+        "resumed",
+        [
+            ProcessingStage.DISCOVER_VIDEO_SET,
+            ProcessingStage.RESOLVE_MODELS,
+        ],
+        ("cache_reused", "cache_miss", "stage_recomputed"),
+        "run_completed",
+    )

--- a/tests/video_selection/application/test_internal_run_controller.py
+++ b/tests/video_selection/application/test_internal_run_controller.py
@@ -174,6 +174,85 @@ def test_internal_run_controller_maps_configuration_error() -> None:
     assert "secret" not in repr(result)
 
 
+def test_internal_run_controller_normalizes_configuration_reason_code() -> None:
+    """設定層の大文字reason codeがstable codeへ正規化されること。
+
+    Arrange:
+        - 実設定層と同じ大文字reason codeのConfiguration Errorが用意される
+    Act:
+        - internal run controllerから失敗するoperationが実行される
+    Assert:
+        - 小文字reason codeを持つexit 2のRun Failureが返されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    tracker = RunProgressTracker(observer)
+    controller = InternalRunController(tracker)
+    error = ConfigurationError(
+        "CONFIG_INVALID_TYPE",
+        "video_input_folderはpathである必要があります",
+    )
+
+    def fail_configuration() -> object:
+        raise error
+
+    # Act
+    exit_code, result = controller.execute(fail_configuration)
+
+    # Assert
+    assert isinstance(result, RunFailure)
+    assert (
+        exit_code,
+        result.reason_code,
+        result.remediation_code,
+        result.resume_guidance,
+        observer.progress_events[-1].reason_code,
+    ) == (
+        2,
+        "config_invalid_type",
+        "fix_configuration",
+        "run_not_started",
+        "config_invalid_type",
+    )
+
+
+def test_internal_run_controller_keeps_runtime_value_error_operational() -> None:
+    """実行中のValueErrorがusage errorへ誤分類されないこと。
+
+    Arrange:
+        - snapshot変更を表すplain ValueErrorが用意される
+    Act:
+        - internal run controllerから失敗するoperationが実行される
+    Assert:
+        - internal operation failureとしてexit 1が返されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    tracker = RunProgressTracker(observer)
+    controller = InternalRunController(tracker)
+    error = ValueError("Video Set snapshotがfingerprint計算中に変更されました")
+
+    def fail_during_snapshot() -> object:
+        raise error
+
+    # Act
+    exit_code, result = controller.execute(fail_during_snapshot)
+
+    # Assert
+    assert isinstance(result, RunFailure)
+    assert (
+        exit_code,
+        result.reason_code,
+        result.remediation_code,
+        result.resume_guidance,
+    ) == (
+        1,
+        "internal_error",
+        "report_internal_error",
+        "completed_stages_reusable",
+    )
+
+
 def test_internal_run_controller_hides_unexpected_error_detail() -> None:
     """未知例外がraw detailを出さずinternal_errorへ変換されること。
 

--- a/tests/video_selection/application/test_video_selection_application.py
+++ b/tests/video_selection/application/test_video_selection_application.py
@@ -30,6 +30,7 @@ from src.video_selection.models.processing_stage import (
     ProcessingStage,
 )
 from src.video_selection.models.resolved_models import ResolvedModels
+from src.video_selection.models.run_failure import RunFailure
 from src.video_selection.models.run_outcome import RunOutcome
 from src.video_selection.models.run_status import RunStatus
 from src.video_selection.models.selected_image import SelectedImage
@@ -304,6 +305,72 @@ def test_application_omits_unknown_total_when_nested_stages_expand_run(
         0,
         tuple((index, None) for index in range(1, 8)),
         "run_completed",
+    )
+
+
+@pytest.mark.parametrize(
+    ("invalid_input", "expected_reason_code"),
+    (
+        ("missing_input", "video_input_folder_not_found"),
+        ("empty_input", "video_input_folder_empty"),
+        ("duplicate_input", "duplicate_video"),
+        ("invalid_output", "output_folder_invalid"),
+    ),
+)
+def test_internal_controller_maps_preflight_path_failures_to_usage_result(
+    tmp_path: Path,
+    invalid_input: str,
+    expected_reason_code: str,
+) -> None:
+    """実行前に修正できる入力・出力不備がexit 2へ分類されること。
+
+    Arrange:
+        - 不存在・動画なし・重複入力、または非空Output Folderが用意される
+    Act:
+        - Internal Run Controllerからapplicationが実行される
+    Assert:
+        - run未開始相当の安全なusage failureが返されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    output_folder = tmp_path / "output"
+    if invalid_input != "missing_input":
+        input_folder.mkdir()
+    if invalid_input == "duplicate_input":
+        (input_folder / "chapter-01.mp4").write_bytes(b"duplicate")
+        (input_folder / "chapter-02.mp4").write_bytes(b"duplicate")
+    if invalid_input == "invalid_output":
+        (input_folder / "chapter-01.mp4").write_bytes(b"video-01")
+        output_folder.mkdir()
+        (output_folder / "keep.txt").write_text("keep", encoding="utf-8")
+    observer = RecordingRunObserver()
+    progress = RunProgressTracker(observer)
+    application = _successful_application(observer)
+    configuration = EffectiveConfiguration(
+        video_input_folder=input_folder,
+        output_folder=output_folder,
+        image_count=1,
+    )
+
+    # Act
+    exit_code, result = InternalRunController(progress).execute(
+        lambda: application.run(configuration)
+    )
+
+    # Assert
+    assert isinstance(result, RunFailure)
+    assert (
+        exit_code,
+        result.reason_code,
+        result.remediation_code,
+        result.resume_guidance,
+        tuple(event.kind for event in observer.progress_events),
+    ) == (
+        2,
+        expected_reason_code,
+        "fix_configuration",
+        "run_not_started",
+        ("run_started", "run_failed"),
     )
 
 

--- a/tests/video_selection/application/test_video_selection_application.py
+++ b/tests/video_selection/application/test_video_selection_application.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 import pytest
 
+from src.video_selection.application.internal_run_controller import (
+    InternalRunController,
+)
 from src.video_selection.application.video_selection_application import (
     VideoSelectionApplication,
 )
@@ -27,12 +30,14 @@ from src.video_selection.models.processing_stage import (
     ProcessingStage,
 )
 from src.video_selection.models.resolved_models import ResolvedModels
+from src.video_selection.models.run_outcome import RunOutcome
 from src.video_selection.models.run_status import RunStatus
 from src.video_selection.models.selected_image import SelectedImage
 from src.video_selection.models.video_set import VideoSet
 from src.video_selection.services.atomic_output_publisher import AtomicOutputPublisher
 from src.video_selection.services.input_folder_lock import InputFolderLock
 from src.video_selection.services.prepared_output import PreparedOutput
+from src.video_selection.services.run_progress_tracker import RunProgressTracker
 from tests.video_selection.fakes.failing_vision_runtime import FailingVisionRuntime
 from tests.video_selection.fakes.fake_context_collector import FakeContextCollector
 from tests.video_selection.fakes.fake_media_runtime import FakeMediaRuntime
@@ -168,6 +173,138 @@ def test_run_publishes_normalized_fake_result_atomically(tmp_path: Path) -> None
         )
     )
     assert len(manifests) == len(VIDEO_SET_STAGE_ORDER)
+
+
+def test_internal_controller_emits_application_stage_events(tmp_path: Path) -> None:
+    """internal application runが全Stageをtyped eventとして通知すること。
+
+    Arrange:
+        - 共有observer、Progress Tracker、fake applicationが用意される
+    Act:
+        - Internal Run Controllerから成功runが実行される
+    Assert:
+        - 全Stageの開始・完了とrun terminalが表示文字列なしで通知されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    (input_folder / "chapter-01.mp4").write_bytes(b"video-01")
+    candidate = FrameCandidate(identifier="frame-001", image_bytes=b"image")
+    observer = RecordingRunObserver()
+    progress = RunProgressTracker(observer, clock=lambda: 10.0)
+    application = VideoSelectionApplication(
+        media_runtime=FakeMediaRuntime((candidate,)),
+        speech_runtime=FakeContextCollector(()),
+        model_runtime=FakeModelRuntime("model-sha-001"),
+        vision_runtime=FakeVisionRuntime(
+            (CandidateAnnotation(candidate=candidate, summary="summary"),)
+        ),
+        observer=observer,
+        progress=progress,
+    )
+    configuration = EffectiveConfiguration(
+        video_input_folder=input_folder,
+        output_folder=tmp_path / "output",
+        image_count=1,
+    )
+
+    # Act
+    exit_code, result = InternalRunController(progress).execute(
+        lambda: application.run(configuration)
+    )
+
+    # Assert
+    started = tuple(
+        event.stage
+        for event in observer.progress_events
+        if event.kind == "stage_started"
+    )
+    completed = tuple(
+        event.stage
+        for event in observer.progress_events
+        if event.kind == "stage_completed"
+    )
+    assert isinstance(result, RunOutcome)
+    assert (
+        exit_code,
+        result.status,
+        observer.progress_events[0].kind,
+        observer.progress_events[-1].kind,
+        started,
+        completed,
+    ) == (
+        0,
+        RunStatus.COMPLETED,
+        "run_started",
+        "run_completed",
+        VIDEO_SET_STAGE_ORDER,
+        VIDEO_SET_STAGE_ORDER,
+    )
+
+
+def test_application_omits_unknown_total_when_nested_stages_expand_run(
+    tmp_path: Path,
+) -> None:
+    """内部runtimeがStageを追加するrunで根拠のない総Stage数が省略されること。
+
+    Arrange:
+        - candidate抽出中にatomic Video Stageを通知するruntimeが用意される
+    Act:
+        - 同じProgress Trackerでapplication全体が実行される
+    Assert:
+        - Stage番号は単調増加し、未確定の総Stage数なしでrunが完了すること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    (input_folder / "chapter-01.mp4").write_bytes(b"video-01")
+    candidate = FrameCandidate(identifier="frame-001", image_bytes=b"image")
+    observer = RecordingRunObserver()
+    progress = RunProgressTracker(observer, clock=lambda: 10.0)
+
+    def emit_nested_video_stage() -> None:
+        progress.start_stage(
+            ProcessingStage.SCAN_VIDEO,
+            work_unit_kind="video",
+        )
+        progress.complete_stage()
+
+    application = VideoSelectionApplication(
+        media_runtime=FakeMediaRuntime(
+            (candidate,),
+            on_extract_candidates=emit_nested_video_stage,
+        ),
+        speech_runtime=FakeContextCollector(()),
+        model_runtime=FakeModelRuntime("model-sha-001"),
+        vision_runtime=FakeVisionRuntime(
+            (CandidateAnnotation(candidate=candidate, summary="summary"),)
+        ),
+        observer=observer,
+        progress=progress,
+    )
+    configuration = EffectiveConfiguration(
+        video_input_folder=input_folder,
+        output_folder=tmp_path / "output",
+        image_count=1,
+    )
+
+    # Act
+    exit_code, result = InternalRunController(progress).execute(
+        lambda: application.run(configuration)
+    )
+
+    # Assert
+    started = tuple(
+        (event.stage_index, event.stage_count)
+        for event in observer.progress_events
+        if event.kind == "stage_started"
+    )
+    assert isinstance(result, RunOutcome)
+    assert (exit_code, started, observer.progress_events[-1].kind) == (
+        0,
+        tuple((index, None) for index in range(1, 8)),
+        "run_completed",
+    )
 
 
 def test_speech_model_is_frozen_before_context_collection(tmp_path: Path) -> None:

--- a/tests/video_selection/fakes/fake_media_runtime.py
+++ b/tests/video_selection/fakes/fake_media_runtime.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 from src.video_selection.models.frame_candidate import FrameCandidate
 from src.video_selection.models.video_set import VideoSet
 
@@ -5,8 +7,14 @@ from src.video_selection.models.video_set import VideoSet
 class FakeMediaRuntime:
     """固定されたFrame Candidateを返すfake。"""
 
-    def __init__(self, candidates: tuple[FrameCandidate, ...]) -> None:
+    def __init__(
+        self,
+        candidates: tuple[FrameCandidate, ...],
+        *,
+        on_extract_candidates: Callable[[], None] | None = None,
+    ) -> None:
         self._candidates = candidates
+        self._on_extract_candidates = on_extract_candidates
 
     def extract_candidates(
         self,
@@ -14,4 +22,6 @@ class FakeMediaRuntime:
     ) -> tuple[FrameCandidate, ...]:
         """Video Setに対する候補を返す。"""
         del video_set
+        if self._on_extract_candidates is not None:
+            self._on_extract_candidates()
         return self._candidates

--- a/tests/video_selection/fakes/fake_structured_vision_runtime.py
+++ b/tests/video_selection/fakes/fake_structured_vision_runtime.py
@@ -21,6 +21,7 @@ class FakeStructuredVisionRuntime:
         catalog: SceneCatalog,
         annotations: tuple[CandidateAnnotation, ...],
         *,
+        fail_scene_catalog: bool = False,
         failure_moment_id: str | None = None,
         reject_all_calls: bool = False,
         scene_catalog_call_started: Event | None = None,
@@ -30,6 +31,7 @@ class FakeStructuredVisionRuntime:
         self._annotations = {
             annotation.candidate_moment_id: annotation for annotation in annotations
         }
+        self._fail_scene_catalog = fail_scene_catalog
         self._failure_moment_id = failure_moment_id
         self._reject_all_calls = reject_all_calls
         self._scene_catalog_call_started = scene_catalog_call_started
@@ -50,6 +52,8 @@ class FakeStructuredVisionRuntime:
             raise AssertionError("Scene Catalogが再生成されました")
         is_first_call = not self.scene_catalog_calls
         self.scene_catalog_calls.append(request)
+        if self._fail_scene_catalog:
+            raise RuntimeError("fake raw catalog response: chain of thought")
         if is_first_call and self._scene_catalog_call_started is not None:
             self._scene_catalog_call_started.set()
             if (

--- a/tests/video_selection/fakes/fake_structured_vision_runtime.py
+++ b/tests/video_selection/fakes/fake_structured_vision_runtime.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from dataclasses import replace
 from threading import Event
 
@@ -26,6 +27,7 @@ class FakeStructuredVisionRuntime:
         reject_all_calls: bool = False,
         scene_catalog_call_started: Event | None = None,
         release_scene_catalog_call: Event | None = None,
+        on_candidate_annotation: Callable[[], None] | None = None,
     ) -> None:
         self._catalog = catalog
         self._annotations = {
@@ -36,6 +38,7 @@ class FakeStructuredVisionRuntime:
         self._reject_all_calls = reject_all_calls
         self._scene_catalog_call_started = scene_catalog_call_started
         self._release_scene_catalog_call = release_scene_catalog_call
+        self._on_candidate_annotation = on_candidate_annotation
         self.scene_catalog_calls: list[SceneCatalogRequest] = []
         self.candidate_annotation_calls: list[CandidateAnnotationRequest] = []
 
@@ -76,6 +79,8 @@ class FakeStructuredVisionRuntime:
         if self._reject_all_calls:
             raise AssertionError("Candidate Annotationが再生成されました")
         self.candidate_annotation_calls.append(request)
+        if self._on_candidate_annotation is not None:
+            self._on_candidate_annotation()
         if request.moment.identifier == self._failure_moment_id:
             raise RuntimeError("fake raw response: chain of thought")
         annotation = self._annotations[request.moment.identifier]

--- a/tests/video_selection/fakes/fake_video_stage_media_runtime.py
+++ b/tests/video_selection/fakes/fake_video_stage_media_runtime.py
@@ -26,6 +26,7 @@ class FakeVideoStageMediaRuntime:
         *,
         runtime_identity: MediaRuntimeIdentity | None = None,
         on_preflight: Callable[[], None] | None = None,
+        on_scan_video: Callable[[Path], None] | None = None,
         distant_moments: bool = False,
         require_streaming_refinement: bool = False,
         cpu_burn_seconds: float = 0.0,
@@ -45,6 +46,7 @@ class FakeVideoStageMediaRuntime:
             "0" * 64,
         )
         self._on_preflight = on_preflight
+        self._on_scan_video = on_scan_video
         self._distant_moments = distant_moments
         self._require_streaming_refinement = require_streaming_refinement
         self._cpu_burn_seconds = cpu_burn_seconds
@@ -135,6 +137,8 @@ class FakeVideoStageMediaRuntime:
         )
         self.scan_calls.append(media_path)
         self.call_order.append(("scan", media_path.name))
+        if self._on_scan_video is not None:
+            self._on_scan_video(media_path)
         self._burn_cpu()
         heartbeat_folder = artifact_folder / "heartbeats"
         scene_folder = artifact_folder / ".scene-proxies"

--- a/tests/video_selection/fakes/recording_run_observer.py
+++ b/tests/video_selection/fakes/recording_run_observer.py
@@ -2,14 +2,20 @@ from src.video_selection.models.completed_stage import CompletedStage
 from src.video_selection.models.legacy_cache_cleanup_diagnostic import (
     LegacyCacheCleanupDiagnostic,
 )
+from src.video_selection.models.progress_event import ProgressEvent
 
 
 class RecordingRunObserver:
     """完了したProcessing Stageを記録するobserver。"""
 
     def __init__(self) -> None:
+        self.progress_events: list[ProgressEvent] = []
         self.completed_stages: list[CompletedStage] = []
         self.legacy_cache_diagnostics: list[LegacyCacheCleanupDiagnostic] = []
+
+    def observe(self, event: ProgressEvent) -> None:
+        """Progress Eventを順番に記録する。"""
+        self.progress_events.append(event)
 
     def stage_completed(self, completed_stage: CompletedStage) -> None:
         """完了したStageを順番に記録する。"""

--- a/tests/video_selection/models/test_progress_event.py
+++ b/tests/video_selection/models/test_progress_event.py
@@ -1,0 +1,101 @@
+import pytest
+
+from src.video_selection.models.processing_stage import ProcessingStage
+from src.video_selection.models.progress_event import ProgressEvent
+
+
+def test_progress_event_carries_safe_typed_stage_observation() -> None:
+    """安全なStage進捗が表示文でなく型付き値として保持されること。
+
+    Arrange:
+        - Stage、Video、count、cache、経過時間、ETAが用意される
+    Act:
+        - renderer非依存のProgress Eventが生成される
+    Assert:
+        - 入力した型付き観測値がそのまま公開されること
+    """
+    # Arrange
+    stage = ProcessingStage.SCAN_VIDEO
+
+    # Act
+    event = ProgressEvent(
+        kind="progress",
+        severity="info",
+        stage=stage,
+        stage_index=2,
+        video_order=1,
+        video_count=3,
+        video_relative_path="chapter-01/movie.mkv",
+        processed_count=5,
+        total_count=10,
+        cache_hit_count=1,
+        cache_miss_count=4,
+        reuse_count=1,
+        recompute_count=4,
+        elapsed_seconds=31.0,
+        eta_seconds=45.0,
+        estimation_state="available",
+        work_unit_kind="video",
+        reason_code="stage_progress",
+    )
+
+    # Assert
+    assert event == ProgressEvent(
+        kind="progress",
+        severity="info",
+        stage=stage,
+        stage_index=2,
+        video_order=1,
+        video_count=3,
+        video_relative_path="chapter-01/movie.mkv",
+        processed_count=5,
+        total_count=10,
+        cache_hit_count=1,
+        cache_miss_count=4,
+        reuse_count=1,
+        recompute_count=4,
+        elapsed_seconds=31.0,
+        eta_seconds=45.0,
+        estimation_state="available",
+        work_unit_kind="video",
+        reason_code="stage_progress",
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"video_relative_path": "/private/movie.mkv"}, "absolute path"),
+        ({"processed_count": 6, "total_count": 5}, "processed count"),
+        ({"eta_seconds": 1.0, "estimation_state": "estimating"}, "ETA state"),
+    ],
+)
+def test_progress_event_rejects_unsafe_or_inconsistent_observation(
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    """安全でないpathまたは矛盾する進捗値が拒否されること。
+
+    Arrange:
+        - 基本となるStage進捗と不正な上書き値が用意される
+    Act:
+        - Progress Eventの生成が試行される
+    Assert:
+        - 不正な観測値がValueErrorで拒否されること
+    """
+    # Arrange
+    values: dict[str, object] = {
+        "kind": "progress",
+        "severity": "info",
+        "stage": ProcessingStage.SCAN_VIDEO,
+        "stage_index": 1,
+        "processed_count": 5,
+        "total_count": 5,
+        "elapsed_seconds": 30.0,
+        "estimation_state": "estimating",
+    }
+    values.update(overrides)
+
+    # Act / Assert
+    with pytest.raises(ValueError, match=message):
+        ProgressEvent(**values)  # type: ignore[arg-type]

--- a/tests/video_selection/models/test_run_failure.py
+++ b/tests/video_selection/models/test_run_failure.py
@@ -1,0 +1,41 @@
+from src.video_selection.models.run_failure import RunFailure
+
+
+def test_run_failure_keeps_original_error_out_of_safe_representation() -> None:
+    """元例外がcauseとして保持されても安全な表現へ漏れないこと。
+
+    Arrange:
+        - absolute pathとraw model textを含む未知の例外が用意される
+    Act:
+        - stable codeとallowlist値だけでRun Failureが生成される
+    Assert:
+        - 公開表現には安全なfieldだけが含まれ、元例外はcauseで保持されること
+    """
+    # Arrange
+    cause = RuntimeError("/private/model-store: raw model response")
+
+    # Act
+    failure = RunFailure(
+        reason_code="internal_error",
+        exit_code=1,
+        remediation_code="report_internal_error",
+        resume_guidance="completed_stages_reusable",
+        observed_values=(("attempt_count", 2),),
+        cause=cause,
+    )
+
+    # Assert
+    assert (
+        str(failure),
+        repr(failure),
+        failure.cause,
+    ) == (
+        "internal_error",
+        (
+            "RunFailure(reason_code='internal_error', exit_code=1, "
+            "remediation_code='report_internal_error', "
+            "resume_guidance='completed_stages_reusable', "
+            "observed_values=(('attempt_count', 2),))"
+        ),
+        cause,
+    )

--- a/tests/video_selection/services/test_completed_stage_writer.py
+++ b/tests/video_selection/services/test_completed_stage_writer.py
@@ -272,6 +272,105 @@ def test_fault_after_rename_keeps_reusable_completed_stage(tmp_path: Path) -> No
     assert restored == {"value": "committed"}
 
 
+@pytest.mark.parametrize("stage", tuple(ProcessingStage))
+@pytest.mark.parametrize(
+    ("checkpoint", "expected_reusable"),
+    [("before-rename", False), ("after-rename", True)],
+)
+def test_each_processing_stage_observes_atomic_commit_boundary(
+    tmp_path: Path,
+    stage: ProcessingStage,
+    checkpoint: str,
+    expected_reusable: bool,
+) -> None:
+    """全Processing Stageがrename境界の前後で同じ再利用契約を守ること。
+
+    Arrange:
+        - 指定Stageのatomic rename直前または直後で失敗するwriterが用意される
+    Act:
+        - Stage確定が失敗した後に通常writerから同じfingerprintが読まれる
+    Assert:
+        - rename前は未完了、rename後だけCompleted Stageとして再利用されること
+    """
+    # Arrange
+    cache_folder = tmp_path / "cache"
+    subject_fingerprint = "5" * 64
+    semantic_input = {"stage": stage.value}
+    fingerprint = build_stage_fingerprint(stage, (), semantic_input)
+
+    def inject_fault(actual_checkpoint: str) -> None:
+        if actual_checkpoint == checkpoint:
+            raise OSError(f"injected {checkpoint}")
+
+    writer = CompletedStageWriter(
+        cache_folder,
+        subject_namespace="video-sets",
+        subject_fingerprint=subject_fingerprint,
+        fault_injector=inject_fault,
+    )
+
+    # Act
+    with pytest.raises(OSError, match=f"injected {checkpoint}"):
+        writer.write(
+            stage,
+            fingerprint,
+            (),
+            semantic_input,
+            {"value": "committed"},
+        )
+    restored = CompletedStageWriter(
+        cache_folder,
+        subject_namespace="video-sets",
+        subject_fingerprint=subject_fingerprint,
+    ).read(stage, fingerprint, (), semantic_input)
+
+    # Assert
+    assert (restored is not None) is expected_reusable
+
+
+def test_recognized_orphan_temporary_stage_is_removed_before_recompute(
+    tmp_path: Path,
+) -> None:
+    """hard terminationで残った認識可能なpartial Stageだけが削除されること。
+
+    Arrange:
+        - Stage rootに正規形式のorphan temporary folderと未知entryが用意される
+    Act:
+        - 同じStage Fingerprintが再計算されCompleted Stageへ確定される
+    Assert:
+        - orphanだけが削除され、未知entryとCompleted Stageが保持されること
+    """
+    # Arrange
+    cache_folder = tmp_path / "cache"
+    subject_fingerprint = "1" * 64
+    stage = ProcessingStage.DISCOVER_VIDEO_SET
+    semantic_input = {"value": "resume"}
+    fingerprint = build_stage_fingerprint(stage, (), semantic_input)
+    stage_root = cache_folder / "video-sets" / subject_fingerprint / stage.value
+    stage_root.mkdir(parents=True)
+    orphan = stage_root / f".{fingerprint.value}.{'a' * 32}.tmp"
+    orphan.mkdir()
+    (orphan / "partial.bin").write_bytes(b"partial")
+    unknown = stage_root / f".{fingerprint.value}.user.tmp"
+    unknown.mkdir()
+    (unknown / "keep.bin").write_bytes(b"keep")
+    writer = CompletedStageWriter(
+        cache_folder,
+        subject_namespace="video-sets",
+        subject_fingerprint=subject_fingerprint,
+    )
+
+    # Act
+    writer.write(stage, fingerprint, (), semantic_input, {"value": "recomputed"})
+
+    # Assert
+    assert (
+        orphan.exists(),
+        unknown.exists(),
+        (stage_root / fingerprint.value / "manifest.json").is_file(),
+    ) == (False, True, True)
+
+
 def test_rename_failure_leaves_no_partial_completed_stage(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/video_selection/services/test_context_stage_processor.py
+++ b/tests/video_selection/services/test_context_stage_processor.py
@@ -32,6 +32,7 @@ from src.video_selection.models.video_scan_result import VideoScanResult
 from src.video_selection.models.video_timeline import VideoTimeline
 from src.video_selection.services.context_stage_processor import ContextStageProcessor
 from src.video_selection.services.discover_video_set import discover_video_set
+from src.video_selection.services.run_progress_tracker import RunProgressTracker
 from tests.video_selection.fakes.fake_speech_runtime import FakeSpeechRuntime
 from tests.video_selection.fakes.fake_video_stage_media_runtime import (
     FakeVideoStageMediaRuntime,
@@ -136,6 +137,81 @@ def test_non_forced_text_subtitle_is_preferred_without_running_stt(
         ("available", "context_extracted")
     ]
     assert speech_runtime.transcribe_calls == []
+
+
+def test_stt_chunk_emits_external_work_start_event(tmp_path: Path) -> None:
+    """STT chunkのblocking処理開始がProgress Eventとして通知されること。
+
+    Arrange:
+        - audio 1 chunkとrun開始済みProgress Trackerが用意される
+    Act:
+        - Context Collection StageのSTT fallbackが実行される
+    Assert:
+        - speech recognition開始eventがraw transcriptなしで一度通知されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    (input_folder / "video.mkv").write_bytes(b"video-content")
+    video_set = discover_video_set(input_folder)
+    source = video_set.sources[0]
+    audio_stream = _stream(
+        1,
+        "audio",
+        "pcm_s16le",
+        language="jpn",
+        is_default=True,
+        start_pts=100,
+    )
+    probe = MediaProbe(
+        format_names=("matroska",),
+        streams=(_stream(0, "video", "ffv1", is_default=True), audio_stream),
+    )
+    pcm = PcmAudioChunk(
+        stream_index=1,
+        sample_start=0,
+        sample_count=16000,
+        sample_rate=16000,
+        channel_count=1,
+        sample_format="s16le",
+        pts=160000,
+        time_base=Fraction(1, 16000),
+        pcm_bytes=b"\x00\x00" * 16000,
+    )
+    observer = RecordingRunObserver()
+    progress = RunProgressTracker(observer, clock=lambda: 10.0)
+    progress.start_run()
+    processor = ContextStageProcessor(
+        FakeVideoStageMediaRuntime(media_probe=probe, pcm_audio_chunks=(pcm,)),
+        FakeSpeechRuntime(),
+        observer,
+        progress=progress,
+    )
+
+    # Act
+    processor.process(
+        video_set=video_set,
+        source=source,
+        probe=probe,
+        scan=_scan(),
+        configuration=EffectiveConfiguration(
+            video_input_folder=input_folder,
+            output_folder=tmp_path / "output",
+            language="ja",
+        ),
+        media_runtime_identity=MediaRuntimeIdentity(
+            "6.1.1-test",
+            "6.1.1-test",
+            "0" * 64,
+        ),
+    )
+
+    # Assert
+    assert tuple(
+        (event.kind, event.reason_code, event.processed_count, event.eta_seconds)
+        for event in observer.progress_events
+        if event.kind == "external_work_started"
+    ) == (("external_work_started", "speech_recognition_started", None, None),)
 
 
 def test_empty_non_forced_subtitle_is_no_context_without_stt_fallback(

--- a/tests/video_selection/services/test_external_work_monitor.py
+++ b/tests/video_selection/services/test_external_work_monitor.py
@@ -1,0 +1,72 @@
+from threading import Event
+
+from src.video_selection.models.processing_stage import ProcessingStage
+from src.video_selection.services.external_work_monitor import ExternalWorkMonitor
+from src.video_selection.services.run_progress_tracker import RunProgressTracker
+from tests.video_selection.fakes.recording_run_observer import RecordingRunObserver
+
+
+def test_external_work_monitor_emits_heartbeat_every_thirty_seconds() -> None:
+    """blocking external work中に開始eventと30秒heartbeatが発行されること。
+
+    Arrange:
+        - fake clockと30秒進めるwait boundaryが用意される
+    Act:
+        - active Stage内でblocking external operationが実行される
+    Assert:
+        - 開始直後と30秒後に根拠のない進捗率なしでeventが発行されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    current_time = [0.0]
+    second_wait_started = Event()
+    waits: list[float] = []
+    wait_count = 0
+
+    def wait_for_stop(stop: Event, timeout_seconds: float) -> bool:
+        nonlocal wait_count
+        waits.append(timeout_seconds)
+        wait_count += 1
+        if wait_count == 1:
+            current_time[0] += timeout_seconds
+            return False
+        second_wait_started.set()
+        return stop.wait(timeout=1.0)
+
+    tracker = RunProgressTracker(observer, clock=lambda: current_time[0])
+    tracker.start_run()
+    tracker.start_stage(
+        ProcessingStage.COLLECT_CONTEXT,
+        work_unit_kind="audio_chunk",
+    )
+    monitor = ExternalWorkMonitor(tracker, wait_for_stop=wait_for_stop)
+
+    def external_operation() -> str:
+        if not second_wait_started.wait(timeout=1.0):
+            msg = "heartbeatが発行されませんでした"
+            raise RuntimeError(msg)
+        return "completed"
+
+    # Act
+    result = monitor.run(
+        external_operation,
+        reason_code="speech_recognition_started",
+    )
+
+    # Assert
+    external_events = observer.progress_events[-2:]
+    assert (
+        result,
+        waits,
+        tuple(event.kind for event in external_events),
+        tuple(event.elapsed_seconds for event in external_events),
+        tuple(event.processed_count for event in external_events),
+        tuple(event.eta_seconds for event in external_events),
+    ) == (
+        "completed",
+        [30.0, 30.0],
+        ("external_work_started", "heartbeat"),
+        (0.0, 30.0),
+        (None, None),
+        (None, None),
+    )

--- a/tests/video_selection/services/test_gpu_work_coordinator.py
+++ b/tests/video_selection/services/test_gpu_work_coordinator.py
@@ -1,0 +1,70 @@
+from threading import Event, Lock, Thread
+
+from src.video_selection.services.gpu_work_coordinator import GpuWorkCoordinator
+
+
+def test_gpu_work_coordinator_serializes_speech_and_vision_work() -> None:
+    """STTとOllama相当workが同じprocess内で重ならず実行されること。
+
+    Arrange:
+        - 同じcoordinatorを共有する二つのthreadと同期eventが用意される
+    Act:
+        - speech-to-text実行中にvision inferenceが要求される
+    Assert:
+        - active GPU workの最大件数が1で両方完了すること
+    """
+    # Arrange
+    coordinator = GpuWorkCoordinator()
+    state_lock = Lock()
+    first_started = Event()
+    second_attempted = Event()
+    release_first = Event()
+    active_count = 0
+    maximum_active_count = 0
+    completed: list[str] = []
+
+    def work(name: str, *, block: bool) -> str:
+        nonlocal active_count, maximum_active_count
+        with state_lock:
+            active_count += 1
+            maximum_active_count = max(maximum_active_count, active_count)
+        if block:
+            first_started.set()
+            if not release_first.wait(timeout=1.0):
+                msg = "最初のGPU workを解放できませんでした"
+                raise RuntimeError(msg)
+        with state_lock:
+            active_count -= 1
+            completed.append(name)
+        return name
+
+    def run_speech() -> None:
+        coordinator.run("speech_to_text", lambda: work("speech", block=True))
+
+    def run_vision() -> None:
+        second_attempted.set()
+        coordinator.run("vision_inference", lambda: work("vision", block=False))
+
+    first = Thread(target=run_speech)
+    second = Thread(target=run_vision)
+
+    # Act
+    first.start()
+    if not first_started.wait(timeout=1.0):
+        msg = "最初のGPU workが開始されませんでした"
+        raise RuntimeError(msg)
+    second.start()
+    if not second_attempted.wait(timeout=1.0):
+        msg = "二つ目のGPU workが要求されませんでした"
+        raise RuntimeError(msg)
+    release_first.set()
+    first.join(timeout=1.0)
+    second.join(timeout=1.0)
+
+    # Assert
+    assert (maximum_active_count, completed, first.is_alive(), second.is_alive()) == (
+        1,
+        ["speech", "vision"],
+        False,
+        False,
+    )

--- a/tests/video_selection/services/test_line_progress_renderer.py
+++ b/tests/video_selection/services/test_line_progress_renderer.py
@@ -1,0 +1,49 @@
+from src.video_selection.models.processing_stage import ProcessingStage
+from src.video_selection.models.progress_event import ProgressEvent
+from src.video_selection.services.line_progress_renderer import LineProgressRenderer
+
+
+def test_line_progress_renderer_escapes_control_characters() -> None:
+    """relative pathの制御文字がescapeされ1 event 1行で描画されること。
+
+    Arrange:
+        - 改行を含む安全なrelative path付きProgress Eventが用意される
+    Act:
+        - line rendererでeventが描画される
+    Assert:
+        - 改行を増やさずstable fieldだけの一行が返されること
+    """
+    # Arrange
+    event = ProgressEvent(
+        kind="progress",
+        severity="info",
+        stage=ProcessingStage.SCAN_VIDEO,
+        stage_index=1,
+        stage_count=2,
+        video_order=1,
+        video_count=3,
+        video_relative_path="chapter\n01.mkv",
+        processed_count=5,
+        total_count=10,
+        cache_hit_count=1,
+        cache_miss_count=4,
+        reuse_count=1,
+        recompute_count=4,
+        elapsed_seconds=31.0,
+        eta_seconds=45.0,
+        estimation_state="available",
+        work_unit_kind="video",
+        reason_code="stage_progress",
+    )
+    renderer = LineProgressRenderer()
+
+    # Act
+    rendered = renderer.render(event)
+
+    # Assert
+    assert rendered == (
+        "[info] event=progress reason=stage_progress stage=scan-video "
+        'stage_index=1/2 video=1/3 path="chapter\\n01.mkv" '
+        "progress=5/10 cache_hit=1 cache_miss=4 reuse=1 recompute=4 "
+        "elapsed=31.0s eta=45.0s unit=video"
+    )

--- a/tests/video_selection/services/test_processing_stage_runner.py
+++ b/tests/video_selection/services/test_processing_stage_runner.py
@@ -12,6 +12,7 @@ from src.video_selection.services.build_stage_fingerprint import (
 from src.video_selection.services.processing_stage_runner import (
     ProcessingStageRunner,
 )
+from src.video_selection.services.run_progress_tracker import RunProgressTracker
 from tests.video_selection.fakes.recording_run_observer import RecordingRunObserver
 
 
@@ -330,3 +331,63 @@ def test_stage_can_select_only_semantic_upstream_dependencies(tmp_path: Path) ->
     )
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["upstream_stage_fingerprints"] == [discovery.fingerprint.value]
+
+
+def test_processing_stage_runner_emits_cache_and_completion_events(
+    tmp_path: Path,
+) -> None:
+    """cache missからrecompute完了までtyped eventが順番に通知されること。
+
+    Arrange:
+        - run開始済みProgress Trackerとcold Stage cacheが用意される
+    Act:
+        - cache lookup後に一つのProcessing Stageが確定される
+    Assert:
+        - miss、recompute、Stage完了が同じStage番号で通知されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    progress = RunProgressTracker(observer, clock=lambda: 10.0)
+    progress.start_run()
+    runner = ProcessingStageRunner(
+        tmp_path / "cache",
+        observer,
+        subject_namespace="video-sets",
+        subject_fingerprint="4" * 64,
+        stage_order=(ProcessingStage.DISCOVER_VIDEO_SET,),
+        progress=progress,
+        total_stage_count=1,
+    )
+    semantic_input = {"video_set": "cold"}
+
+    # Act
+    restored = runner.reuse(
+        ProcessingStage.DISCOVER_VIDEO_SET,
+        semantic_input,
+        lambda artifact: artifact,
+    )
+    runner.complete(
+        ProcessingStage.DISCOVER_VIDEO_SET,
+        semantic_input,
+        {"video_set": "completed"},
+    )
+
+    # Assert
+    assert restored is None
+    assert tuple(
+        (
+            event.kind,
+            event.stage_index,
+            event.cache_hit_count,
+            event.cache_miss_count,
+            event.reuse_count,
+            event.recompute_count,
+        )
+        for event in observer.progress_events
+    ) == (
+        ("run_started", None, 0, 0, 0, 0),
+        ("stage_started", 1, 0, 0, 0, 0),
+        ("cache", 1, 0, 1, 0, 0),
+        ("cache", 1, 0, 1, 0, 1),
+        ("stage_completed", 1, 0, 0, 0, 0),
+    )

--- a/tests/video_selection/services/test_processing_stage_runner.py
+++ b/tests/video_selection/services/test_processing_stage_runner.py
@@ -391,3 +391,57 @@ def test_processing_stage_runner_emits_cache_and_completion_events(
         ("cache", 1, 0, 1, 0, 1),
         ("stage_completed", 1, 0, 0, 0, 0),
     )
+
+
+def test_processing_stage_runner_records_recompute_duration_for_eta(
+    tmp_path: Path,
+) -> None:
+    """Stage runnerのrecompute完了時間がETA sampleへ記録されること。
+
+    Arrange:
+        - 同じComparable Work Seriesを5回完了するcold Stage runnerが用意される
+    Act:
+        - 6件目のStageで残り1件のETAが通知される
+    Assert:
+        - 実完了時間を使ったETAがavailableとして通知されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    current_time = [0.0]
+    progress = RunProgressTracker(observer, clock=lambda: current_time[0])
+    progress.start_run()
+
+    def produce_artifact(_stage_folder: Path) -> dict[str, object]:
+        current_time[0] += 10.0
+        return {"status": "completed"}
+
+    for run_index in range(5):
+        runner = ProcessingStageRunner(
+            tmp_path / f"cache-{run_index}",
+            observer,
+            subject_namespace="video-sets",
+            subject_fingerprint=f"{run_index:064x}",
+            stage_order=(ProcessingStage.DISCOVER_VIDEO_SET,),
+            progress=progress,
+            work_unit_kind="video_set",
+        )
+        runner.complete_artifacts(
+            ProcessingStage.DISCOVER_VIDEO_SET,
+            {"run_index": run_index},
+            produce_artifact,
+        )
+    progress.start_stage(
+        ProcessingStage.DISCOVER_VIDEO_SET,
+        work_unit_kind="video_set",
+    )
+    current_time[0] += 30.0
+
+    # Act
+    progress.progress(
+        remaining_reuse_count=0,
+        remaining_recompute_count=1,
+    )
+
+    # Assert
+    event = observer.progress_events[-1]
+    assert (event.estimation_state, event.eta_seconds) == ("available", 10.0)

--- a/tests/video_selection/services/test_progress_stream_observer.py
+++ b/tests/video_selection/services/test_progress_stream_observer.py
@@ -1,0 +1,54 @@
+from io import StringIO
+
+import pytest
+
+from src.video_selection.models.progress_event import ProgressEvent
+from src.video_selection.services.progress_stream_observer import (
+    ProgressStreamObserver,
+)
+
+
+@pytest.mark.parametrize(
+    ("is_tty", "expected"),
+    [
+        (
+            False,
+            "[info] event=progress reason=stage_progress progress=1/2\n",
+        ),
+        (
+            True,
+            "\r[info] event=progress reason=stage_progress progress=1/2\x1b[K",
+        ),
+    ],
+)
+def test_progress_stream_observer_selects_renderer_from_stream(
+    monkeypatch: pytest.MonkeyPatch,
+    is_tty: bool,
+    expected: str,
+) -> None:
+    """streamのTTY状態から対応rendererが自動選択されること。
+
+    Arrange:
+        - TTY状態を制御したmemory text streamが用意される
+    Act:
+        - Progress Eventがstream observerへ通知される
+    Assert:
+        - TTY状態に対応した形式だけがstreamへ書かれること
+    """
+    # Arrange
+    stream = StringIO()
+    monkeypatch.setattr(stream, "isatty", lambda: is_tty)
+    observer = ProgressStreamObserver(stream)
+    event = ProgressEvent(
+        kind="progress",
+        severity="info",
+        processed_count=1,
+        total_count=2,
+        reason_code="stage_progress",
+    )
+
+    # Act
+    observer.observe(event)
+
+    # Assert
+    assert stream.getvalue() == expected

--- a/tests/video_selection/services/test_run_progress_tracker.py
+++ b/tests/video_selection/services/test_run_progress_tracker.py
@@ -1,0 +1,132 @@
+from src.video_selection.models.processing_stage import ProcessingStage
+from src.video_selection.services.run_progress_tracker import RunProgressTracker
+from tests.video_selection.fakes.recording_run_observer import RecordingRunObserver
+
+
+def test_run_progress_tracker_emits_serial_typed_lifecycle() -> None:
+    """runとStageの直列ライフサイクルが型付きeventで通知されること。
+
+    Arrange:
+        - Recording Run Observerと制御可能なmonotonic clockが用意される
+    Act:
+        - run、Stage、進捗、Stage完了、run完了が順番に記録される
+    Assert:
+        - event kind、Stage番号、Stage経過時間が契約順で通知されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    now = 10.0
+    tracker = RunProgressTracker(observer, clock=lambda: now)
+
+    # Act
+    tracker.start_run()
+    tracker.start_stage(
+        ProcessingStage.SCAN_VIDEO,
+        stage_count=2,
+        video_order=1,
+        video_count=1,
+        video_relative_path="chapter-01.mkv",
+        work_unit_kind="video",
+    )
+    now = 15.0
+    tracker.progress(processed_count=1, total_count=1)
+    tracker.complete_stage()
+    tracker.start_stage(
+        ProcessingStage.EXTRACT_FRAME_CANDIDATES,
+        stage_count=2,
+        video_order=1,
+        video_count=1,
+        video_relative_path="chapter-01.mkv",
+        work_unit_kind="candidate",
+    )
+    now = 19.0
+    tracker.complete_stage()
+    tracker.complete_run()
+
+    # Assert
+    assert tuple(
+        (event.kind, event.stage_index, event.elapsed_seconds)
+        for event in observer.progress_events
+    ) == (
+        ("run_started", None, None),
+        ("stage_started", 1, 0.0),
+        ("progress", 1, 5.0),
+        ("stage_completed", 1, 5.0),
+        ("stage_started", 2, 0.0),
+        ("stage_completed", 2, 4.0),
+        ("run_completed", None, None),
+    )
+
+
+def test_run_progress_tracker_emits_eta_from_known_work_series() -> None:
+    """系列別残件数が既知の場合だけsampleからETA付きeventが通知されること。
+
+    Arrange:
+        - active Annotation Stageへ10秒のrecompute sampleが5件記録される
+    Act:
+        - Stage開始50秒後に残りrecompute 5件の進捗が通知される
+    Assert:
+        - available状態と50秒のETAがProgress Eventへ含まれること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    current_time = [0.0]
+    tracker = RunProgressTracker(observer, clock=lambda: current_time[0])
+    tracker.start_run()
+    tracker.start_stage(
+        ProcessingStage.ANNOTATE_CANDIDATE,
+        work_unit_kind="candidate",
+    )
+    for _ in range(5):
+        tracker.record_work_sample("recompute", 10.0)
+    current_time[0] = 50.0
+
+    # Act
+    tracker.progress(
+        processed_count=5,
+        total_count=10,
+        remaining_reuse_count=0,
+        remaining_recompute_count=5,
+    )
+
+    # Assert
+    event = observer.progress_events[-1]
+    assert (
+        event.kind,
+        event.estimation_state,
+        event.eta_seconds,
+        event.elapsed_seconds,
+    ) == ("progress", "available", 50.0, 50.0)
+
+
+def test_progress_without_comparable_series_omits_eta() -> None:
+    """比較可能なwork系列がなくても件数進捗だけが通知されること。
+
+    Arrange:
+        - work unit種別を持たないactive Stageが用意される
+    Act:
+        - 30秒経過後に既知totalなしの処理済み件数が通知される
+    Assert:
+        - progress eventは発行され、ETAと根拠のないtotalが省略されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    current_time = [0.0]
+    tracker = RunProgressTracker(observer, clock=lambda: current_time[0])
+    tracker.start_run()
+    tracker.start_stage(ProcessingStage.SELECT_IMAGES)
+    current_time[0] = 31.0
+
+    # Act
+    tracker.progress(processed_count=1)
+
+    # Assert
+    event = observer.progress_events[-1]
+    assert (
+        event.kind,
+        event.processed_count,
+        event.total_count,
+        event.work_unit_kind,
+        event.estimation_state,
+        event.eta_seconds,
+    ) == ("progress", 1, None, None, "unavailable", None)

--- a/tests/video_selection/services/test_run_progress_tracker.py
+++ b/tests/video_selection/services/test_run_progress_tracker.py
@@ -99,6 +99,52 @@ def test_run_progress_tracker_emits_eta_from_known_work_series() -> None:
     ) == ("progress", "available", 50.0, 50.0)
 
 
+def test_run_progress_tracker_excludes_zero_duration_sample() -> None:
+    """0秒の完了sampleがComparable Work Seriesから除外されること。
+
+    Arrange:
+        - 0秒のcurrent sampleと4件の10秒sampleが記録される
+    Act:
+        - 5件目の有効sampleの前後でETAが要求される
+    Assert:
+        - 0秒は件数に含まれず、有効sampleが5件になった後だけETAが返されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    current_time = [0.0]
+    tracker = RunProgressTracker(observer, clock=lambda: current_time[0])
+    tracker.start_run()
+    tracker.start_stage(
+        ProcessingStage.ANNOTATE_CANDIDATE,
+        work_unit_kind="candidate",
+    )
+    tracker.record_work_sample("recompute")
+    for _ in range(4):
+        tracker.record_work_sample("recompute", 10.0)
+    current_time[0] = 30.0
+
+    # Act
+    tracker.progress(
+        remaining_reuse_count=0,
+        remaining_recompute_count=1,
+    )
+    before_fifth_sample = observer.progress_events[-1]
+    tracker.record_work_sample("recompute", 10.0)
+    tracker.progress(
+        remaining_reuse_count=0,
+        remaining_recompute_count=1,
+    )
+    after_fifth_sample = observer.progress_events[-1]
+
+    # Assert
+    assert (
+        before_fifth_sample.estimation_state,
+        before_fifth_sample.eta_seconds,
+        after_fifth_sample.estimation_state,
+        after_fifth_sample.eta_seconds,
+    ) == ("estimating", None, "available", 10.0)
+
+
 def test_progress_without_comparable_series_omits_eta() -> None:
     """比較可能なwork系列がなくても件数進捗だけが通知されること。
 

--- a/tests/video_selection/services/test_stage_eta_estimator.py
+++ b/tests/video_selection/services/test_stage_eta_estimator.py
@@ -1,0 +1,200 @@
+from src.video_selection.models.processing_stage import ProcessingStage
+from src.video_selection.services.stage_eta_estimator import StageEtaEstimator
+
+
+def test_stage_eta_estimator_converges_for_stable_workload() -> None:
+    """安定した5 sampleから最終実績20%以内のStage ETAが返されること。
+
+    Arrange:
+        - 同じStageとwork unitに10秒のrecompute sampleが5件記録される
+    Act:
+        - 30秒経過後に残り5件のETAが要求される
+    Assert:
+        - 50秒のETAがavailableとして返されること
+    """
+    # Arrange
+    estimator = StageEtaEstimator()
+    for _ in range(5):
+        estimator.record_sample(
+            ProcessingStage.ANNOTATE_CANDIDATE,
+            "candidate",
+            "recompute",
+            10.0,
+        )
+
+    # Act
+    estimate = estimator.estimate(
+        ProcessingStage.ANNOTATE_CANDIDATE,
+        "candidate",
+        remaining_reuse_count=0,
+        remaining_recompute_count=5,
+        stage_elapsed_seconds=50.0,
+    )
+
+    # Assert
+    assert estimate == ("available", 50.0)
+
+
+def test_stage_eta_estimator_hides_eta_before_thirty_seconds() -> None:
+    """5 sampleがあってもStage開始30秒未満ではETAが隠されること。
+
+    Arrange:
+        - 同じComparable Work Seriesへsampleが5件記録される
+    Act:
+        - Stage開始29.9秒時点のETAが要求される
+    Assert:
+        - estimatingとなりETAが返されないこと
+    """
+    # Arrange
+    estimator = StageEtaEstimator()
+    for _ in range(5):
+        estimator.record_sample(
+            ProcessingStage.ANNOTATE_CANDIDATE,
+            "candidate",
+            "recompute",
+            10.0,
+        )
+
+    # Act
+    estimate = estimator.estimate(
+        ProcessingStage.ANNOTATE_CANDIDATE,
+        "candidate",
+        remaining_reuse_count=0,
+        remaining_recompute_count=1,
+        stage_elapsed_seconds=29.9,
+    )
+
+    # Assert
+    assert estimate == ("estimating", None)
+
+
+def test_stage_eta_estimator_resets_series_after_large_swing() -> None:
+    """予測が50%を超えて変動した系列が5件の新sampleまで隠されること。
+
+    Arrange:
+        - 1秒で安定したrecompute sampleが5件記録される
+    Act:
+        - 10秒の急変sampleと、その後4件の10秒sampleが順次記録される
+    Assert:
+        - 急変直後はestimatingとなり、新系列5件でETAが再表示されること
+    """
+    # Arrange
+    estimator = StageEtaEstimator()
+    for _ in range(5):
+        estimator.record_sample(
+            ProcessingStage.ANNOTATE_CANDIDATE,
+            "candidate",
+            "recompute",
+            1.0,
+        )
+
+    # Act
+    before_swing = estimator.estimate(
+        ProcessingStage.ANNOTATE_CANDIDATE,
+        "candidate",
+        remaining_reuse_count=0,
+        remaining_recompute_count=5,
+        stage_elapsed_seconds=30.0,
+    )
+    estimator.record_sample(
+        ProcessingStage.ANNOTATE_CANDIDATE,
+        "candidate",
+        "recompute",
+        10.0,
+    )
+    after_swing = estimator.estimate(
+        ProcessingStage.ANNOTATE_CANDIDATE,
+        "candidate",
+        remaining_reuse_count=0,
+        remaining_recompute_count=5,
+        stage_elapsed_seconds=31.0,
+    )
+    for _ in range(4):
+        estimator.record_sample(
+            ProcessingStage.ANNOTATE_CANDIDATE,
+            "candidate",
+            "recompute",
+            10.0,
+        )
+    after_recovery = estimator.estimate(
+        ProcessingStage.ANNOTATE_CANDIDATE,
+        "candidate",
+        remaining_reuse_count=0,
+        remaining_recompute_count=5,
+        stage_elapsed_seconds=35.0,
+    )
+
+    # Assert
+    assert (before_swing, after_swing, after_recovery) == (
+        ("available", 5.0),
+        ("estimating", None),
+        ("available", 50.0),
+    )
+
+
+def test_reuse_and_recompute_samples_are_required_separately() -> None:
+    """reuseとrecomputeの残件が各系列のsampleだけで見積もられること。
+
+    Arrange:
+        - reuse 5件とrecompute 4件の異なる所要時間sampleが用意される
+    Act:
+        - 両方の残件を含むETAがrecompute 5件目の前後で要求される
+    Assert:
+        - 一方のsampleで代用されず、両系列5件後だけ加算ETAが返されること
+    """
+    # Arrange
+    estimator = StageEtaEstimator()
+    for _ in range(5):
+        estimator.record_sample(
+            ProcessingStage.ANNOTATE_CANDIDATE,
+            "candidate",
+            "reuse",
+            1.0,
+        )
+    for _ in range(4):
+        estimator.record_sample(
+            ProcessingStage.ANNOTATE_CANDIDATE,
+            "candidate",
+            "recompute",
+            10.0,
+        )
+
+    # Act
+    before_recompute_series_is_ready = estimator.estimate(
+        ProcessingStage.ANNOTATE_CANDIDATE,
+        "candidate",
+        remaining_reuse_count=5,
+        remaining_recompute_count=1,
+        stage_elapsed_seconds=30.0,
+    )
+    estimator.record_sample(
+        ProcessingStage.ANNOTATE_CANDIDATE,
+        "candidate",
+        "recompute",
+        10.0,
+    )
+    after_both_series_are_ready = estimator.estimate(
+        ProcessingStage.ANNOTATE_CANDIDATE,
+        "candidate",
+        remaining_reuse_count=5,
+        remaining_recompute_count=1,
+        stage_elapsed_seconds=30.0,
+    )
+    unknown_future_cache_results = estimator.estimate(
+        ProcessingStage.ANNOTATE_CANDIDATE,
+        "candidate",
+        remaining_reuse_count=None,
+        remaining_recompute_count=None,
+        stage_elapsed_seconds=30.0,
+    )
+
+    # Assert
+    assert (
+        before_recompute_series_is_ready,
+        after_both_series_are_ready,
+        unknown_future_cache_results,
+    ) == (
+        ("estimating", None),
+        ("available", 15.0),
+        ("unavailable", None),
+    )

--- a/tests/video_selection/services/test_tty_progress_renderer.py
+++ b/tests/video_selection/services/test_tty_progress_renderer.py
@@ -1,0 +1,38 @@
+from src.video_selection.models.progress_event import ProgressEvent
+from src.video_selection.services.tty_progress_renderer import TtyProgressRenderer
+
+
+def test_tty_progress_renderer_updates_line_until_terminal_event() -> None:
+    """TTY進捗が同じ行を更新しterminal eventで改行されること。
+
+    Arrange:
+        - 進行中eventとrun完了eventが用意される
+    Act:
+        - TTY rendererで両eventが描画される
+    Assert:
+        - 進行中は改行せず、完了時だけ改行されること
+    """
+    # Arrange
+    renderer = TtyProgressRenderer()
+    progress = ProgressEvent(
+        kind="progress",
+        severity="info",
+        processed_count=1,
+        total_count=2,
+        reason_code="stage_progress",
+    )
+    completed = ProgressEvent(
+        kind="run_completed",
+        severity="info",
+        reason_code="run_completed",
+    )
+
+    # Act
+    progress_text = renderer.render(progress)
+    completed_text = renderer.render(completed)
+
+    # Assert
+    assert (progress_text, completed_text) == (
+        "\r[info] event=progress reason=stage_progress progress=1/2\x1b[K",
+        "\r[info] event=run_completed reason=run_completed\x1b[K\n",
+    )

--- a/tests/video_selection/services/test_video_set_vision_processor.py
+++ b/tests/video_selection/services/test_video_set_vision_processor.py
@@ -449,6 +449,69 @@ def test_warm_vision_progress_reports_reuse_without_external_work(
     )
 
 
+def test_vision_processor_records_annotation_duration_for_eta(
+    tmp_path: Path,
+) -> None:
+    """Vision processorのAnnotation完了時間がETA sampleへ記録されること。
+
+    Arrange:
+        - 同じAnnotation系列を異なるVideo Setで5回再計算するprocessorが用意される
+    Act:
+        - 6件目のAnnotation Stageで残り1件のETAが通知される
+    Assert:
+        - atomic completionまでの実時間によるETAが通知されること
+    """
+    # Arrange
+    observer = RecordingRunObserver()
+    current_time = [0.0]
+    progress = RunProgressTracker(observer, clock=lambda: current_time[0])
+    progress.start_run()
+    requests = _requests()
+    request = requests[0]
+    annotation = _annotations(requests)[0]
+
+    def advance_annotation_clock() -> None:
+        current_time[0] += 10.0
+
+    for run_index in range(5):
+        run_folder = tmp_path / f"run-{run_index}"
+        run_folder.mkdir()
+        video_set, configuration = _video_set_and_configuration(run_folder)
+        VideoSetVisionProcessor(
+            FakeStructuredVisionRuntime(
+                _catalog(),
+                (annotation,),
+                on_candidate_annotation=advance_annotation_clock,
+            ),
+            observer,
+            progress=progress,
+        ).process(
+            video_set=video_set,
+            representatives=request.frame_candidates,
+            representative_source_fingerprints=(StageFingerprint("c" * 64),),
+            annotation_requests=(request,),
+            configuration=configuration,
+            resolved_models=FakeModelRuntime("vision-model").resolve_models(
+                configuration
+            ),
+        )
+    progress.start_stage(
+        ProcessingStage.ANNOTATE_CANDIDATE,
+        work_unit_kind="candidate",
+    )
+    current_time[0] += 30.0
+
+    # Act
+    progress.progress(
+        remaining_reuse_count=0,
+        remaining_recompute_count=1,
+    )
+
+    # Assert
+    event = observer.progress_events[-1]
+    assert (event.estimation_state, event.eta_seconds) == ("available", 10.0)
+
+
 def test_verbatim_context_cue_is_rejected_before_annotation_cache(
     tmp_path: Path,
 ) -> None:

--- a/tests/video_selection/services/test_video_set_vision_processor.py
+++ b/tests/video_selection/services/test_video_set_vision_processor.py
@@ -12,11 +12,13 @@ from src.video_selection.models.candidate_moment import CandidateMoment
 from src.video_selection.models.context_cue import ContextCue
 from src.video_selection.models.effective_configuration import EffectiveConfiguration
 from src.video_selection.models.frame_candidate import FrameCandidate
+from src.video_selection.models.processing_stage import ProcessingStage
 from src.video_selection.models.scene_catalog import SceneCatalog
 from src.video_selection.models.scene_catalog_entry import SceneCatalogEntry
 from src.video_selection.models.stage_fingerprint import StageFingerprint
 from src.video_selection.models.video_set import VideoSet
 from src.video_selection.services.discover_video_set import discover_video_set
+from src.video_selection.services.run_progress_tracker import RunProgressTracker
 from src.video_selection.services.video_set_vision_processor import (
     VideoSetVisionProcessor,
 )
@@ -185,36 +187,98 @@ def test_same_catalog_fingerprint_runs_inference_once_under_lock(
     assert len(runtime.scene_catalog_calls) == 1
 
 
-def test_completed_annotations_survive_a_later_annotation_failure(
+@pytest.mark.parametrize("failure_position", [0, 1, 2])
+def test_completed_annotations_survive_first_middle_last_failure(
     tmp_path: Path,
+    failure_position: int,
 ) -> None:
-    """後続Annotation失敗後も先に完了したMomentが再利用されること。
+    """先頭・途中・末尾Annotation失敗後も先行Momentが再利用されること。
 
     Arrange:
-        - 2件目だけ失敗するfake VisionRuntimeが用意される
+        - 3件のうち指定位置だけ失敗するfake VisionRuntimeが用意される
     Act:
         - 失敗runの後に同じ入力が再実行される
     Assert:
-        - Scene Catalogと1件目は再実行されず2件目だけ生成されること
-        - 最初の失敗runで全Annotation完了結果が返されないこと
+        - Scene Catalogと先行Annotationは再実行されず未完了分だけ生成されること
     """
     # Arrange
     video_set, configuration = _video_set_and_configuration(tmp_path)
-    requests = _requests()
+    requests = _three_requests()
     catalog = _catalog()
-    annotations = _annotations(requests)
+    annotations = _three_annotations(requests)
     first_runtime = FakeStructuredVisionRuntime(
         catalog,
         annotations,
-        failure_moment_id=requests[1].moment.identifier,
+        failure_moment_id=requests[failure_position].moment.identifier,
+    )
+    models = FakeModelRuntime("vision-model").resolve_models(configuration)
+
+    # Act / Assert
+    with pytest.raises(RuntimeError, match="fake raw response"):
+        VideoSetVisionProcessor(
+            first_runtime,
+            RecordingRunObserver(),
+        ).process(
+            video_set=video_set,
+            representatives=tuple(request.frame_candidates[0] for request in requests),
+            representative_source_fingerprints=(StageFingerprint("c" * 64),),
+            annotation_requests=requests,
+            configuration=configuration,
+            resolved_models=models,
+        )
+
+    # Act
+    retry_runtime = FakeStructuredVisionRuntime(catalog, annotations)
+    result = VideoSetVisionProcessor(
+        retry_runtime,
+        RecordingRunObserver(),
+    ).process(
+        video_set=video_set,
+        representatives=tuple(request.frame_candidates[0] for request in requests),
+        representative_source_fingerprints=(StageFingerprint("c" * 64),),
+        annotation_requests=requests,
+        configuration=configuration,
+        resolved_models=models,
+    )
+
+    # Assert
+    assert retry_runtime.scene_catalog_calls == []
+    assert [
+        item.moment.identifier for item in retry_runtime.candidate_annotation_calls
+    ] == [request.moment.identifier for request in requests[failure_position:]]
+    assert result.annotations == annotations
+    assert [item.cache_hit for item in result.annotation_diagnostics] == [
+        *([True] * failure_position),
+        *([False] * (len(requests) - failure_position)),
+    ]
+
+
+def test_failed_scene_catalog_is_recomputed_on_rerun(tmp_path: Path) -> None:
+    """失敗したScene Catalogが未完了として再生成されること。
+
+    Arrange:
+        - Scene Catalogだけが失敗するfake Vision Runtimeが用意される
+    Act:
+        - 失敗runの後に同じ入力が再実行される
+    Assert:
+        - 失敗Catalogは再生成され、その後のAnnotationがすべて確定されること
+    """
+    # Arrange
+    video_set, configuration = _video_set_and_configuration(tmp_path)
+    requests = _three_requests()
+    catalog = _catalog()
+    annotations = _three_annotations(requests)
+    failing_runtime = FakeStructuredVisionRuntime(
+        catalog,
+        annotations,
+        fail_scene_catalog=True,
     )
     models = FakeModelRuntime("vision-model").resolve_models(configuration)
 
     # Act
-    # Assert
-    with pytest.raises(RuntimeError, match="fake raw response"):
+    with pytest.raises(RuntimeError, match="fake raw catalog response"):
         VideoSetVisionProcessor(
-            first_runtime,
+            failing_runtime,
             RecordingRunObserver(),
         ).process(
             video_set=video_set,
@@ -236,12 +300,153 @@ def test_completed_annotations_survive_a_later_annotation_failure(
         configuration=configuration,
         resolved_models=models,
     )
-    assert retry_runtime.scene_catalog_calls == []
+
+    # Assert
+    assert len(failing_runtime.scene_catalog_calls) == 1
+    assert failing_runtime.candidate_annotation_calls == []
+    assert len(retry_runtime.scene_catalog_calls) == 1
     assert [
         item.moment.identifier for item in retry_runtime.candidate_annotation_calls
-    ] == [requests[1].moment.identifier]
+    ] == [request.moment.identifier for request in requests]
     assert result.annotations == annotations
-    assert [item.cache_hit for item in result.annotation_diagnostics] == [True, False]
+
+
+def test_vision_stage_progress_reports_catalog_and_each_annotation(
+    tmp_path: Path,
+) -> None:
+    """Scene Catalogと各Candidate Annotationが個別Stageとして通知されること。
+
+    Arrange:
+        - 2件のAnnotation requestとrun開始済みProgress Trackerが用意される
+    Act:
+        - cold Video Set Vision processingが実行される
+    Assert:
+        - Catalogと各Annotationが単調なStage番号とrecompute結果で通知されること
+    """
+    # Arrange
+    video_set, configuration = _video_set_and_configuration(tmp_path)
+    requests = _requests()
+    observer = RecordingRunObserver()
+    progress = RunProgressTracker(observer, clock=lambda: 10.0)
+    progress.start_run()
+    processor = VideoSetVisionProcessor(
+        FakeStructuredVisionRuntime(_catalog(), _annotations(requests)),
+        observer,
+        progress=progress,
+    )
+
+    # Act
+    processor.process(
+        video_set=video_set,
+        representatives=tuple(request.frame_candidates[0] for request in requests),
+        representative_source_fingerprints=(StageFingerprint("c" * 64),),
+        annotation_requests=requests,
+        configuration=configuration,
+        resolved_models=FakeModelRuntime("vision-model").resolve_models(configuration),
+    )
+
+    # Assert
+    assert tuple(
+        (event.stage, event.stage_index, event.work_unit_kind)
+        for event in observer.progress_events
+        if event.kind == "stage_started"
+    ) == (
+        (ProcessingStage.BUILD_SCENE_CATALOG, 1, "scene_catalog"),
+        (ProcessingStage.ANNOTATE_CANDIDATE, 2, "candidate"),
+        (ProcessingStage.ANNOTATE_CANDIDATE, 3, "candidate"),
+    )
+    assert tuple(
+        (
+            event.cache_miss_count,
+            event.recompute_count,
+            event.cache_hit_count,
+            event.reuse_count,
+        )
+        for event in observer.progress_events
+        if event.kind == "cache"
+    ) == ((1, 1, 0, 0), (1, 1, 0, 0), (1, 1, 0, 0))
+    assert tuple(
+        event.reason_code
+        for event in observer.progress_events
+        if event.kind == "external_work_started"
+    ) == (
+        "scene_catalog_inference_started",
+        "candidate_annotation_inference_started",
+        "candidate_annotation_inference_started",
+    )
+
+
+def test_warm_vision_progress_reports_reuse_without_external_work(
+    tmp_path: Path,
+) -> None:
+    """warm Vision Stageがcache reuseだけを通知し外部処理を開始しないこと。
+
+    Arrange:
+        - Catalogと2件のAnnotationがCompleted Stageとして確定済みである
+    Act:
+        - 同じ入力がProgress Tracker付きで再実行される
+    Assert:
+        - 各Stageがhit/reuseとして通知され外部処理eventがないこと
+    """
+    # Arrange
+    video_set, configuration = _video_set_and_configuration(tmp_path)
+    requests = _requests()
+    catalog = _catalog()
+    annotations = _annotations(requests)
+    models = FakeModelRuntime("vision-model").resolve_models(configuration)
+    VideoSetVisionProcessor(
+        FakeStructuredVisionRuntime(catalog, annotations),
+        RecordingRunObserver(),
+    ).process(
+        video_set=video_set,
+        representatives=tuple(request.frame_candidates[0] for request in requests),
+        representative_source_fingerprints=(StageFingerprint("c" * 64),),
+        annotation_requests=requests,
+        configuration=configuration,
+        resolved_models=models,
+    )
+    observer = RecordingRunObserver()
+    progress = RunProgressTracker(observer, clock=lambda: 10.0)
+    progress.start_run()
+
+    # Act
+    VideoSetVisionProcessor(
+        FakeStructuredVisionRuntime(
+            catalog,
+            annotations,
+            reject_all_calls=True,
+        ),
+        observer,
+        progress=progress,
+    ).process(
+        video_set=video_set,
+        representatives=tuple(request.frame_candidates[0] for request in requests),
+        representative_source_fingerprints=(StageFingerprint("c" * 64),),
+        annotation_requests=requests,
+        configuration=configuration,
+        resolved_models=models,
+    )
+
+    # Assert
+    cache_events = tuple(
+        (
+            event.cache_hit_count,
+            event.cache_miss_count,
+            event.reuse_count,
+            event.recompute_count,
+            event.reason_code,
+        )
+        for event in observer.progress_events
+        if event.kind == "cache"
+    )
+    assert cache_events == (
+        (1, 0, 1, 0, "cache_reused"),
+        (1, 0, 1, 0, "cache_reused"),
+        (1, 0, 1, 0, "cache_reused"),
+    )
+    assert not any(
+        event.kind == "external_work_started" for event in observer.progress_events
+    )
 
 
 def test_verbatim_context_cue_is_rejected_before_annotation_cache(
@@ -387,6 +592,20 @@ def _requests() -> tuple[CandidateAnnotationRequest, ...]:
     )
 
 
+def _three_requests() -> tuple[CandidateAnnotationRequest, ...]:
+    first, second = _requests()
+    third_frame = FrameCandidate("frame-c", b"image-c")
+    third = CandidateAnnotationRequest(
+        moment=_moment("c", third_frame.identifier, Fraction(30)),
+        frame_candidates=(third_frame,),
+        context_cues=(),
+        video_set_progress=Fraction(7, 8),
+        selection_intent="ブログ本文を説明できる画像を選ぶ",
+        cue_selection_policy_version="nearby-context-v1",
+    )
+    return (first, second, third)
+
+
 def _moment(seed: str, frame_id: str, time: Fraction) -> CandidateMoment:
     return CandidateMoment(
         identifier="mom_" + seed * 64,
@@ -440,3 +659,22 @@ def _annotations(
             spoiler_evidence="主要人物の正体が画面で明示される",
         ),
     )
+
+
+def _three_annotations(
+    requests: tuple[CandidateAnnotationRequest, ...],
+) -> tuple[CandidateAnnotation, ...]:
+    first, second = _annotations(requests[:2])
+    third = CandidateAnnotation(
+        candidate=requests[2].frame_candidates[0],
+        summary="終盤の探索場面",
+        candidate_moment_id=requests[2].moment.identifier,
+        scene_slug="exploration",
+        blog_image_type="normal_gameplay",
+        explanation_value="medium",
+        frame_choice_reason="探索対象が明確に写る",
+        screen_text_kind="hud",
+        context_relevance="unavailable",
+        spoiler_risk="none",
+    )
+    return (first, second, third)

--- a/tests/video_selection/services/test_video_stage_processor.py
+++ b/tests/video_selection/services/test_video_stage_processor.py
@@ -10,6 +10,7 @@ from src.video_selection.models.effective_configuration import EffectiveConfigur
 from src.video_selection.models.media_runtime_identity import MediaRuntimeIdentity
 from src.video_selection.models.processing_stage import ProcessingStage
 from src.video_selection.services.discover_video_set import discover_video_set
+from src.video_selection.services.run_progress_tracker import RunProgressTracker
 from src.video_selection.services.video_stage_processor import VideoStageProcessor
 from tests.video_selection.fakes.fake_speech_runtime import FakeSpeechRuntime
 from tests.video_selection.fakes.fake_video_stage_media_runtime import (
@@ -63,6 +64,76 @@ def test_context_collection_is_the_third_source_local_video_stage(
         ("absent", "no_subtitle_stream"),
         ("absent", "no_audio_stream"),
     ]
+
+
+def test_video_stage_progress_follows_video_order_with_monotonic_stage_index(
+    tmp_path: Path,
+) -> None:
+    """複数Videoの3 StageがVideo Orderと単調なStage番号で通知されること。
+
+    Arrange:
+        - 自然順の2動画とrun開始済みProgress Trackerが用意される
+    Act:
+        - Video Stage processorで両動画が直列処理される
+    Assert:
+        - scan、extract、contextが各Video Orderに結び付いて通知されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    (input_folder / "01-first.mp4").write_bytes(b"first-video")
+    (input_folder / "02-second.mp4").write_bytes(b"second-video")
+    observer = RecordingRunObserver()
+    progress = RunProgressTracker(observer, clock=lambda: 10.0)
+    progress.start_run()
+    processor = VideoStageProcessor(
+        FakeVideoStageMediaRuntime(),
+        FakeSpeechRuntime(),
+        observer,
+        progress=progress,
+    )
+
+    # Act
+    processor.process(
+        discover_video_set(input_folder),
+        _configuration(input_folder, tmp_path / "output"),
+    )
+
+    # Assert
+    started = tuple(
+        (
+            event.stage,
+            event.stage_index,
+            event.stage_count,
+            event.video_order,
+            event.video_count,
+            event.video_relative_path,
+        )
+        for event in observer.progress_events
+        if event.kind == "stage_started"
+    )
+    assert started == (
+        (ProcessingStage.SCAN_VIDEO, 1, None, 1, 2, "01-first.mp4"),
+        (
+            ProcessingStage.EXTRACT_FRAME_CANDIDATES,
+            2,
+            None,
+            1,
+            2,
+            "01-first.mp4",
+        ),
+        (ProcessingStage.COLLECT_CONTEXT, 3, None, 1, 2, "01-first.mp4"),
+        (ProcessingStage.SCAN_VIDEO, 4, None, 2, 2, "02-second.mp4"),
+        (
+            ProcessingStage.EXTRACT_FRAME_CANDIDATES,
+            5,
+            None,
+            2,
+            2,
+            "02-second.mp4",
+        ),
+        (ProcessingStage.COLLECT_CONTEXT, 6, None, 2, 2, "02-second.mp4"),
+    )
 
 
 def test_video_sources_are_serial_and_video_stage_cache_is_source_local(
@@ -171,6 +242,63 @@ def test_video_sources_are_serial_and_video_stage_cache_is_source_local(
         "01-renamed.mp4",
         "99-renamed.mp4",
     ]
+
+
+@pytest.mark.parametrize("failure_position", [0, 1, 2])
+def test_completed_video_stages_survive_first_middle_last_video_failure(
+    tmp_path: Path,
+    failure_position: int,
+) -> None:
+    """先頭・途中・末尾Videoの失敗後も先行Video Stageが再利用されること。
+
+    Arrange:
+        - 自然順の3動画と指定Videoのscanだけ失敗するMedia Runtimeが用意される
+    Act:
+        - 失敗runの後に同じVideo Setとcacheで再実行される
+    Assert:
+        - 失敗Videoより前は再計算されず、失敗Video以降だけが処理されること
+    """
+    # Arrange
+    input_folder = tmp_path / "videos"
+    input_folder.mkdir()
+    video_names = ("01-first.mp4", "02-middle.mp4", "03-last.mp4")
+    for index, name in enumerate(video_names, start=1):
+        (input_folder / name).write_bytes(f"video-{index}".encode())
+    configuration = _configuration(input_folder, tmp_path / "output")
+    video_set = discover_video_set(input_folder)
+    failed_name = video_names[failure_position]
+
+    def fail_selected_video(path: Path) -> None:
+        if path.name == failed_name:
+            raise OSError("injected video scan failure")
+
+    failing_runtime = FakeVideoStageMediaRuntime(on_scan_video=fail_selected_video)
+
+    # Act
+    with pytest.raises(OSError, match="injected video scan failure"):
+        VideoStageProcessor(
+            failing_runtime,
+            FakeSpeechRuntime(),
+            RecordingRunObserver(),
+        ).process(video_set, configuration)
+    retry_runtime = FakeVideoStageMediaRuntime()
+    results = VideoStageProcessor(
+        retry_runtime,
+        FakeSpeechRuntime(),
+        RecordingRunObserver(),
+    ).process(video_set, configuration)
+
+    # Assert
+    expected_recomputed = list(video_names[failure_position:])
+    assert [path.name for path in failing_runtime.scan_calls] == list(
+        video_names[: failure_position + 1]
+    )
+    assert [path.name for path in failing_runtime.range_calls] == list(
+        video_names[:failure_position]
+    )
+    assert [path.name for path in retry_runtime.scan_calls] == expected_recomputed
+    assert [path.name for path in retry_runtime.range_calls] == expected_recomputed
+    assert len(results) == 3
 
 
 def test_corrupt_candidate_proxy_recomputes_only_candidate_stage(

--- a/tests/video_selection/speech/test_faster_whisper_speech_runtime.py
+++ b/tests/video_selection/speech/test_faster_whisper_speech_runtime.py
@@ -2,6 +2,7 @@
 
 from fractions import Fraction
 from pathlib import Path
+from threading import Event, Thread
 from types import SimpleNamespace
 
 import ctranslate2
@@ -9,6 +10,7 @@ import numpy as np
 import pytest
 
 from src.video_selection.models.pcm_audio_chunk import PcmAudioChunk
+from src.video_selection.services.gpu_work_coordinator import GpuWorkCoordinator
 from src.video_selection.speech.faster_whisper_speech_runtime import (
     FasterWhisperSpeechRuntime,
 )
@@ -201,3 +203,84 @@ def test_runtime_identity_changes_with_gpu_runtime_capability(
 
     # Assert
     assert first.runtime_identity != second.runtime_identity
+
+
+def test_transcription_waits_for_shared_gpu_lease() -> None:
+    """STTが共有GPU leaseを取得してからmodelを実行すること。
+
+    Arrange:
+        - Vision相当workが保持中の実coordinatorとSpeech Runtimeが用意される
+    Act:
+        - 別threadからSTTが要求され、先行leaseが解放される
+    Assert:
+        - 解放前はmodelが呼ばれず、解放後にtranscriptionが完了すること
+    """
+    # Arrange
+    coordinator = GpuWorkCoordinator()
+    lease_started = Event()
+    release_lease = Event()
+    model = FakeFasterWhisperModel(
+        (),
+        SimpleNamespace(language="ja", duration_after_vad=0.0),
+    )
+    runtime = FasterWhisperSpeechRuntime(
+        model,
+        runtime_identity="speech-runtime:test",
+        resolved_model_identity="hf:" + "a" * 40,
+        gpu_coordinator=coordinator,
+    )
+    pcm = PcmAudioChunk(
+        stream_index=1,
+        sample_start=0,
+        sample_count=1,
+        sample_rate=16000,
+        channel_count=1,
+        sample_format="s16le",
+        pts=0,
+        time_base=Fraction(1, 16000),
+        pcm_bytes=b"\x00\x00",
+    )
+    failures: list[BaseException] = []
+
+    def hold_gpu_lease() -> None:
+        def wait_for_release() -> None:
+            lease_started.set()
+            if not release_lease.wait(timeout=1.0):
+                msg = "GPU leaseを解放できませんでした"
+                raise RuntimeError(msg)
+
+        try:
+            coordinator.run("vision_inference", wait_for_release)
+        except BaseException as error:
+            failures.append(error)
+
+    def transcribe() -> None:
+        try:
+            runtime.transcribe(
+                pcm,
+                language="ja",
+                vad_filter=True,
+                beam_size=5,
+            )
+        except BaseException as error:
+            failures.append(error)
+
+    holder = Thread(target=hold_gpu_lease)
+    worker = Thread(target=transcribe)
+
+    # Act
+    holder.start()
+    assert lease_started.wait(timeout=1.0)
+    worker.start()
+    worker.join(timeout=0.05)
+    blocked_before_release = worker.is_alive() and model.audio is None
+    release_lease.set()
+    holder.join(timeout=1.0)
+    worker.join(timeout=1.0)
+
+    # Assert
+    assert blocked_before_release is True
+    assert failures == []
+    assert model.audio is not None
+    assert holder.is_alive() is False
+    assert worker.is_alive() is False

--- a/tests/video_selection/vision/test_ollama_vision_runtime.py
+++ b/tests/video_selection/vision/test_ollama_vision_runtime.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from email.message import Message
 from email.utils import format_datetime
 from fractions import Fraction
+from threading import Event, Thread
 from typing import cast
 from urllib.error import HTTPError
 
@@ -29,7 +30,91 @@ from src.video_selection.models.vision_runtime_error import VisionRuntimeError
 from src.video_selection.models.vision_runtime_failure_reason import (
     VisionRuntimeFailureReason,
 )
+from src.video_selection.services.gpu_work_coordinator import GpuWorkCoordinator
 from src.video_selection.vision.ollama_vision_runtime import OllamaVisionRuntime
+
+
+def test_inference_waits_for_shared_gpu_lease() -> None:
+    """Ollama推論が共有GPU leaseを取得してからrequestされること。
+
+    Arrange:
+        - STT相当workが保持中の実coordinatorとVision Runtimeが用意される
+    Act:
+        - 別threadからScene Catalog推論が要求され、先行leaseが解放される
+    Assert:
+        - 解放前はOllamaへrequestされず、解放後に推論が完了すること
+    """
+    # Arrange
+    coordinator = GpuWorkCoordinator()
+    lease_started = Event()
+    release_lease = Event()
+    request_count = 0
+    failures: list[BaseException] = []
+
+    def requester(
+        _method: str,
+        _url: str,
+        _payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        nonlocal request_count
+        request_count += 1
+        return _response(_catalog_payload())
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+        model_state_resolver=_resolved_artifact,
+        gpu_coordinator=coordinator,
+    )
+    request = SceneCatalogRequest(
+        representatives=(FrameCandidate("frame-a", b"image-a"),),
+        selection_intent="ブログ画像を分類する",
+    )
+
+    def hold_gpu_lease() -> None:
+        def wait_for_release() -> None:
+            lease_started.set()
+            if not release_lease.wait(timeout=1.0):
+                msg = "GPU leaseを解放できませんでした"
+                raise RuntimeError(msg)
+
+        try:
+            coordinator.run("speech_to_text", wait_for_release)
+        except BaseException as error:
+            failures.append(error)
+
+    def infer() -> None:
+        try:
+            runtime.create_scene_catalog(
+                request,
+                _resolved_model(ModelRole.SCENE_CATALOG),
+                num_ctx=32768,
+            )
+        except BaseException as error:
+            failures.append(error)
+
+    holder = Thread(target=hold_gpu_lease)
+    worker = Thread(target=infer)
+
+    # Act
+    holder.start()
+    assert lease_started.wait(timeout=1.0)
+    worker.start()
+    worker.join(timeout=0.05)
+    blocked_before_release = worker.is_alive() and request_count == 0
+    release_lease.set()
+    holder.join(timeout=1.0)
+    worker.join(timeout=1.0)
+
+    # Assert
+    assert blocked_before_release is True
+    assert failures == []
+    assert request_count == 1
+    assert holder.is_alive() is False
+    assert worker.is_alive() is False
 
 
 def test_scene_catalog_uses_strict_documented_ollama_request() -> None:


### PR DESCRIPTION
## 概要

- renderer非依存の `ProgressEvent`、TTY/line renderer、30秒heartbeat、根拠が揃った場合だけ表示するStage ETAを追加
- 最外周の `InternalRunController` で stable `RunFailure`、exit 0/1/2/130、Ctrl+Cと運用エラー後のCompleted Stage再利用を実装
- recognized partial Stageのlock内削除、cache hit/missとreuse/recomputeの分離、STT/Ollamaのprocess内GPU排他を追加
- 実行前に修正可能な入力不備をexit 2へ分類し、設定reason codeを正規化。実行時snapshot変更とI/O障害はexit 1を維持
- Stage開始からatomic completionまたはcache復元完了までのcurrent-run実績を、reuse/recompute別のETA sampleとして記録
- Video/Annotationのfirst・middle・last、Scene Catalog、全Stageのrename前後、既存staging/renameを含むfault matrixと運用文書を更新

## 検証

- `uv run task test`
  - Ruff: pass
  - mypy: pass
  - pytest: 587 passed
- 実行前入力不備のexit 2、実行時snapshot変更のexit 1、設定reason code正規化
- 実pipelineでのETA sample記録、0秒除外、5 sample・30秒・20%収束・50% swing reset契約
- Ctrl+C / operation error の再開マトリクス
- STT/Ollama共有GPU leaseとexternal work heartbeat

## 制約

- public CLIは変更していません。Video Set CLIへの接続は #190 で行います。
- targetは `integration/issue-161-video-input` で、非`main`のためversion bumpは行いません。

Closes #188