### PR TITLE
test: 3並列前提のVideo Scanテストを固定化する

### DIFF
--- a/tests/video_selection/services/test_video_stage_processor.py
+++ b/tests/video_selection/services/test_video_stage_processor.py
@@ -1055,7 +1055,10 @@ def test_primary_scan_failure_is_not_masked_by_sibling_cancellation(
             RecordingRunObserver(),
         ).process(
             discover_video_set(input_folder),
-            _configuration(input_folder, tmp_path / "output"),
+            replace(
+                _configuration(input_folder, tmp_path / "output"),
+                video_scan_workers=3,
+            ),
         )
 
     # Assert

--- a/tests/video_selection/services/test_video_stage_processor.py
+++ b/tests/video_selection/services/test_video_stage_processor.py
@@ -334,7 +334,10 @@ def test_three_video_scans_run_concurrently(
         RecordingRunObserver(),
     ).process(
         discover_video_set(input_folder),
-        _configuration(input_folder, tmp_path / "output"),
+        replace(
+            _configuration(input_folder, tmp_path / "output"),
+            video_scan_workers=3,
+        ),
     )
 
     # Assert
@@ -683,7 +686,10 @@ def test_downstream_starts_while_later_video_scans_are_active(
         RecordingRunObserver(),
     ).process(
         discover_video_set(input_folder),
-        _configuration(input_folder, tmp_path / "output"),
+        replace(
+            _configuration(input_folder, tmp_path / "output"),
+            video_scan_workers=3,
+        ),
     )
 
     # Assert


### PR DESCRIPTION
Closes #207

## 概要

3本同時実行を前提とするVideo Scanテスト3件を、テスト契約どおり固定3 workerで実行するようにします。

動的並列化のauto設定はホスト負荷に応じて初期worker数を1へ抑制できます。そのため、並行scanのCPU計測、pipelining、一次障害保持を検証するテストが高負荷時に想定した競合を作れず、BarrierまたはEvent待機で失敗していました。

## 変更

次のテストの設定だけ `video_scan_workers=3` を明示します。

- `test_three_video_scans_run_concurrently`
- `test_downstream_starts_while_later_video_scans_are_active`
- `test_primary_scan_failure_is_not_masked_by_sibling_cancellation`

製品コード、auto worker制御、公開設定は変更しません。

## 検証

- WinPC/WSL2 高負荷: 3テスト × 320回 = 960/960成功
- Mac: `uv run task test` — 874 passed
- Mac: FFmpeg integration — 36 passed
- WinPC/WSL2: `uv run task test` — 874 passed
- WinPC/WSL2: `uv run task test-ffmpeg` — 36 passed
- `git diff --check` 成功