### PR TITLE
fix: WSL再起動時の微小なRAM差を許容する

### DIFF
--- a/docs/target-acceptance.md
+++ b/docs/target-acceptance.md
@@ -126,6 +126,10 @@ Comparison Runとphaseの完了はsuite別の`acceptance-state.json`へatomicに
 identity、commitを検証し、未完了runだけを続行する。driver、FFmpeg、kernelなどtarget
 probeの値が変わったstateは混在させない。completed coldを再実行してwarmへ戻したり、
 completed Comparison Runやcold/warmを再実行したりしない。
+初回probeの`visible_ram_bytes`実測値はstateとAcceptance Recordへそのまま保持する一方、
+durable resumeではWSL2の起動ごとに生じるpage単位のRAM accounting差だけを吸収するため、
+保存値との差が1 MiB以内なら同じtargetとして扱う。1 MiBを超える差、field欠落、非整数値は
+target identity不一致とし、`visible_ram_bytes`以外のtarget fieldは完全一致を要求する。
 設定file外の`OLLAMA_HOST`を含む実効endpointも、URLを公開しないdigestとしてsuite identityへ
 固定する。
 

--- a/src/video_selection/acceptance/target_suite_runner.py
+++ b/src/video_selection/acceptance/target_suite_runner.py
@@ -68,6 +68,7 @@ SuiteMaterializer = Callable[
 StoragePreflight = Callable[[AcceptanceProfile, Path], dict[str, object]]
 
 _STATE_SCHEMA = "game-screen-pick/target-acceptance-state@1.2.0"
+_VISIBLE_RAM_IDENTITY_TOLERANCE_BYTES = 1024**2
 
 
 class TargetSuiteRunner:
@@ -200,7 +201,7 @@ class TargetSuiteRunner:
             write_atomic_json(state_path, state)
         else:
             _validate_state_identity(state, identity)
-            if state.get("target") != target:
+            if not _target_identity_matches(state.get("target"), target):
                 raise ValueError(
                     "Acceptance stateが現在のtarget identityと一致しません"
                 )
@@ -645,6 +646,30 @@ def _validate_state_identity(
         state.get(key) != value for key, value in identity.items()
     ):
         raise ValueError("Acceptance stateが現在のsuite identityと一致しません")
+
+
+def _target_identity_matches(
+    stored: object,
+    current: Mapping[str, object],
+) -> bool:
+    """起動時の微小なvisible RAM差だけを許容してtargetを比較する。"""
+    if not isinstance(stored, Mapping) or set(stored) != set(current):
+        return False
+    stored_ram = stored.get("visible_ram_bytes")
+    current_ram = current.get("visible_ram_bytes")
+    if (
+        type(stored_ram) is not int
+        or type(current_ram) is not int
+        or stored_ram <= 0
+        or current_ram <= 0
+        or abs(stored_ram - current_ram) > _VISIBLE_RAM_IDENTITY_TOLERANCE_BYTES
+    ):
+        return False
+    return all(
+        stored.get(key) == value
+        for key, value in current.items()
+        if key != "visible_ram_bytes"
+    )
 
 
 def _runs_completed(state: Mapping[str, object]) -> bool:

--- a/tests/video_selection/acceptance/test_target_suite_runner.py
+++ b/tests/video_selection/acceptance/test_target_suite_runner.py
@@ -1101,7 +1101,11 @@ def test_completed_state_rejects_changed_target_identity(tmp_path: Path) -> None
     # Arrange
     profile_path = _profile(tmp_path)
     calls: list[str] = []
-    target = {"os": "linux", "gpu_driver": "first"}
+    target = {
+        "os": "linux",
+        "gpu_driver": "first",
+        "visible_ram_bytes": 32 * 1024**3,
+    }
 
     def execute(
         run_name: str,
@@ -1127,6 +1131,165 @@ def test_completed_state_rejects_changed_target_identity(tmp_path: Path) -> None
 
     # Assert
     assert "target identity" in str(error.value)
+    assert calls == ["cold", "warm"]
+
+
+@pytest.mark.parametrize(
+    "delta_bytes",
+    (-12 * 1024, -4 * 1024, -(1024**2), 1024**2),
+)
+def test_completed_state_accepts_boot_level_visible_ram_variation(
+    tmp_path: Path,
+    delta_bytes: int,
+) -> None:
+    """起動単位の微小なvisible RAM差で完了stateが再利用されること。
+
+    Arrange:
+        - 実測visible RAMを持つcold/warm完了stateが用意される
+    Act:
+        - 現在値だけが1 MiB以内で変動したtargetからsuiteが再開される
+    Assert:
+        - 初回実測値がstateに保持され、phase再実行なしで再開されること
+    """
+    # Arrange
+    profile_path = _profile(tmp_path)
+    calls: list[str] = []
+    initial_ram_bytes = 32 * 1024**3
+    target = {
+        "os": "linux",
+        "gpu_driver": "stable",
+        "visible_ram_bytes": initial_ram_bytes,
+    }
+
+    def execute(
+        run_name: str,
+        configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        calls.append(run_name)
+        return _successful_run_attempt(configuration, run_name)
+
+    runner = _runner(execute, environment_probe=lambda: dict(target))
+    assert runner.run(profile_path=profile_path, suite="release") == 3
+    state_path = (
+        tmp_path
+        / "artifacts"
+        / "target-acceptance"
+        / "release"
+        / "acceptance-state.json"
+    )
+    state = read_json_object(state_path)
+    assert state is not None
+    stored_target = state["target"]
+    assert isinstance(stored_target, dict)
+    assert stored_target["visible_ram_bytes"] == initial_ram_bytes
+    target["visible_ram_bytes"] = initial_ram_bytes + delta_bytes
+
+    # Act
+    resumed = runner.run(profile_path=profile_path, suite="release")
+
+    # Assert
+    assert resumed == 3
+    assert calls == ["cold", "warm"]
+    resumed_state = read_json_object(state_path)
+    assert resumed_state is not None
+    resumed_target = resumed_state["target"]
+    assert isinstance(resumed_target, dict)
+    assert resumed_target["visible_ram_bytes"] == initial_ram_bytes
+
+
+@pytest.mark.parametrize(
+    "delta_bytes",
+    (-(1024**2) - 1, 1024**2 + 1),
+)
+def test_completed_state_rejects_meaningful_visible_ram_change(
+    tmp_path: Path,
+    delta_bytes: int,
+) -> None:
+    """1 MiBを超えるvisible RAM差がtarget変更として拒否されること。
+
+    Arrange:
+        - 実測visible RAMを持つcold/warm完了stateが用意される
+    Act:
+        - 現在値が1 MiBを超えて変わったtargetからsuiteが再開される
+    Assert:
+        - target identity不一致としてphase再実行前に拒否されること
+    """
+    # Arrange
+    profile_path = _profile(tmp_path)
+    calls: list[str] = []
+    initial_ram_bytes = 32 * 1024**3
+    target = {
+        "os": "linux",
+        "gpu_driver": "stable",
+        "visible_ram_bytes": initial_ram_bytes,
+    }
+
+    def execute(
+        run_name: str,
+        configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        calls.append(run_name)
+        return _successful_run_attempt(configuration, run_name)
+
+    runner = _runner(execute, environment_probe=lambda: dict(target))
+    assert runner.run(profile_path=profile_path, suite="release") == 3
+    target["visible_ram_bytes"] = initial_ram_bytes + delta_bytes
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="target identity"):
+        runner.run(profile_path=profile_path, suite="release")
+    assert calls == ["cold", "warm"]
+
+
+@pytest.mark.parametrize(
+    "invalid_value",
+    (None, True, "34359738368", "missing"),
+)
+def test_completed_state_rejects_invalid_visible_ram_identity(
+    tmp_path: Path,
+    invalid_value: object,
+) -> None:
+    """欠落または非整数のvisible RAM identityが拒否されること。
+
+    Arrange:
+        - 正の整数のvisible RAMを持つcold/warm完了stateが用意される
+    Act:
+        - 現在targetのRAM fieldが欠落または不正型へ変更される
+    Assert:
+        - target identity不一致としてphase再実行前に拒否されること
+    """
+    # Arrange
+    profile_path = _profile(tmp_path)
+    calls: list[str] = []
+    target: dict[str, object] = {
+        "os": "linux",
+        "gpu_driver": "stable",
+        "visible_ram_bytes": 32 * 1024**3,
+    }
+
+    def execute(
+        run_name: str,
+        configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        calls.append(run_name)
+        return _successful_run_attempt(configuration, run_name)
+
+    runner = _runner(execute, environment_probe=lambda: dict(target))
+    assert runner.run(profile_path=profile_path, suite="release") == 3
+    if invalid_value == "missing":
+        target.pop("visible_ram_bytes")
+    else:
+        target["visible_ram_bytes"] = invalid_value
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="target identity"):
+        runner.run(profile_path=profile_path, suite="release")
     assert calls == ["cold", "warm"]
 
 
@@ -1394,6 +1557,7 @@ def _runner(
                 "host_os": "windows_11_pro",
                 "environment": "wsl2",
                 "gpu": "rtx_5090",
+                "visible_ram_bytes": 32 * 1024**3,
             }
         ),
         revision_probe=lambda _path: ("a" * 40, False),


### PR DESCRIPTION
## 概要

WSL2再起動時に`MemTotal`がページ単位で微小変動しても、同一targetとしてfull-scale target acceptanceを安全に再開できるようにします。

Closes #210

## 原因

Acceptance stateのtarget identityを辞書の完全一致で比較していたため、Windows/WSL2の構成が変わっていなくても、再起動による`visible_ram_bytes`の数KiBの変動だけで再開が拒否されていました。

## 変更内容

- `visible_ram_bytes`のみ保存値との差が1 MiB以内なら同一targetとして扱う
- 初回probeの実測値はstateへそのまま保持する
- 1 MiB超、field欠落、非整数値、非正値は不一致として拒否する
- RAM以外のtarget fieldは従来どおり完全一致を要求する
- durable resumeの判定仕様を文書化する

## 影響

WSL2を再起動しても、ハードウェア・driver・runtime等が同一なら完了済みphaseを再実行せず再開できます。意味のある構成変更は引き続き拒否されます。

## 検証

- `uv run pytest tests/video_selection/acceptance/test_target_suite_runner.py`（34 passed）
- `uv run task test`（884 passed）
- `git diff --check`