### PR TITLE
fix: Frame Candidateを時間的に分散する

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -281,7 +281,7 @@ Candidate Annotationとcache再利用のためにFrame Candidateごとに永続�
 _Avoid_: Heartbeat Proxy, original-resolution frame, selected output
 
 **Frame Refinement**:
-Candidate Momentのanchor前後にあるnative frameを対象に、Content Reject Reason判定、Source-Local Frame Deduplication、最大Frame Candidate数への選抜を行うVideo Stage処理。重なるrefinement windowは一つのRefinement Window Groupとして扱い、最初に最もQuality Scoreが高いframeを選び、残りは選択済みframeとの最小視覚距離、Quality Score、anchorへの近さ、早いVideo Timeの順で最大件数まで選ぶ。Candidate Momentから参照する最終順序はVideo Time順とする。
+Candidate Momentのanchor前後にあるnative frameを対象に、Content Reject Reason判定、Source-Local Frame Deduplication、最大Frame Candidate数への選抜を行うVideo Stage処理。重なるrefinement windowは一つのRefinement Window Groupとして扱い、最初に最もQuality Scoreが高いframeを選び、残りは選択済みframeとの最小時間距離、最小視覚距離、Quality Score、anchorへの近さ、早いVideo Timeの順で最大件数まで選ぶ。高Qualityの一時的なeffectが一時点へ集中してもfallback候補を同じ瞬間だけで埋めず、Refinement Window内の有効frameへ時間的に分散させる。Candidate Momentから参照する最終順序はVideo Time順とする。
 _Avoid_: fixed-fps conversion, Candidate Annotation, Representative Frame selection
 
 **Refinement Window Group**:

--- a/docs/video-stage.md
+++ b/docs/video-stage.md
@@ -21,7 +21,7 @@ Ctrl+Cでは未開始の`scan-video`を先に取り消し、その後で実行�
    - Moment前後のnative frameだけをrange scanで取り出します。独立rangeは入力順を保ったまま、logical CPU数に応じて最大4 workerで並列decodeします。
    - 同時に保持するdecode結果はworker数以下へ制限します。重なるMoment windowを一つのRefinement Window Groupとして順次処理し、選抜proxyを書いた時点でそのgroupのRGB frameを解放します。
    - 各Refinement Window Groupのproxyと解析結果をDurable Work Unitとしてatomicに確定し、PTS順に親Stageへ集約します。
-   - group内でmodel-free Neutral Image Analysis、無効frame除外、Moment内deduplication、多様性選抜を行います。
+   - group内でmodel-free Neutral Image Analysis、無効frame除外、Moment内deduplication、多様性選抜を行います。最初に最高Qualityのframeを保持し、残りは選択済みframeとの最小時間距離を最優先、最小視覚距離とQualityを後続条件として、Refinement Window全体へ決定的に分散させます。
    - Frame Candidate Proxyと抽出metricをatomicに確定します。
 3. `collect-context`
    - embedded text subtitleを優先し、選ばれなかった場合だけaudio STTを実行します。forced subtitleの場合はsubtitleとSTTの両方を保持します。

--- a/src/video_selection/services/refine_candidate_moments.py
+++ b/src/video_selection/services/refine_candidate_moments.py
@@ -339,6 +339,13 @@ def _select_diverse_frames(
         chosen = max(
             remaining,
             key=lambda item: (
+                min(
+                    abs(
+                        _video_time(item[0], timeline)
+                        - _video_time(existing[0], timeline)
+                    )
+                    for existing in selected
+                ),
                 min(_visual_distance(item[1], existing[1]) for existing in selected),
                 item[1].quality_score,
                 -abs(_video_time(item[0], timeline) - moment.anchor_time),

--- a/src/video_selection/services/stage_version.py
+++ b/src/video_selection/services/stage_version.py
@@ -5,7 +5,7 @@ from ..models.processing_stage import ProcessingStage
 _STAGE_VERSIONS = {
     ProcessingStage.DISCOVER_VIDEO_SET: "video-set-discovery-v1",
     ProcessingStage.SCAN_VIDEO: "video-scan-v6",
-    ProcessingStage.EXTRACT_FRAME_CANDIDATES: "frame-candidate-extraction-v3",
+    ProcessingStage.EXTRACT_FRAME_CANDIDATES: "frame-candidate-extraction-v4",
     ProcessingStage.COLLECT_CONTEXT: "context-collection-v4",
     ProcessingStage.RESOLVE_MODELS: "model-resolution-v1",
     ProcessingStage.BUILD_SCENE_CATALOG: "scene-catalog-v1",

--- a/src/video_selection/services/video_stage_processor.py
+++ b/src/video_selection/services/video_stage_processor.py
@@ -89,7 +89,7 @@ _SCAN_PARTITION_SECONDS = 900.0
 _TIMELINE_ALGORITHM_VERSION = "exact-timeline-v1"
 _SCAN_PROXY_ANALYSIS_VERSION = "scan-proxy-analysis-v1"
 _HEARTBEAT_PROXY_CONTRACT = "ffmpeg-mjpeg-960-q3-no-metadata-v1"
-_CANDIDATE_EXTRACTION_VERSION = "frame-candidate-extraction-v3"
+_CANDIDATE_EXTRACTION_VERSION = "frame-candidate-extraction-v4"
 _REFINEMENT_GROUP_CHECKPOINT_VERSION = checkpoint_version(
     CheckpointOperation.FRAME_REFINEMENT_GROUP
 )

--- a/tests/video_selection/services/test_refine_candidate_moments.py
+++ b/tests/video_selection/services/test_refine_candidate_moments.py
@@ -159,3 +159,36 @@ def test_per_moment_deduplication_and_zero_frame_moment_are_reported() -> None:
     assert extraction.deduplicated_frame_count == 1
     assert extraction.zero_frame_moment_count == 1
     assert extraction.reject_breakdown[ContentRejectReason.BLACKOUT.value] == 1
+
+
+def test_frame_candidates_cover_the_refinement_window_over_clustered_quality() -> None:
+    """高品質frameが一時点へ集中しても時間的に分散して選抜されること。
+
+    Arrange:
+        - 中央付近の3frameだけが品質と視覚差で優位になるnative frame列が用意される
+    Act:
+        - 2秒未満のRefinement Windowから最大3frameが選抜される
+    Assert:
+        - 最良品質frameを保持しながらwindow前後の有効frameも選抜されること
+    """
+    # Arrange
+    shifts = (0, 4, 8, 1, 5, 9, 2, 6, 10, 3)
+    frames = tuple(
+        _detailed_frame(source_pts, shift)
+        for source_pts, shift in enumerate(shifts, start=10)
+    )
+    moment = _moment("6", Fraction(3, 2))
+
+    # Act
+    extraction = refine_candidate_moments(
+        video_fingerprint="c" * 64,
+        timeline=_timeline(),
+        moments=(moment,),
+        frames=frames,
+        refinement_radius_seconds=0.5,
+        max_frame_candidates=3,
+    )
+
+    # Assert
+    selected_pts = tuple(candidate.source_pts for candidate in extraction.candidates)
+    assert selected_pts == (10, 15, 19)

--- a/tests/video_selection/services/test_stage_version.py
+++ b/tests/video_selection/services/test_stage_version.py
@@ -43,7 +43,7 @@ def test_extract_frame_candidates_has_isolated_cpu_metric_stage_version() -> Non
     version = stage_version(stage)
 
     # Assert
-    assert version == "frame-candidate-extraction-v3"
+    assert version == "frame-candidate-extraction-v4"
 
 
 def test_scan_video_has_partition_resume_stage_version() -> None:


### PR DESCRIPTION
## 概要

- Frame Refinementで最高QualityのPrimary候補を維持する
- 残り候補を、選択済みframeとの最小時間距離を最優先にしてRefinement Window全体へ分散する
- 視覚距離、Quality、anchor距離、Video Timeを安定した後続tie-breakとして維持する
- Frame Candidate Extractionを`v4`へ更新し、Frame Refinement以降だけを安全に失効させる
- `CONTEXT.md`とVideo Stage文書へ選抜契約を反映する

## 背景

PR #226のrelease target acceptanceでは、通常雑魚戦の2秒windowに59件の有効native frameがある一方、候補3件が攻撃effect付近へ集中しました。後段のCombat Representative Fallbackは渡された3枚を正しく独立評価しましたが、敵本体が明瞭な別時刻を入力として受け取れず、ordinary combatが0件でした。

Combat Visibilityの掲載境界は緩めず、fallbackへ渡す候補だけを時間的に偏らないよう修正します。

Relates to #221

## 検証

- `uv run task test`
- 1113 tests passed
- 高Quality frameが中央へ集中するfixtureで、従来の`(13, 14, 15)`ではなくwindow前後を含む`(10, 15, 19)`が選ばれることを確認

## マージ後の確認

Issue #189のrelease target suiteを再実行し、通常雑魚戦coverageとFresh Processing時間を再測定します。既知の1200秒超過はbudget緩和で隠さず、独立requestのbounded並列化範囲を別途診断します。