### PR TITLE
fix: Acceptance active markerの回復対象を正しく解決する

### DIFF
--- a/docs/target-acceptance.md
+++ b/docs/target-acceptance.md
@@ -237,6 +237,9 @@ attemptとして確定する。active attempt journalのexecution context、cach
 kill後も残ったVideo Identity、Durable Work Unit、Completed Stage manifestを照合して
 確定直前の作業量も回復し、markerを消して新しいattemptから自動再開する。`--reset-suite`や
 最初からの再処理は要求しない。
+回復対象はactive markerの種別keyと保存run名の両方でexecution planから一意に解決する。
+phaseとcomparisonが同時にactiveな場合、または保存run名がplanに存在しない場合は、
+attempt、state、journalを推測で変更せずfail-fastする。
 
 identityを変えた場合や意図的に特定runからやり直す場合だけ、対象runまたはsuiteを
 明示的にresetする。

--- a/src/video_selection/acceptance/target_suite_runner.py
+++ b/src/video_selection/acceptance/target_suite_runner.py
@@ -243,6 +243,7 @@ class TargetSuiteRunner:
         if not _is_sha256(materialization_source_snapshot):
             raise ValueError("Suite source snapshot fingerprintがありません")
         if state is not None:
+            _resolve_active_step(state, execution_steps)
             if "materialization_source_snapshot_fingerprint" not in state:
                 state["materialization_source_snapshot_fingerprint"] = (
                     materialization_source_snapshot

--- a/src/video_selection/acceptance/target_suite_runner.py
+++ b/src/video_selection/acceptance/target_suite_runner.py
@@ -1376,9 +1376,7 @@ def _recover_abandoned_attempt(
 ) -> None:
     """process終了で残ったactive markerを保守的なattemptへ閉じる。"""
     active_markers = {
-        key: state[key]
-        for key in _ACTIVE_RUN_STATE_KEYS
-        if state.get(key) is not None
+        key: state[key] for key in _ACTIVE_RUN_STATE_KEYS if state.get(key) is not None
     }
     if not active_markers:
         return

--- a/src/video_selection/acceptance/target_suite_runner.py
+++ b/src/video_selection/acceptance/target_suite_runner.py
@@ -180,9 +180,7 @@ class TargetSuiteRunner:
                 cold_configuration,
                 warm_configuration,
             )
-            if any(
-                state.get(step.active_state_key) is not None for step in execution_steps
-            ):
+            if _resolve_active_step(state, execution_steps) is not None:
                 raise ValueError("完了済みAcceptance stateにactive runがあります")
             attempt_journal.clear()
             for step in execution_steps:
@@ -1375,22 +1373,9 @@ def _recover_abandoned_attempt(
     attempt_journal: AcceptanceAttemptJournal,
 ) -> None:
     """process終了で残ったactive markerを保守的なattemptへ閉じる。"""
-    active_markers = {
-        key: state[key] for key in _ACTIVE_RUN_STATE_KEYS if state.get(key) is not None
-    }
-    if not active_markers:
+    step = _resolve_active_step(state, steps)
+    if step is None:
         return
-    if len(active_markers) != 1:
-        raise ValueError("複数のAcceptance Runが同時にactiveです")
-    active_key, active_name = next(iter(active_markers.items()))
-    active_steps = tuple(
-        step
-        for step in steps
-        if step.active_state_key == active_key and step.name == active_name
-    )
-    if len(active_steps) != 1:
-        raise ValueError("Acceptance active runが現在のexecution planと一致しません")
-    step = active_steps[0]
     started_at = state.get(_active_attempt_started_key(step))
     duration_seconds = (
         max(0.0, time.time() - float(started_at))
@@ -1461,6 +1446,29 @@ def _recover_abandoned_attempt(
     }
     write_atomic_json(state_path, state)
     attempt_journal.clear()
+
+
+def _resolve_active_step(
+    state: Mapping[str, object],
+    steps: tuple[AcceptanceExecutionStep, ...],
+) -> AcceptanceExecutionStep | None:
+    """active markerを副作用なしで一つの実行stepへ解決する。"""
+    active_markers = {
+        key: state[key] for key in _ACTIVE_RUN_STATE_KEYS if state.get(key) is not None
+    }
+    if not active_markers:
+        return None
+    if len(active_markers) != 1:
+        raise ValueError("複数のAcceptance Runが同時にactiveです")
+    active_key, active_name = next(iter(active_markers.items()))
+    active_steps = tuple(
+        step
+        for step in steps
+        if step.active_state_key == active_key and step.name == active_name
+    )
+    if len(active_steps) != 1:
+        raise ValueError("Acceptance active runが現在のexecution planと一致しません")
+    return active_steps[0]
 
 
 def _active_attempt_started_key(step: AcceptanceExecutionStep) -> str:

--- a/src/video_selection/acceptance/target_suite_runner.py
+++ b/src/video_selection/acceptance/target_suite_runner.py
@@ -79,6 +79,7 @@ SuiteMaterializer = Callable[
 StoragePreflight = Callable[[AcceptanceProfile, Path], dict[str, object]]
 
 _STATE_SCHEMA = "game-screen-pick/target-acceptance-state@1.3.0"
+_ACTIVE_RUN_STATE_KEYS = ("active_phase", "active_comparison_run")
 
 
 class TargetSuiteRunner:
@@ -1374,17 +1375,24 @@ def _recover_abandoned_attempt(
     attempt_journal: AcceptanceAttemptJournal,
 ) -> None:
     """process終了で残ったactive markerを保守的なattemptへ閉じる。"""
-    active_steps = tuple(
-        step for step in steps if state.get(step.active_state_key) is not None
-    )
-    if not active_steps:
+    active_markers = {
+        key: state[key]
+        for key in _ACTIVE_RUN_STATE_KEYS
+        if state.get(key) is not None
+    }
+    if not active_markers:
         return
-    if len(active_steps) != 1:
+    if len(active_markers) != 1:
         raise ValueError("複数のAcceptance Runが同時にactiveです")
-    step = active_steps[0]
-    active_name = state.get(step.active_state_key)
-    if active_name != step.name:
+    active_key, active_name = next(iter(active_markers.items()))
+    active_steps = tuple(
+        step
+        for step in steps
+        if step.active_state_key == active_key and step.name == active_name
+    )
+    if len(active_steps) != 1:
         raise ValueError("Acceptance active runが現在のexecution planと一致しません")
+    step = active_steps[0]
     started_at = state.get(_active_attempt_started_key(step))
     duration_seconds = (
         max(0.0, time.time() - float(started_at))

--- a/tests/video_selection/acceptance/test_target_suite_runner.py
+++ b/tests/video_selection/acceptance/test_target_suite_runner.py
@@ -3285,7 +3285,9 @@ def _persist_active_attempt(
     state_path = suite_root / "acceptance-state.json"
     state = read_json_object(state_path)
     assert state is not None
-    attempts_key = "phase_attempts" if step_kind == "phase" else "comparison_run_attempts"
+    attempts_key = (
+        "phase_attempts" if step_kind == "phase" else "comparison_run_attempts"
+    )
     attempts_by_name = state[attempts_key]
     assert isinstance(attempts_by_name, dict)
     attempts = attempts_by_name[step_name]

--- a/tests/video_selection/acceptance/test_target_suite_runner.py
+++ b/tests/video_selection/acceptance/test_target_suite_runner.py
@@ -531,10 +531,10 @@ def test_simultaneous_active_markers_are_rejected_without_mutation(
 def test_unknown_active_marker_is_rejected_without_mutation(
     tmp_path: Path,
 ) -> None:
-    """実行planに存在しないactive markerが変更されず拒否されること。
+    """旧stateの未知active markerがmigrationされず拒否されること。
 
     Arrange:
-        - 未知のphase名を持つactive stateとjournalが永続化される
+        - source fingerprintがない旧stateへ未知phase markerとjournalが永続化される
     Act:
         - `--reset-suite`なしで同じrelease suiteが再実行される
     Assert:
@@ -566,6 +566,7 @@ def test_unknown_active_marker_is_rejected_without_mutation(
     state = read_json_object(state_path)
     assert state is not None
     state["active_phase"] = "unknown"
+    state.pop("materialization_source_snapshot_fingerprint")
     write_atomic_json(state_path, state)
     state_before = state_path.read_bytes()
     journal_before = journal_path.read_bytes()

--- a/tests/video_selection/acceptance/test_target_suite_runner.py
+++ b/tests/video_selection/acceptance/test_target_suite_runner.py
@@ -377,17 +377,53 @@ def test_abandoned_active_phase_is_recovered_without_reset(
     assert abandoned["stage_durations_seconds"] == {"scan-video": 3.0}
 
 
-def test_abandoned_warm_marker_recovers_only_warm_phase(
+@pytest.mark.parametrize(
+    (
+        "suite",
+        "step_kind",
+        "step_name",
+        "active_key",
+        "attempts_key",
+        "expected_calls",
+    ),
+    (
+        pytest.param(
+            "release",
+            "phase",
+            "warm",
+            "active_phase",
+            "phase_attempts",
+            ("cold", "warm", "warm"),
+            id="warm-phase",
+        ),
+        pytest.param(
+            "full",
+            "comparison",
+            "fixed3",
+            "active_comparison_run",
+            "comparison_run_attempts",
+            ("fixed3", "fixed3"),
+            id="fixed3-comparison",
+        ),
+    ),
+)
+def test_abandoned_marker_recovers_only_matching_run(
     tmp_path: Path,
+    suite: str,
+    step_kind: str,
+    step_name: str,
+    active_key: str,
+    attempts_key: str,
+    expected_calls: tuple[str, ...],
 ) -> None:
-    """process異常終了したwarmだけが再開されること。
+    """process異常終了したrunだけがmarker名どおり再開されること。
 
     Arrange:
-        - cold完了後にwarmの単一active markerとjournalが永続化される
+        - warmまたはfixed3の単一active markerとjournalが永続化される
     Act:
         - `--reset-suite`なしで同じsuiteが再実行される
     Assert:
-        - coldが再実行されずwarmだけがabandoned attemptから再開されること
+        - 他のrunへ戻らず一致するrunだけがabandoned attemptから再開されること
     """
     # Arrange
     profile_path = _profile(tmp_path)
@@ -400,90 +436,36 @@ def test_abandoned_warm_marker_recovers_only_warm_phase(
         _suite_root: Path,
     ) -> AcceptanceRunAttemptExecutionResult:
         calls.append(run_name)
-        if run_name == "warm":
-            return 130, _interrupted_run_attempt(run_name), None, None
-        return _successful_run_attempt(configuration, run_name)
-
-    runner = _runner(execute)
-    assert runner.run(profile_path=profile_path, suite="release") == 130
-    suite_root = tmp_path / "artifacts" / "target-acceptance" / "release"
-    _persist_active_attempt(
-        suite_root,
-        step_kind="phase",
-        step_name="warm",
-    )
-
-    # Act
-    resumed = runner.run(profile_path=profile_path, suite="release")
-
-    # Assert
-    assert resumed == 130
-    assert calls == ["cold", "warm", "warm"]
-    state = read_json_object(suite_root / "acceptance-state.json")
-    assert state is not None
-    assert state.get("active_phase") is None
-    phase_attempts = state["phase_attempts"]
-    assert isinstance(phase_attempts, dict)
-    warm_attempts = phase_attempts["warm"]
-    assert isinstance(warm_attempts, list)
-    assert any(
-        isinstance(attempt, dict)
-        and attempt.get("failure_reason") == "process_abandoned"
-        for attempt in warm_attempts
-    )
-
-
-def test_abandoned_comparison_marker_recovers_only_comparison_run(
-    tmp_path: Path,
-) -> None:
-    """process異常終了したcomparison runだけが再開されること。
-
-    Arrange:
-        - fixed3の単一active markerとjournalがfull suiteへ永続化される
-    Act:
-        - `--reset-suite`なしで同じsuiteが再実行される
-    Assert:
-        - phaseへ進まずfixed3だけがabandoned attemptから再開されること
-    """
-    # Arrange
-    profile_path = _profile(tmp_path)
-    calls: list[str] = []
-
-    def execute(
-        run_name: str,
-        _configuration: EffectiveConfiguration,
-        _models: ResolvedModels,
-        _suite_root: Path,
-    ) -> AcceptanceRunAttemptExecutionResult:
-        calls.append(run_name)
+        if step_name == "warm" and run_name == "cold":
+            return _successful_run_attempt(configuration, run_name)
         return 130, _interrupted_run_attempt(run_name), None, None
 
     runner = _runner(execute)
-    assert runner.run(profile_path=profile_path, suite="full") == 130
-    suite_root = tmp_path / "artifacts" / "target-acceptance" / "full"
+    assert runner.run(profile_path=profile_path, suite=suite) == 130
+    suite_root = tmp_path / "artifacts" / "target-acceptance" / suite
     _persist_active_attempt(
         suite_root,
-        step_kind="comparison",
-        step_name="fixed3",
+        step_kind=step_kind,
+        step_name=step_name,
     )
 
     # Act
-    resumed = runner.run(profile_path=profile_path, suite="full")
+    resumed = runner.run(profile_path=profile_path, suite=suite)
 
     # Assert
     assert resumed == 130
-    assert calls == ["fixed3", "fixed3"]
+    assert calls == list(expected_calls)
     state = read_json_object(suite_root / "acceptance-state.json")
     assert state is not None
-    assert state.get("active_comparison_run") is None
-    comparison_attempts = state["comparison_run_attempts"]
-    assert isinstance(comparison_attempts, dict)
-    fixed_three_attempts = comparison_attempts["fixed3"]
-    assert isinstance(fixed_three_attempts, list)
+    assert state.get(active_key) is None
+    attempts_by_name = state[attempts_key]
+    assert isinstance(attempts_by_name, dict)
+    attempts = attempts_by_name[step_name]
+    assert isinstance(attempts, list)
     assert any(
         isinstance(attempt, dict)
         and attempt.get("failure_reason") == "process_abandoned"
-        for attempt in fixed_three_attempts
+        for attempt in attempts
     )
 
 

--- a/tests/video_selection/acceptance/test_target_suite_runner.py
+++ b/tests/video_selection/acceptance/test_target_suite_runner.py
@@ -579,6 +579,59 @@ def test_unknown_active_marker_is_rejected_without_mutation(
     assert journal_path.read_bytes() == journal_before
 
 
+def test_completed_release_rejects_out_of_plan_active_comparison_without_mutation(
+    tmp_path: Path,
+) -> None:
+    """完了済みreleaseでも対象外comparison markerが変更されず拒否されること。
+
+    Arrange:
+        - coldとwarmが完了したrelease stateへfixed3 markerとjournalが永続化される
+    Act:
+        - `--reset-suite`なしで同じrelease suiteが再実行される
+    Assert:
+        - stateとjournalを変更せずexecution plan不一致として拒否されること
+    """
+    # Arrange
+    profile_path = _profile(tmp_path)
+    calls: list[str] = []
+
+    def execute(
+        run_name: str,
+        configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        calls.append(run_name)
+        return _successful_run_attempt(configuration, run_name)
+
+    runner = _runner(execute)
+    assert runner.run(profile_path=profile_path, suite="release") == 3
+    suite_root = tmp_path / "artifacts" / "target-acceptance" / "release"
+    state_path = suite_root / "acceptance-state.json"
+    journal_path = suite_root / "work" / "active-attempt.json"
+    state = read_json_object(state_path)
+    assert state is not None
+    state["active_comparison_run"] = "fixed3"
+    write_atomic_json(state_path, state)
+    AcceptanceAttemptJournal(journal_path).start(
+        attempt_id="abandoned-fixed3",
+        step_kind="comparison",
+        step_name="fixed3",
+        started_at_epoch_seconds=0.0,
+        execution_context={},
+    )
+    state_before = state_path.read_bytes()
+    journal_before = journal_path.read_bytes()
+
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="execution planと一致しません"):
+        runner.run(profile_path=profile_path, suite="release")
+    assert calls == ["cold", "warm"]
+    assert state_path.read_bytes() == state_before
+    assert journal_path.read_bytes() == journal_before
+
+
 def test_reset_suite_discards_completed_state_and_runs_cold_again(
     tmp_path: Path,
 ) -> None:

--- a/tests/video_selection/acceptance/test_target_suite_runner.py
+++ b/tests/video_selection/acceptance/test_target_suite_runner.py
@@ -314,16 +314,17 @@ def test_abandoned_active_phase_is_recovered_without_reset(
     """process異常終了でactive phaseが残ってもsuiteが再開されること。
 
     Arrange:
-        - cold executorが計測record確定前に一度だけ異常終了するsuiteが用意される
+        - cold中にprocess終了した単一active markerとjournalが永続化される
     Act:
         - `--reset-suite`なしで同じsuiteが再実行される
     Assert:
-        - active markerが回復されcoldとwarmがCompleted workから続行されること
+        - marker名と一致するcoldだけがabandoned attemptとして回復されること
+        - coldとwarmがCompleted workから続行されること
     """
     # Arrange
     profile_path = _profile(tmp_path)
     calls: list[str] = []
-    failed = False
+    interrupted = False
 
     def execute(
         run_name: str,
@@ -331,28 +332,22 @@ def test_abandoned_active_phase_is_recovered_without_reset(
         _models: ResolvedModels,
         _suite_root: Path,
     ) -> AcceptanceRunAttemptExecutionResult:
-        nonlocal failed
+        nonlocal interrupted
         calls.append(run_name)
-        if not failed:
-            failed = True
-            AcceptanceAttemptJournal(
-                _suite_root / "work" / "active-attempt.json"
-            ).record_snapshot(
-                {
-                    "cache_hit_count": 2,
-                    "cache_miss_count": 1,
-                    "reuse_count": 2,
-                    "unexpected_recompute_count": 1,
-                    "stage_durations_seconds": {"scan-video": 3.0},
-                    "completed_stage_counts": {"scan-video": 1},
-                },
-                {"1" * 64: "recomputed"},
-            )
-            raise RuntimeError("simulated process loss")
+        if not interrupted:
+            interrupted = True
+            return 130, _interrupted_run_attempt(run_name), None, None
         return _successful_run_attempt(configuration, run_name)
 
     runner = _runner(execute)
-    assert runner.run(profile_path=profile_path, suite="release") == 1
+    assert runner.run(profile_path=profile_path, suite="release") == 130
+    suite_root = tmp_path / "artifacts" / "target-acceptance" / "release"
+    state_path = suite_root / "acceptance-state.json"
+    _persist_active_attempt(
+        suite_root,
+        step_kind="phase",
+        step_name="cold",
+    )
 
     # Act
     resumed = runner.run(profile_path=profile_path, suite="release")
@@ -360,13 +355,7 @@ def test_abandoned_active_phase_is_recovered_without_reset(
     # Assert
     assert resumed == 1
     assert calls == ["cold", "cold", "warm"]
-    state = read_json_object(
-        tmp_path
-        / "artifacts"
-        / "target-acceptance"
-        / "release"
-        / "acceptance-state.json"
-    )
+    state = read_json_object(state_path)
     assert state is not None
     assert state.get("active_phase") is None
     phases = state["phases"]
@@ -375,13 +364,237 @@ def test_abandoned_active_phase_is_recovered_without_reset(
     assert isinstance(cold, dict)
     attempts = cold["attempts"]
     assert isinstance(attempts, list)
-    first_attempt = attempts[0]
-    assert isinstance(first_attempt, dict)
-    assert first_attempt["cache_hit_count"] == 2
-    assert first_attempt["cache_miss_count"] == 1
-    assert first_attempt["reuse_count"] == 2
-    assert first_attempt["unexpected_recompute_count"] == 1
-    assert first_attempt["stage_durations_seconds"] == {"scan-video": 3.0}
+    abandoned = next(
+        attempt
+        for attempt in attempts
+        if isinstance(attempt, dict)
+        and attempt.get("failure_reason") == "process_abandoned"
+    )
+    assert abandoned["cache_hit_count"] == 2
+    assert abandoned["cache_miss_count"] == 1
+    assert abandoned["reuse_count"] == 2
+    assert abandoned["unexpected_recompute_count"] == 1
+    assert abandoned["stage_durations_seconds"] == {"scan-video": 3.0}
+
+
+def test_abandoned_warm_marker_recovers_only_warm_phase(
+    tmp_path: Path,
+) -> None:
+    """process異常終了したwarmだけが再開されること。
+
+    Arrange:
+        - cold完了後にwarmの単一active markerとjournalが永続化される
+    Act:
+        - `--reset-suite`なしで同じsuiteが再実行される
+    Assert:
+        - coldが再実行されずwarmだけがabandoned attemptから再開されること
+    """
+    # Arrange
+    profile_path = _profile(tmp_path)
+    calls: list[str] = []
+
+    def execute(
+        run_name: str,
+        configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        calls.append(run_name)
+        if run_name == "warm":
+            return 130, _interrupted_run_attempt(run_name), None, None
+        return _successful_run_attempt(configuration, run_name)
+
+    runner = _runner(execute)
+    assert runner.run(profile_path=profile_path, suite="release") == 130
+    suite_root = tmp_path / "artifacts" / "target-acceptance" / "release"
+    _persist_active_attempt(
+        suite_root,
+        step_kind="phase",
+        step_name="warm",
+    )
+
+    # Act
+    resumed = runner.run(profile_path=profile_path, suite="release")
+
+    # Assert
+    assert resumed == 130
+    assert calls == ["cold", "warm", "warm"]
+    state = read_json_object(suite_root / "acceptance-state.json")
+    assert state is not None
+    assert state.get("active_phase") is None
+    phase_attempts = state["phase_attempts"]
+    assert isinstance(phase_attempts, dict)
+    warm_attempts = phase_attempts["warm"]
+    assert isinstance(warm_attempts, list)
+    assert any(
+        isinstance(attempt, dict)
+        and attempt.get("failure_reason") == "process_abandoned"
+        for attempt in warm_attempts
+    )
+
+
+def test_abandoned_comparison_marker_recovers_only_comparison_run(
+    tmp_path: Path,
+) -> None:
+    """process異常終了したcomparison runだけが再開されること。
+
+    Arrange:
+        - fixed3の単一active markerとjournalがfull suiteへ永続化される
+    Act:
+        - `--reset-suite`なしで同じsuiteが再実行される
+    Assert:
+        - phaseへ進まずfixed3だけがabandoned attemptから再開されること
+    """
+    # Arrange
+    profile_path = _profile(tmp_path)
+    calls: list[str] = []
+
+    def execute(
+        run_name: str,
+        _configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        calls.append(run_name)
+        return 130, _interrupted_run_attempt(run_name), None, None
+
+    runner = _runner(execute)
+    assert runner.run(profile_path=profile_path, suite="full") == 130
+    suite_root = tmp_path / "artifacts" / "target-acceptance" / "full"
+    _persist_active_attempt(
+        suite_root,
+        step_kind="comparison",
+        step_name="fixed3",
+    )
+
+    # Act
+    resumed = runner.run(profile_path=profile_path, suite="full")
+
+    # Assert
+    assert resumed == 130
+    assert calls == ["fixed3", "fixed3"]
+    state = read_json_object(suite_root / "acceptance-state.json")
+    assert state is not None
+    assert state.get("active_comparison_run") is None
+    comparison_attempts = state["comparison_run_attempts"]
+    assert isinstance(comparison_attempts, dict)
+    fixed_three_attempts = comparison_attempts["fixed3"]
+    assert isinstance(fixed_three_attempts, list)
+    assert any(
+        isinstance(attempt, dict)
+        and attempt.get("failure_reason") == "process_abandoned"
+        for attempt in fixed_three_attempts
+    )
+
+
+def test_simultaneous_active_markers_are_rejected_without_mutation(
+    tmp_path: Path,
+) -> None:
+    """phaseとcomparisonの同時active stateが変更されず拒否されること。
+
+    Arrange:
+        - fixed3とcoldが同時にactiveな矛盾stateとjournalが永続化される
+    Act:
+        - `--reset-suite`なしで同じfull suiteが再実行される
+    Assert:
+        - 複数runの誤回復としてstateとjournalを変更せず拒否されること
+    """
+    # Arrange
+    profile_path = _profile(tmp_path)
+    calls: list[str] = []
+
+    def execute(
+        run_name: str,
+        _configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        calls.append(run_name)
+        return 130, _interrupted_run_attempt(run_name), None, None
+
+    runner = _runner(execute)
+    assert runner.run(profile_path=profile_path, suite="full") == 130
+    suite_root = tmp_path / "artifacts" / "target-acceptance" / "full"
+    state_path = suite_root / "acceptance-state.json"
+    journal_path = suite_root / "work" / "active-attempt.json"
+    _persist_active_attempt(
+        suite_root,
+        step_kind="comparison",
+        step_name="fixed3",
+    )
+    state = read_json_object(state_path)
+    assert state is not None
+    execution_context = state["active_comparison_run_execution_context"]
+    state.update(
+        {
+            "active_phase": "cold",
+            "active_phase_started_at_epoch_seconds": 0.0,
+            "active_phase_attempt_id": "abandoned-cold",
+            "active_phase_execution_context": execution_context,
+        }
+    )
+    write_atomic_json(state_path, state)
+    state_before = state_path.read_bytes()
+    journal_before = journal_path.read_bytes()
+
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="複数のAcceptance Run"):
+        runner.run(profile_path=profile_path, suite="full")
+    assert calls == ["fixed3"]
+    assert state_path.read_bytes() == state_before
+    assert journal_path.read_bytes() == journal_before
+
+
+def test_unknown_active_marker_is_rejected_without_mutation(
+    tmp_path: Path,
+) -> None:
+    """実行planに存在しないactive markerが変更されず拒否されること。
+
+    Arrange:
+        - 未知のphase名を持つactive stateとjournalが永続化される
+    Act:
+        - `--reset-suite`なしで同じrelease suiteが再実行される
+    Assert:
+        - stateとjournalを変更せずexecution plan不一致として拒否されること
+    """
+    # Arrange
+    profile_path = _profile(tmp_path)
+    calls: list[str] = []
+
+    def execute(
+        run_name: str,
+        _configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        calls.append(run_name)
+        return 130, _interrupted_run_attempt(run_name), None, None
+
+    runner = _runner(execute)
+    assert runner.run(profile_path=profile_path, suite="release") == 130
+    suite_root = tmp_path / "artifacts" / "target-acceptance" / "release"
+    state_path = suite_root / "acceptance-state.json"
+    journal_path = suite_root / "work" / "active-attempt.json"
+    _persist_active_attempt(
+        suite_root,
+        step_kind="phase",
+        step_name="cold",
+    )
+    state = read_json_object(state_path)
+    assert state is not None
+    state["active_phase"] = "unknown"
+    write_atomic_json(state_path, state)
+    state_before = state_path.read_bytes()
+    journal_before = journal_path.read_bytes()
+
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="execution planと一致しません"):
+        runner.run(profile_path=profile_path, suite="release")
+    assert calls == ["cold"]
+    assert state_path.read_bytes() == state_before
+    assert journal_path.read_bytes() == journal_before
 
 
 def test_reset_suite_discards_completed_state_and_runs_cold_again(
@@ -3077,6 +3290,57 @@ def _runner(
                 "peak_additional_budget_bytes": 96 * 1024**3,
             }
         ),
+    )
+
+
+def _persist_active_attempt(
+    suite_root: Path,
+    *,
+    step_kind: str,
+    step_name: str,
+) -> None:
+    """計測済みattemptに続くprocess異常終了状態を永続化する。"""
+    state_path = suite_root / "acceptance-state.json"
+    state = read_json_object(state_path)
+    assert state is not None
+    attempts_key = "phase_attempts" if step_kind == "phase" else "comparison_run_attempts"
+    attempts_by_name = state[attempts_key]
+    assert isinstance(attempts_by_name, dict)
+    attempts = attempts_by_name[step_name]
+    assert isinstance(attempts, list)
+    prior_attempt = attempts[-1]
+    assert isinstance(prior_attempt, dict)
+    execution_context = prior_attempt["execution_context"]
+    assert isinstance(execution_context, dict)
+    active_key = "active_phase" if step_kind == "phase" else "active_comparison_run"
+    attempt_id = f"abandoned-{step_name}"
+    state.update(
+        {
+            active_key: step_name,
+            f"{active_key}_started_at_epoch_seconds": 0.0,
+            f"{active_key}_attempt_id": attempt_id,
+            f"{active_key}_execution_context": execution_context,
+        }
+    )
+    write_atomic_json(state_path, state)
+    journal = AcceptanceAttemptJournal(suite_root / "work" / "active-attempt.json")
+    journal.start(
+        attempt_id=attempt_id,
+        step_kind=step_kind,
+        step_name=step_name,
+        started_at_epoch_seconds=0.0,
+        execution_context=execution_context,
+    )
+    journal.record_snapshot(
+        {
+            "cache_hit_count": 2,
+            "cache_miss_count": 1,
+            "reuse_count": 2,
+            "unexpected_recompute_count": 1,
+            "stage_durations_seconds": {"scan-video": 3.0},
+            "completed_stage_counts": {"scan-video": 1},
+        },
+        {"1" * 64: "recomputed"},
     )
 
 


### PR DESCRIPTION
## 概要

process強制終了後に残った単一Acceptance active markerが、cold/warmの共有state keyによって複数runと誤認される問題を修正します。

Closes #240
Refs #215

## 変更内容

- active markerの種別keyと保存run名の両方から回復対象を一意に解決
- cold、warm、fixed3 comparisonの単一markerを対応runの `process_abandoned` attemptとして回復
- phaseとcomparisonが同時activeな矛盾stateを変更せずfail-fast
- execution planに存在しないrun名を変更せずfail-fast
- 完了済みstateの早期完了経路でも、journal消去やfinalizationより先に同じmarker検証を実施
- source snapshot fingerprintがないlegacy stateでも、migration書き込みより先にmarkerを検証
- active attempt journal、Completed Stage、Durable Work Unit、Video Identity cacheを保持
- target acceptance運用文書へ回復と矛盾stateの境界を追記

`--reset-suite` と `--reset-run` は要求しません。

## 原因

release suiteのcoldとwarmは同じ `active_phase` keyを共有します。従来処理はmarker値のrun名を照合せず、keyが存在する全stepをactiveとして数えていたため、`active_phase=cold` 1件をcoldとwarmの2件と誤認していました。

また、完了済みstateの早期完了経路はrelease execution planが使う `active_phase` だけを確認し、legacy state migrationはmarker検証より先にstateを書き換えていました。副作用のない共通resolverを早期完了、中断回復、migration前検証で利用します。

## 検証

- focused target suite runner: 67 passed
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run task test`: 1228 passed
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run task test-ffmpeg`: 45 passed
- 完了済みreleaseへ対象外comparison markerとjournalを置く回帰テストで、修正前の未検出・journal消去を再現後にGreen化
- source fingerprintがないlegacy stateへ未知markerを置く回帰テストで、修正前のmigration書き込みを再現後にGreen化

## Supported target probe

WSL2 / RTX 5090 targetの既存release suiteをresetなしで再開しました。

- 修正前: processなし、cold marker 1件、対応journal 1件でも「複数のAcceptance Run」としてexit 2
- 修正後: 旧cold markerを `process_abandoned` attempt 1件として確定し、新しいcold attemptを開始
- Video Identity 3/3をcache hit
- Video Scan、Frame Candidate Extraction、Context Collectionを各3/3 cache hit
- Scene Catalogをcache hit
- Candidate Annotation開始まで到達し、回復確認後にSIGINTで安全に中断
- 中断後はactive markerなし、active attempt journalなし

Completed Stage、Durable Work Unit、Video Identity cacheのresetや削除は行っていません。

## 続き

merge後、統合commitで同じrelease suiteをresetなし再開し、Candidate Annotation 96件とdownstreamの正式acceptanceを継続します。
