### PR TITLE
fix: target acceptanceの安全な再開境界を修復

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -81,12 +81,12 @@ supported target上の実videoからrelease suiteとfull-scale suiteの対象を
 _Avoid_: public TOML, Effective Configuration, committed fixture, production default
 
 **Acceptance Suite Lock**:
-一つのartifact rootとsuiteに対するtarget acceptance commandの同時実行を即時拒否し、安全なsuite root解決後からstate、active marker、attempt journal、cache、worksheetの読込・回復・変更までを保護する非待機排他境界。後発commandは先発の実行中に証拠を変更せず、異なるsuiteの実行は互いに妨げない。
+一つのartifact rootとsuiteに対するtarget acceptance commandの同時実行を即時拒否し、安全なsuite root解決後からstate、active marker、attempt journal、cache、worksheetの読込・回復・変更までを保護する非待機排他境界。lock pathはartifact rootからsymlinkを辿らずdirectory handle相対で作成・openし、後発commandは先発の実行中に証拠を変更せず、異なるsuiteの実行は互いに妨げない。
 _Avoid_: Input Lock, waiting queue, active attempt marker, global lock
 
 **Suite-Owned Deletion Boundary**:
-target acceptanceのrecursive deleteを、明示されたsuite所有root内の対象と、そのrootから対象までにあるsymlinkでも通常directory以外でもない既存chainだけへ限定する安全境界。検証に失敗した場合は外部内容と既存acceptance証拠を変更せずresetを拒否する。
-_Avoid_: path文字列prefix検査, targetだけのsymlink検査, best-effort cleanup, external directory
+target acceptanceのrecursive deleteを、明示されたsuite所有root内の対象と、そのrootから対象までにあるsymlinkでも通常directory以外でもない既存chainだけへ限定する安全境界。削除時は検証済みchainをdirectory handle相対で開き、path検証後にancestorがrenameまたはsymlinkへ差し替えられても外部treeを辿らない。検証に失敗した場合は外部内容と既存acceptance証拠を変更せずresetを拒否する。
+_Avoid_: path文字列prefix検査, targetだけのsymlink検査, path検証とpath-based deleteの分離, best-effort cleanup, external directory
 
 **Acceptance Record**:
 一回のtarget acceptanceで得たcommit、runtime/model identity、pathなしのVideo Set fingerprint、Stage時間、resource、cache、quality判定をversioned JSONとして保存する証拠。media、absolute path、raw text、prompt、model responseを含めない。
@@ -169,7 +169,7 @@ Speech Runtimeが返す、word本文、chunk内の開始・終了PCM sample位�
 _Avoid_: Context Cue, backend object, calibrated confidence, global Video Time
 
 **PCM Range Continuity Validation**:
-checkpoint対象のPCM sample rangeについてMedia Runtimeから観測した先頭sampleのPTSを要求rangeのsample gridと照合し、不連続ならDurable Work Unitの確定前に拒否する検査。観測PTSを期待値へ置換して重複や欠落を隠さず、連続rangeでは中断なしと再開後に同じ音声sampleとContext Cueを確定する。
+checkpoint対象のPCM sample rangeについて、canonical chunkへまとめる前の各PCM frameでMedia Runtimeが観測したPTSを要求rangeのsample gridと照合し、不連続ならDurable Work Unitの確定前に拒否する検査。既存対応範囲である3 output sample以内のpacket timestamp量子化だけは検証後にcanonical gridへ正規化する。大きな観測PTSを期待値へ置換して重複や欠落を隠さず、連続rangeでは中断なしと再開後に同じ音声sampleとContext Cueを確定する。
 _Avoid_: expected PTSへの上書き, timestamp補間, best-effort audio concatenation, completed chunkの黙示修復
 
 **Rejected Speech Diagnostic**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,6 +80,14 @@ _Avoid_: internal adapter, preview mode, compatibility period, Processing Stage
 supported target上の実videoからrelease suiteとfull-scale suiteの対象を指定するtarget-onlyのuntracked設定。repositoryにはschema templateだけを置き、実pathやvideo名を記録しない。
 _Avoid_: public TOML, Effective Configuration, committed fixture, production default
 
+**Acceptance Suite Lock**:
+一つのartifact rootとsuiteに対するtarget acceptance commandの同時実行を即時拒否し、安全なsuite root解決後からstate、active marker、attempt journal、cache、worksheetの読込・回復・変更までを保護する非待機排他境界。後発commandは先発の実行中に証拠を変更せず、異なるsuiteの実行は互いに妨げない。
+_Avoid_: Input Lock, waiting queue, active attempt marker, global lock
+
+**Suite-Owned Deletion Boundary**:
+target acceptanceのrecursive deleteを、明示されたsuite所有root内の対象と、そのrootから対象までにあるsymlinkでも通常directory以外でもない既存chainだけへ限定する安全境界。検証に失敗した場合は外部内容と既存acceptance証拠を変更せずresetを拒否する。
+_Avoid_: path文字列prefix検査, targetだけのsymlink検査, best-effort cleanup, external directory
+
 **Acceptance Record**:
 一回のtarget acceptanceで得たcommit、runtime/model identity、pathなしのVideo Set fingerprint、Stage時間、resource、cache、quality判定をversioned JSONとして保存する証拠。media、absolute path、raw text、prompt、model responseを含めない。
 _Avoid_: Canonical Selection Report, runtime log, baseline snapshot, raw benchmark output
@@ -111,6 +119,10 @@ _Avoid_: Acceptance Run, Acceptance Phase, Acceptance Comparison Run, retry insi
 **Acceptance Attempt Journal**:
 activeなAcceptance Run Attemptのexecution context、cache・reuse・recompute件数、Stage aggregate、Work Unitごとのresolutionを、Progress Event境界でatomicに更新するprivacy-safeな回復記録。process強制終了後はCompleted Stage、Durable Work Unit、Video Identityの確定manifestと照合してkill直前の作業量を回復する。resource samplerの未確定sampleを捏造せず、attempt完了後に削除する。
 _Avoid_: Acceptance Record, pipeline checkpoint, raw progress log, resource sample database
+
+**Acceptance Worksheet Recovery**:
+Fresh ProcessingとCache Reuseの完了record、retained artifact、candidate binding、materialized Video Set identityを再検証し、未確定のprivate review worksheetだけを復旧する終端再開。確定済みworkloadを再実行せず、現在のsource revision、target runtime、Model Runtimeの利用可能性や更新状態には依存しない。retained evidenceが欠落または改変されている場合は明示的に拒否する。
+_Avoid_: target preflight, model resolution, workload rerun, unchecked report rendering
 
 **Legacy Cache**:
 旧screenshot selectorが作成した認識可能なprocessing cache entry、旧processing cache内の`video-identities/`、またはmanifestから現行より古いversioned Candidate Annotation Stage Contractだと識別できるCompleted Stage。cache lock取得後に自動削除し、変換・保持・互換利用は行わない。現行の独立Video Identity cache、現行contractの設定違いによるStage Fingerprint不一致、認識できない`videos/`・`video-sets/`・`work-units/` entryは含まない。
@@ -155,6 +167,10 @@ _Avoid_: Resolved Model Identity, configured device profile, host identity, mode
 **Speech Recognition Result**:
 Speech Runtimeが返す、word本文、chunk内の開始・終了PCM sample位置、source segmentとの対応、未校正のbackend diagnosticsからなるinfra-level結果。faster-whisper固有型とbinary float秒を境界の外へ漏らさず、Context Collection Stageがword grouping、global Video Time変換、chunk overlap所有権、reliability、Context Cue IDを決める。
 _Avoid_: Context Cue, backend object, calibrated confidence, global Video Time
+
+**PCM Range Continuity Validation**:
+checkpoint対象のPCM sample rangeについてMedia Runtimeから観測した先頭sampleのPTSを要求rangeのsample gridと照合し、不連続ならDurable Work Unitの確定前に拒否する検査。観測PTSを期待値へ置換して重複や欠落を隠さず、連続rangeでは中断なしと再開後に同じ音声sampleとContext Cueを確定する。
+_Avoid_: expected PTSへの上書き, timestamp補間, best-effort audio concatenation, completed chunkの黙示修復
 
 **Rejected Speech Diagnostic**:
 word grouping後に低reliabilityとしてContext Cueへ採用しなかったSTT文字列、正確な時刻範囲、未校正backend値を保持する非公開のContext Collection Stage artifact。processing cache内だけに保存し、画像評価、progress、error、Human Selection Report、machine-readable reportへ渡さず、`--reset-cache`で削除する。

--- a/docs/pipeline-resume.md
+++ b/docs/pipeline-resume.md
@@ -44,7 +44,7 @@ flowchart TD
     K --> N{Context source}
     N --> O[Embedded Subtitle stream checkpoint]
     N --> P[PCM sample rangeを抽出]
-    P --> PA{観測したrange先頭PTSが<br/>要求sample gridと連続?}
+    P --> PA{coalesce前の各frame PTSが<br/>要求sample gridと連続?}
     PA -- Yes --> PB[PCM sample range checkpoint]
     PA -- No --> PC[補間・PTS上書きをせずrun失敗]
     PB --> Q[PCM chunkごとのSpeech Recognition checkpoint]
@@ -175,10 +175,12 @@ Scene CatalogとFinal Selectionは一回のatomic operation自体が最小単位
 Annotationも一枚の外部model requestと条件付き専用確認をまとめたCompleted Stageです。
 requestの途中tokenやpartial responseは再利用しません。
 
-PCM rangeはFFmpegから観測した先頭PTSを期待sample位置へ置換しません。独立rangeの観測PTSが
-要求sample gridと一致しない場合は、音声の重複・欠落を連続音声として確定せず、そのrangeの
-checkpointを作る前に失敗します。連続音声では同じsample rangeとPCM bytesを確定するため、
-中断なしとcheckpoint再開で同じSpeech Recognition入力とContext Cueになります。
+PCM rangeはcanonical chunkへまとめる前の各frameについてFFmpegから観測したPTSを要求sample
+gridへ照合します。既存対応範囲である3 output sample以内のpacket timestamp量子化だけは
+検証後にcanonical gridへ正規化します。それを超える先頭またはrange途中の不連続は、音声の
+重複・欠落を連続音声として確定せず、そのrangeのcheckpointを作る前に失敗します。連続音声では
+同じsample rangeとPCM bytesを確定するため、中断なしとcheckpoint再開で同じSpeech Recognition
+入力とContext Cueになります。
 
 ## 依存変更時の局所的な再計算
 
@@ -290,7 +292,9 @@ journalと確定manifestを照合してkill直前までの作業量を回復し�
 同じ意味結果ならそのまま使い、不完全なsuite-owned outputだけを除去します。
 同じartifact rootとsuiteの後発commandはstateを読む前に非待機で拒否されるため、実行中の
 先発attemptをabandonedとして回収しません。先発の通常終了、例外、Ctrl+C、process終了で
-OS lockが解放された後は、残ったlock fileを削除せず同じcommandを再実行できます。
+OS lockが解放された後は、残ったlock fileを削除せず同じcommandを再実行できます。`.locks`と
+lock fileはartifact rootからdirectory handle相対かつsymlink非追従で作成・openするため、
+外部pathへ向けられたlockで排他や外部fileを変更しません。
 
 Fresh Processing、Cache Reuseとreview worksheetが確定しても、review pendingまたは
 自動gate不合格のrelease suiteは実行単位resetに備えてprivate workを保持します。human reviewを

--- a/docs/pipeline-resume.md
+++ b/docs/pipeline-resume.md
@@ -43,8 +43,11 @@ flowchart TD
 
     K --> N{Context source}
     N --> O[Embedded Subtitle stream checkpoint]
-    N --> P[PCM sample range checkpoint]
-    P --> Q[PCM chunkごとのSpeech Recognition checkpoint]
+    N --> P[PCM sample rangeを抽出]
+    P --> PA{観測したrange先頭PTSが<br/>要求sample gridと連続?}
+    PA -- Yes --> PB[PCM sample range checkpoint]
+    PA -- No --> PC[補間・PTS上書きをせずrun失敗]
+    PB --> Q[PCM chunkごとのSpeech Recognition checkpoint]
     O --> R[Context Completed Stageを集約]
     Q --> R
 
@@ -172,6 +175,11 @@ Scene CatalogとFinal Selectionは一回のatomic operation自体が最小単位
 Annotationも一枚の外部model requestと条件付き専用確認をまとめたCompleted Stageです。
 requestの途中tokenやpartial responseは再利用しません。
 
+PCM rangeはFFmpegから観測した先頭PTSを期待sample位置へ置換しません。独立rangeの観測PTSが
+要求sample gridと一致しない場合は、音声の重複・欠落を連続音声として確定せず、そのrangeの
+checkpointを作る前に失敗します。連続音声では同じsample rangeとPCM bytesを確定するため、
+中断なしとcheckpoint再開で同じSpeech Recognition入力とContext Cueになります。
+
 ## 依存変更時の局所的な再計算
 
 TOMLへ期待hashを手入力しません。実行時に解決・検証したruntime identity、model identity、
@@ -219,18 +227,20 @@ Work Unitのengine versionを上げた場合も、そのoperationだけを起点
 Target Acceptance:
 
 ```text
-<SUITE_ROOT>/
-├── acceptance-state.json
-├── outputs/{fixed3,cold,warm}/      # schema互換用の内部key
-└── work/
-    ├── active-attempt.json
-    ├── input/
-    ├── interval-checkpoints/        # release
-    ├── source-checkpoints/          # full
-    ├── release-materialization-context.json
-    ├── release-materialization.json
-    ├── full-materialization-context.json
-    └── full-materialization.json
+<ARTIFACT_ROOT>/target-acceptance/
+├── .locks/{release,full}.lock        # fileの存在ではなくOS lockが正本
+└── <SUITE>/
+    ├── acceptance-state.json
+    ├── outputs/{fixed3,cold,warm}/   # schema互換用の内部key
+    └── work/
+        ├── active-attempt.json
+        ├── input/
+        ├── interval-checkpoints/     # release
+        ├── source-checkpoints/       # full
+        ├── release-materialization-context.json
+        ├── release-materialization.json
+        ├── full-materialization-context.json
+        └── full-materialization.json
 ```
 
 Video Identity cacheはprocessing cacheと寿命を分離します。Parallelism Baselineから
@@ -278,6 +288,9 @@ Target Acceptanceではactive attemptのexecution context、cache件数、Work U
 journalと確定manifestを照合してkill直前までの作業量を回復し、旧attemptを
 `process_abandoned`として閉じて新attemptを開始します。完成済みCanonical Outputは削除せず
 同じ意味結果ならそのまま使い、不完全なsuite-owned outputだけを除去します。
+同じartifact rootとsuiteの後発commandはstateを読む前に非待機で拒否されるため、実行中の
+先発attemptをabandonedとして回収しません。先発の通常終了、例外、Ctrl+C、process終了で
+OS lockが解放された後は、残ったlock fileを削除せず同じcommandを再実行できます。
 
 Fresh Processing、Cache Reuseとreview worksheetが確定しても、review pendingまたは
 自動gate不合格のrelease suiteは実行単位resetに備えてprivate workを保持します。human reviewを

--- a/docs/target-acceptance.md
+++ b/docs/target-acceptance.md
@@ -71,6 +71,12 @@ uv run task acceptance-target \
   --suite full
 ```
 
+同じ`artifact_root`とsuiteを指定したcommandは一つだけ実行できる。suite単位の非待機lockは
+profileと安全なsuite rootを解決した後、state、active attempt、journal、cache、resetを
+読み書きする前に取得する。後発commandは先発の証拠を変更せず明示的に拒否される。
+releaseとfullは別々に排他される。lock fileはprocess終了後も残り得るが、fileの存在や保存PIDを
+実行中判定には使わず、OS lockが解放されていれば同じcommandで直ちに再開できる。
+
 modelの更新確認、download、capability検証とResolved Model Identityのfreezeは最初のrun
 timerより前に行う。利用者向けのrun名と役割は次のとおり。
 
@@ -209,6 +215,10 @@ Ollama deployment、server version、Resolved Model Identityをprobeまたは再
 worksheet未生成から再開するときはFresh Processing reportをphase digestと照合し、
 selection artifactを
 Completed Stage manifest、artifact hash、semantic fingerprintで再検証する。
+この検証に合格すれば`worksheet_ready`が未確定でもmaterialize、Git dirty検査、target
+preflight、Ollama接続、model更新・解決、phase workloadを実行せずworksheetだけを復旧する。
+retained report、selected画像、selection artifact、candidate bindingのいずれかが欠落または
+改変されていれば、別の結果を作らず明示的に停止する。
 worksheet生成済みのhuman review待ちから再開するときも、Fresh Processing／Cache Reuse双方の
 canonical reportを
 phase確定時のfile hashと照合し、`report.md`の決定的projection、selected画像のpath、byte数、
@@ -277,9 +287,13 @@ uv run task acceptance-target \
 `parallelism-baseline`はfull suiteだけで利用できる。`cache-reuse`に必要なFresh Processingの
 cacheが既にない場合は、空cacheを再利用測定として扱わず`fresh-processing`を要求する。
 いずれもmaterialized inputとsuite間で共有するVideo Identity cacheは保持する。
-suite root、work、materialized inputのいずれかがsymbolic linkの場合は外部pathを辿らず、
-`--reset-suite`を要求する。削除対象にsymbolic link、不正なfile種別、削除失敗がある場合も
-stateを変更せず追加runを開始しない。`--reset-suite`との同時指定は拒否する。
+suite rootから各output、work、materialized input、processing cacheまでの既存階層を
+recursive deleteより前にすべて`lstat`し、symbolic link、通常directory以外、suite外参照を
+一つでも検出したら全削除対象を変更せず拒否する。このpreflightはmaterializeより前にも行うため、
+外部symlink先へ再生成fileを書き込まない。`--reset-run fresh-processing`、
+`--reset-suite`、Parallelism BaselineからFresh Processingへ移るcache解放に同じ境界を使う。
+symlink構成を安全な通常directoryへ戻すまで、reset種別を変えて処理を続けない。
+削除失敗時もstateを変更せず追加runを開始しない。`--reset-suite`との同時指定は拒否する。
 
 `--reset-suite`は選んだsuiteのstate、run output、worksheet、
 processing cacheを破棄する。release/full suiteの親にある共有Video Identity cacheは保持し、

--- a/docs/target-acceptance.md
+++ b/docs/target-acceptance.md
@@ -75,7 +75,9 @@ uv run task acceptance-target \
 profileと安全なsuite rootを解決した後、state、active attempt、journal、cache、resetを
 読み書きする前に取得する。後発commandは先発の証拠を変更せず明示的に拒否される。
 releaseとfullは別々に排他される。lock fileはprocess終了後も残り得るが、fileの存在や保存PIDを
-実行中判定には使わず、OS lockが解放されていれば同じcommandで直ちに再開できる。
+実行中判定には使わず、OS lockが解放されていれば同じcommandで直ちに再開できる。lock pathは
+artifact rootからdirectory handle相対かつsymlink非追従で作成・openし、`.locks`またはlock
+fileが外部pathへのsymbolic linkなら、外部を変更せず起動を拒否する。
 
 modelの更新確認、download、capability検証とResolved Model Identityのfreezeは最初のrun
 timerより前に行う。利用者向けのrun名と役割は次のとおり。
@@ -292,6 +294,9 @@ recursive deleteより前にすべて`lstat`し、symbolic link、通常director
 一つでも検出したら全削除対象を変更せず拒否する。このpreflightはmaterializeより前にも行うため、
 外部symlink先へ再生成fileを書き込まない。`--reset-run fresh-processing`、
 `--reset-suite`、Parallelism BaselineからFresh Processingへ移るcache解放に同じ境界を使う。
+実削除は検証済み親directoryをsymlink非追従でopenし、そのdirectory handleを基準に行う。
+preflight後に別processがancestorをrenameまたは外部へのsymlinkへ差し替えても、pathを再解決して
+外部treeをrecursive deleteしない。
 symlink構成を安全な通常directoryへ戻すまで、reset種別を変えて処理を続けない。
 削除失敗時もstateを変更せず追加runを開始しない。`--reset-suite`との同時指定は拒否する。
 

--- a/src/video_selection/acceptance/acceptance_suite_lock.py
+++ b/src/video_selection/acceptance/acceptance_suite_lock.py
@@ -1,0 +1,69 @@
+"""同一target acceptance suiteのprocess排他を所有する。"""
+
+import errno
+import fcntl
+import os
+from pathlib import Path
+from threading import Lock
+from types import TracebackType
+
+
+class AcceptanceSuiteLock:
+    """state回復より前から同一suiteの同時実行を拒否する。"""
+
+    _process_guard = Lock()
+    _process_paths: set[Path] = set()
+
+    def __init__(self, path: Path) -> None:
+        self._path = path.absolute()
+        self._descriptor: int | None = None
+
+    def __enter__(self) -> "AcceptanceSuiteLock":
+        """process内予約後にOSの非待機lockを取得する。"""
+        with self._process_guard:
+            if self._path in self._process_paths:
+                raise self._already_running_error()
+            self._process_paths.add(self._path)
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            descriptor = os.open(self._path, os.O_CREAT | os.O_RDWR, 0o600)
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BaseException as error:
+                os.close(descriptor)
+                if isinstance(error, OSError) and error.errno in {
+                    errno.EACCES,
+                    errno.EAGAIN,
+                }:
+                    raise self._already_running_error() from error
+                raise
+            self._descriptor = descriptor
+        except BaseException:
+            self._release_process_path()
+            raise
+        return self
+
+    def __exit__(
+        self,
+        _exception_type: type[BaseException] | None,
+        _exception: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        """終了経路にかかわらずOS lockとprocess内予約を解放する。"""
+        descriptor = self._descriptor
+        self._descriptor = None
+        try:
+            if descriptor is not None:
+                try:
+                    fcntl.flock(descriptor, fcntl.LOCK_UN)
+                finally:
+                    os.close(descriptor)
+        finally:
+            self._release_process_path()
+
+    def _already_running_error(self) -> ValueError:
+        return ValueError(f"Acceptance suiteは実行中です: {self._path.stem}")
+
+    def _release_process_path(self) -> None:
+        with self._process_guard:
+            self._process_paths.discard(self._path)

--- a/src/video_selection/acceptance/acceptance_suite_lock.py
+++ b/src/video_selection/acceptance/acceptance_suite_lock.py
@@ -3,6 +3,8 @@
 import errno
 import fcntl
 import os
+import stat
+from contextlib import suppress
 from pathlib import Path
 from threading import Lock
 from types import TracebackType
@@ -14,8 +16,17 @@ class AcceptanceSuiteLock:
     _process_guard = Lock()
     _process_paths: set[Path] = set()
 
-    def __init__(self, path: Path) -> None:
-        self._path = path.absolute()
+    def __init__(self, path: Path, *, owned_root: Path) -> None:
+        self._path = Path(os.path.abspath(path))
+        self._owned_root = Path(os.path.abspath(owned_root))
+        try:
+            self._relative_path = self._path.relative_to(self._owned_root)
+        except ValueError:
+            raise ValueError(
+                "Acceptance suite lockはartifact root外に作成できません"
+            ) from None
+        if not self._relative_path.parts:
+            raise ValueError("Acceptance suite lock pathが不正です")
         self._descriptor: int | None = None
 
     def __enter__(self) -> "AcceptanceSuiteLock":
@@ -25,8 +36,7 @@ class AcceptanceSuiteLock:
                 raise self._already_running_error()
             self._process_paths.add(self._path)
         try:
-            self._path.parent.mkdir(parents=True, exist_ok=True)
-            descriptor = os.open(self._path, os.O_CREAT | os.O_RDWR, 0o600)
+            descriptor = self._open_lock_file()
             try:
                 fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except BaseException as error:
@@ -42,6 +52,84 @@ class AcceptanceSuiteLock:
             self._release_process_path()
             raise
         return self
+
+    def _open_lock_file(self) -> int:
+        root_descriptor = self._open_owned_root()
+        descriptor = root_descriptor
+        try:
+            for part in self._relative_path.parts[:-1]:
+                descriptor = self._open_or_create_directory(descriptor, part)
+            try:
+                lock_descriptor = os.open(
+                    self._relative_path.parts[-1],
+                    os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW | os.O_CLOEXEC,
+                    0o600,
+                    dir_fd=descriptor,
+                )
+            except OSError:
+                raise ValueError(
+                    "Acceptance suite lock pathにsymbolic linkがあります"
+                ) from None
+            try:
+                lock_mode = os.fstat(lock_descriptor).st_mode
+            except BaseException:
+                os.close(lock_descriptor)
+                raise
+            if not stat.S_ISREG(lock_mode):
+                os.close(lock_descriptor)
+                raise ValueError("Acceptance suite lockが通常fileではありません")
+            return lock_descriptor
+        finally:
+            os.close(descriptor)
+
+    def _open_owned_root(self) -> int:
+        try:
+            before = self._owned_root.lstat()
+        except FileNotFoundError:
+            raise ValueError("Acceptance artifact rootが存在しません") from None
+        if stat.S_ISLNK(before.st_mode):
+            raise ValueError("Acceptance suite lock pathにsymbolic linkがあります")
+        if not stat.S_ISDIR(before.st_mode):
+            raise ValueError("Acceptance artifact rootがdirectoryではありません")
+        try:
+            descriptor = os.open(
+                self._owned_root,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            )
+        except OSError:
+            raise ValueError(
+                "Acceptance suite lock pathにsymbolic linkがあります"
+            ) from None
+        try:
+            matches_root = os.path.samestat(before, os.fstat(descriptor))
+        except BaseException:
+            os.close(descriptor)
+            raise
+        if not matches_root:
+            os.close(descriptor)
+            raise ValueError("Acceptance artifact rootが検証中に変更されました")
+        return descriptor
+
+    @staticmethod
+    def _open_or_create_directory(parent_descriptor: int, name: str) -> int:
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+        try:
+            child_descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+        except FileNotFoundError:
+            with suppress(FileExistsError):
+                os.mkdir(name, mode=0o700, dir_fd=parent_descriptor)
+            try:
+                child_descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+            except OSError:
+                raise ValueError(
+                    "Acceptance suite lock pathにsymbolic linkがあります"
+                ) from None
+        except OSError:
+            raise ValueError(
+                "Acceptance suite lock pathにsymbolic linkがあります"
+            ) from None
+        os.close(parent_descriptor)
+        return child_descriptor
 
     def __exit__(
         self,

--- a/src/video_selection/acceptance/suite_owned_deletion_boundary.py
+++ b/src/video_selection/acceptance/suite_owned_deletion_boundary.py
@@ -1,0 +1,167 @@
+"""suite所有rootを基準に削除対象を検証して削除する。"""
+
+import os
+import shutil
+import stat
+from pathlib import Path
+
+_DIRECTORY_OPEN_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+_RMTREE_AVOIDS_SYMLINK_ATTACKS = shutil.rmtree.avoids_symlink_attacks
+
+
+class SuiteOwnedDeletionBoundary:
+    """検証済みdirectory handleからだけsuite-owned artifactを削除する。"""
+
+    def __init__(self, owned_root: Path) -> None:
+        self._owned_root = Path(os.path.abspath(owned_root))
+
+    def validate_directory(self, path: Path, label: str) -> None:
+        """rootから対象までが通常directoryだけであることを検証する。"""
+        self._validate(path, label, target_kind="directory")
+
+    def validate_file(self, path: Path, label: str) -> None:
+        """rootから対象fileまでに外部参照がないことを検証する。"""
+        self._validate(path, label, target_kind="file")
+
+    def remove_directory(self, path: Path, label: str) -> None:
+        """開いた親directoryを基準にrecursive deletionを完了する。"""
+        self.validate_directory(path, label)
+        opened = self._open_parent(path, label)
+        if opened is None:
+            return
+        parent_descriptor, target_name = opened
+        try:
+            mode = self._target_mode(parent_descriptor, target_name)
+            if mode is None:
+                return
+            if stat.S_ISLNK(mode):
+                raise ValueError(f"{label}の途中階層がsymbolic linkです")
+            if not stat.S_ISDIR(mode):
+                raise ValueError(f"{label}の途中階層が通常directoryではありません")
+            if not _RMTREE_AVOIDS_SYMLINK_ATTACKS:
+                raise ValueError(f"{label}を安全に削除できない実行環境です")
+            shutil.rmtree(target_name, dir_fd=parent_descriptor)
+            if self._target_mode(parent_descriptor, target_name) is not None:
+                raise ValueError(f"{label}を完全に削除できません")
+        except OSError:
+            raise ValueError(f"{label}を完全に削除できません") from None
+        finally:
+            os.close(parent_descriptor)
+
+    def remove_file(self, path: Path, label: str) -> None:
+        """開いた親directoryを基準に通常fileだけを削除する。"""
+        self.validate_file(path, label)
+        opened = self._open_parent(path, label)
+        if opened is None:
+            return
+        parent_descriptor, target_name = opened
+        try:
+            mode = self._target_mode(parent_descriptor, target_name)
+            if mode is None:
+                return
+            if stat.S_ISLNK(mode):
+                raise ValueError(f"{label}の途中階層がsymbolic linkです")
+            if not stat.S_ISREG(mode):
+                raise ValueError(f"{label}が通常fileではありません")
+            os.unlink(target_name, dir_fd=parent_descriptor)
+            if self._target_mode(parent_descriptor, target_name) is not None:
+                raise ValueError(f"{label}を完全に削除できません")
+        except OSError:
+            raise ValueError(f"{label}を削除できません") from None
+        finally:
+            os.close(parent_descriptor)
+
+    def _validate(self, path: Path, label: str, *, target_kind: str) -> None:
+        target, relative = self._relative_target(path, label)
+        current = self._owned_root
+        chain = [self._owned_root]
+        for part in relative.parts:
+            current /= part
+            chain.append(current)
+        for candidate in chain:
+            try:
+                mode = candidate.lstat().st_mode
+            except FileNotFoundError:
+                return
+            if stat.S_ISLNK(mode):
+                raise ValueError(f"{label}の途中階層がsymbolic linkです")
+            is_target = candidate == target
+            if not is_target or target_kind == "directory":
+                if not stat.S_ISDIR(mode):
+                    raise ValueError(f"{label}の途中階層が通常directoryではありません")
+            elif not stat.S_ISREG(mode):
+                raise ValueError(f"{label}が通常fileではありません")
+
+    def _open_parent(self, path: Path, label: str) -> tuple[int, str] | None:
+        _target, relative = self._relative_target(path, label)
+        root_descriptor = self._open_root(label)
+        if root_descriptor is None:
+            return None
+        descriptor = root_descriptor
+        try:
+            for part in relative.parts[:-1]:
+                try:
+                    child_descriptor = os.open(
+                        part,
+                        _DIRECTORY_OPEN_FLAGS,
+                        dir_fd=descriptor,
+                    )
+                except FileNotFoundError:
+                    os.close(descriptor)
+                    return None
+                except OSError:
+                    raise ValueError(
+                        f"{label}の途中階層がsymbolic linkまたは非directoryです"
+                    ) from None
+                os.close(descriptor)
+                descriptor = child_descriptor
+            return descriptor, relative.parts[-1]
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+    def _open_root(self, label: str) -> int | None:
+        try:
+            before = self._owned_root.lstat()
+        except FileNotFoundError:
+            return None
+        if stat.S_ISLNK(before.st_mode):
+            raise ValueError(f"{label}の途中階層がsymbolic linkです")
+        if not stat.S_ISDIR(before.st_mode):
+            raise ValueError(f"{label}の途中階層が通常directoryではありません")
+        try:
+            descriptor = os.open(self._owned_root, _DIRECTORY_OPEN_FLAGS)
+        except OSError:
+            raise ValueError(
+                f"{label}の途中階層がsymbolic linkまたは非directoryです"
+            ) from None
+        try:
+            after = os.fstat(descriptor)
+        except BaseException:
+            os.close(descriptor)
+            raise
+        if not os.path.samestat(before, after):
+            os.close(descriptor)
+            raise ValueError(f"{label}の途中階層が検証中に変更されました")
+        return descriptor
+
+    def _relative_target(self, path: Path, label: str) -> tuple[Path, Path]:
+        target = Path(os.path.abspath(path))
+        try:
+            relative = target.relative_to(self._owned_root)
+        except ValueError:
+            raise ValueError(f"{label}はsuite所有directory外にあります") from None
+        if not relative.parts:
+            raise ValueError(f"{label}はsuite所有root自体を対象にできません")
+        return target, relative
+
+    @staticmethod
+    def _target_mode(parent_descriptor: int, target_name: str) -> int | None:
+        try:
+            return os.stat(
+                target_name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            ).st_mode
+        except FileNotFoundError:
+            return None

--- a/src/video_selection/acceptance/target_suite_runner.py
+++ b/src/video_selection/acceptance/target_suite_runner.py
@@ -2,9 +2,6 @@
 
 import hashlib
 import json
-import os
-import shutil
-import stat
 import time
 from collections.abc import Callable, Mapping
 from contextlib import suppress
@@ -56,6 +53,7 @@ from .human_review import (
 from .load_acceptance_profile import load_acceptance_profile
 from .release_suite_materializer import ReleaseSuiteMaterializer
 from .source_snapshot_fingerprint import acceptance_source_snapshot_fingerprint
+from .suite_owned_deletion_boundary import SuiteOwnedDeletionBoundary
 from .target_environment import (
     probe_source_revision,
     probe_target_environment,
@@ -146,7 +144,7 @@ class TargetSuiteRunner:
             owned_root=profile.artifact_root,
         )
         lock_path = suite_root.parent / ".locks" / f"{suite}.lock"
-        with AcceptanceSuiteLock(lock_path):
+        with AcceptanceSuiteLock(lock_path, owned_root=profile.artifact_root):
             return self._run_locked(
                 profile=profile,
                 suite=suite,
@@ -950,12 +948,7 @@ def _validate_directory_deletion(
     owned_root: Path,
 ) -> None:
     """suite所有rootから対象までが通常directoryだけであることを検証する。"""
-    _validate_deletion_chain(
-        path,
-        label,
-        owned_root=owned_root,
-        target_kind="directory",
-    )
+    SuiteOwnedDeletionBoundary(owned_root).validate_directory(path, label)
 
 
 def _validate_file_deletion(
@@ -965,45 +958,7 @@ def _validate_file_deletion(
     owned_root: Path,
 ) -> None:
     """suite所有rootから対象fileまでに外部参照がないことを検証する。"""
-    _validate_deletion_chain(
-        path,
-        label,
-        owned_root=owned_root,
-        target_kind="file",
-    )
-
-
-def _validate_deletion_chain(
-    path: Path,
-    label: str,
-    *,
-    owned_root: Path,
-    target_kind: str,
-) -> None:
-    root = Path(os.path.abspath(owned_root))
-    target = Path(os.path.abspath(path))
-    try:
-        relative = target.relative_to(root)
-    except ValueError:
-        raise ValueError(f"{label}はsuite所有directory外にあります") from None
-    current = root
-    chain = [root]
-    for part in relative.parts:
-        current /= part
-        chain.append(current)
-    for candidate in chain:
-        try:
-            mode = candidate.lstat().st_mode
-        except FileNotFoundError:
-            return
-        if stat.S_ISLNK(mode):
-            raise ValueError(f"{label}の途中階層がsymbolic linkです")
-        is_target = candidate == target
-        if not is_target or target_kind == "directory":
-            if not stat.S_ISDIR(mode):
-                raise ValueError(f"{label}の途中階層が通常directoryではありません")
-        elif not stat.S_ISREG(mode):
-            raise ValueError(f"{label}が通常fileではありません")
+    SuiteOwnedDeletionBoundary(owned_root).validate_file(path, label)
 
 
 def _remove_directory_strict(
@@ -1013,15 +968,7 @@ def _remove_directory_strict(
     owned_root: Path,
 ) -> None:
     """reset対象directoryが完全に削除された場合だけ後続処理を許可する。"""
-    _validate_directory_deletion(path, label, owned_root=owned_root)
-    if not path.exists():
-        return
-    try:
-        shutil.rmtree(path)
-    except OSError:
-        raise ValueError(f"{label}を完全に削除できません") from None
-    if path.exists() or path.is_symlink():
-        raise ValueError(f"{label}を完全に削除できません")
+    SuiteOwnedDeletionBoundary(owned_root).remove_directory(path, label)
 
 
 def _remove_file_strict(
@@ -1031,15 +978,7 @@ def _remove_file_strict(
     owned_root: Path,
 ) -> None:
     """suite-owned regular fileだけを削除し外部参照を辿らない。"""
-    _validate_file_deletion(path, label, owned_root=owned_root)
-    if not path.exists():
-        return
-    try:
-        path.unlink()
-    except OSError:
-        raise ValueError(f"{label}を削除できません") from None
-    if path.exists() or path.is_symlink():
-        raise ValueError(f"{label}を完全に削除できません")
+    SuiteOwnedDeletionBoundary(owned_root).remove_file(path, label)
 
 
 def _remove_invalid_attempt_output(output_folder: Path, suite_root: Path) -> None:

--- a/src/video_selection/acceptance/target_suite_runner.py
+++ b/src/video_selection/acceptance/target_suite_runner.py
@@ -2,7 +2,9 @@
 
 import hashlib
 import json
+import os
 import shutil
+import stat
 import time
 from collections.abc import Callable, Mapping
 from contextlib import suppress
@@ -43,6 +45,7 @@ from .acceptance_run_attempt_metrics import (
 )
 from .acceptance_run_reset import ACCEPTANCE_RUN_RESETS, AcceptanceRunReset
 from .acceptance_storage_preflight import preflight_acceptance_storage
+from .acceptance_suite_lock import AcceptanceSuiteLock
 from .atomic_json import read_json_object, write_atomic_json
 from .full_suite_materializer import FullSuiteMaterializer
 from .human_review import (
@@ -132,8 +135,39 @@ class TargetSuiteRunner:
         _validate_profile_files(profile)
         suite_root = profile.artifact_root / "target-acceptance" / suite
         _validate_suite_source_paths(profile_path, profile, suite_root)
+        _validate_directory_deletion(
+            suite_root,
+            "Acceptance suite",
+            owned_root=profile.artifact_root,
+        )
+        lock_path = suite_root.parent / ".locks" / f"{suite}.lock"
+        with AcceptanceSuiteLock(lock_path):
+            return self._run_locked(
+                profile=profile,
+                suite=suite,
+                suite_root=suite_root,
+                reset_suite=reset_suite,
+                reset_run=reset_run,
+                human_review_path=human_review_path,
+            )
+
+    def _run_locked(
+        self,
+        *,
+        profile: AcceptanceProfile,
+        suite: str,
+        suite_root: Path,
+        reset_suite: bool,
+        reset_run: AcceptanceRunReset | None,
+        human_review_path: Path | None,
+    ) -> int:
+        """suite lock保持中にstate回復からfinalizationまでを実行する。"""
         if reset_suite:
-            _remove_directory_strict(suite_root, "Acceptance suite")
+            _remove_directory_strict(
+                suite_root,
+                "Acceptance suite",
+                owned_root=suite_root.parent,
+            )
         state_path = suite_root / "acceptance-state.json"
         attempt_journal = AcceptanceAttemptJournal(
             suite_root / "work" / "active-attempt.json"
@@ -141,10 +175,13 @@ class TargetSuiteRunner:
         state = read_json_object(state_path)
         if state is None:
             attempt_journal.clear()
+        if reset_run is not None:
+            _validate_reset_run_deletion_boundaries(reset_run, suite_root)
         if reset_run == "cache-reuse":
             _validate_cache_reuse_reset_prerequisites(
                 state,
                 suite_root / "work" / "input" / ".game-screen-pick" / "cache",
+                suite_root,
             )
         configuration_digest = _content_digest(profile.configuration_path)
         identity_cache_folder = suite_root.parent / "video-identities"
@@ -152,7 +189,6 @@ class TargetSuiteRunner:
             state is not None
             and reset_run is None
             and _runs_completed(state)
-            and state.get("worksheet_ready") is True
             and _is_sha256(state.get("materialization_source_snapshot_fingerprint"))
         ):
             _validate_completed_state_identity(
@@ -183,18 +219,12 @@ class TargetSuiteRunner:
             if _resolve_active_step(state, execution_steps) is not None:
                 raise ValueError("完了済みAcceptance stateにactive runがあります")
             attempt_journal.clear()
-            for step in execution_steps:
-                completed_runs = _mapping(
-                    state.get(step.records_state_key),
-                    step.records_state_key,
-                )
-                load_completed_run_report(
-                    configuration=step.configuration,
-                    run_record=_mapping(
-                        completed_runs.get(step.name),
-                        f"{step.name} run",
-                    ),
-                )
+            self._restore_completed_worksheet(
+                suite=suite,
+                suite_root=suite_root,
+                state=state,
+                execution_steps=execution_steps,
+            )
             return self._finalize(
                 profile,
                 suite_root,
@@ -413,7 +443,10 @@ class TargetSuiteRunner:
                     run_record=cast(dict[str, object], existing),
                 )
                 continue
-            _remove_invalid_attempt_output(step.configuration.output_folder)
+            _remove_invalid_attempt_output(
+                step.configuration.output_folder,
+                suite_root,
+            )
             attempt_id = uuid4().hex
             attempt_started_at_epoch = time.time()
             state[step.active_state_key] = step.name
@@ -575,6 +608,58 @@ class TargetSuiteRunner:
             return self._release_materializer(profile, suite_root)
         return self._full_materializer(profile, suite_root)
 
+    def _restore_completed_worksheet(
+        self,
+        *,
+        suite: str,
+        suite_root: Path,
+        state: dict[str, object],
+        execution_steps: tuple[AcceptanceExecutionStep, ...],
+    ) -> None:
+        """完了runのretained evidenceだけから未確定worksheetを復旧する。"""
+        worksheet_ready = state.get("worksheet_ready") is True
+        cold_report: dict[str, object] | None = None
+        cold_selection: dict[str, object] | None = None
+        for step in execution_steps:
+            completed_runs = _mapping(
+                state.get(step.records_state_key),
+                step.records_state_key,
+            )
+            run_record = _mapping(
+                completed_runs.get(step.name),
+                f"{step.name} run",
+            )
+            if step.is_cold_phase and not worksheet_ready:
+                cold_report, cold_selection = load_completed_run_evidence(
+                    configuration=step.configuration,
+                    run_record=run_record,
+                )
+            else:
+                load_completed_run_report(
+                    configuration=step.configuration,
+                    run_record=run_record,
+                )
+        if worksheet_ready:
+            return
+        if cold_report is None or cold_selection is None:
+            raise ValueError("Fresh Processingのretained evidenceがありません")
+        phases = _mapping(state.get("phases"), "phases")
+        cold_phase = _mapping(phases.get("cold"), "cold phase")
+        state["video_set"] = _mapping(
+            cold_phase.get("video_set"),
+            "video_set",
+        )
+        worksheet = ensure_review_worksheet(
+            suite_root / "review-worksheet.json",
+            suite=suite,
+            suite_fingerprint=_string(state.get("suite_fingerprint")),
+            canonical_report=cold_report,
+            selection_artifact=cold_selection,
+        )
+        state["review_candidate_digest"] = review_candidate_digest(worksheet)
+        state["worksheet_ready"] = True
+        write_atomic_json(suite_root / "acceptance-state.json", state)
+
     def _finalize(
         self,
         profile: AcceptanceProfile,
@@ -669,6 +754,7 @@ class TargetSuiteRunner:
             _remove_directory_strict(
                 suite_root / "baseline",
                 "Acceptance baseline",
+                owned_root=suite_root,
             )
             if record["status"] == "passed":
                 write_normalized_baseline(record, suite_root / "baseline")
@@ -709,28 +795,38 @@ def _reset_acceptance_run_suffix(
         "cache-reuse": {"warm"},
     }[reset_run]
     reset_steps = tuple(step for step in execution_steps if step.name in reset_names)
-    for step in reset_steps:
-        _remove_directory_strict(
+    directory_deletions = [
+        (
             step.configuration.output_folder,
             f"{reset_run} Acceptance output",
         )
+        for step in reset_steps
+    ]
     if "cold" in reset_names:
-        _remove_directory_strict(
-            processing_cache_folder,
-            f"{reset_run} processing cache",
+        directory_deletions.append(
+            (
+                processing_cache_folder,
+                f"{reset_run} processing cache",
+            )
         )
-        _remove_file_strict(
-            suite_root / "review-worksheet.json",
-            "Acceptance review worksheet",
+    directory_deletions.append((suite_root / "baseline", "Acceptance baseline"))
+    file_deletions = [(suite_root / "acceptance.json", "Acceptance record")]
+    if "cold" in reset_names:
+        file_deletions.insert(
+            0,
+            (
+                suite_root / "review-worksheet.json",
+                "Acceptance review worksheet",
+            ),
         )
-    _remove_file_strict(
-        suite_root / "acceptance.json",
-        "Acceptance record",
-    )
-    _remove_directory_strict(
-        suite_root / "baseline",
-        "Acceptance baseline",
-    )
+    for path, label in directory_deletions:
+        _validate_directory_deletion(path, label, owned_root=suite_root)
+    for path, label in file_deletions:
+        _validate_file_deletion(path, label, owned_root=suite_root)
+    for path, label in directory_deletions:
+        _remove_directory_strict(path, label, owned_root=suite_root)
+    for path, label in file_deletions:
+        _remove_file_strict(path, label, owned_root=suite_root)
 
     for step in reset_steps:
         records = state.get(step.records_state_key)
@@ -755,11 +851,56 @@ def _reset_acceptance_run_suffix(
     write_atomic_json(state_path, state)
 
 
+def _validate_reset_run_deletion_boundaries(
+    reset_run: AcceptanceRunReset,
+    suite_root: Path,
+) -> None:
+    """materialize前にreset対象の全path chainを非破壊検証する。"""
+    reset_names = {
+        "parallelism-baseline": ("fixed3", "cold", "warm"),
+        "fresh-processing": ("cold", "warm"),
+        "cache-reuse": ("warm",),
+    }[reset_run]
+    directory_deletions = [
+        (
+            suite_root / "outputs" / run_name,
+            f"{reset_run} Acceptance output",
+        )
+        for run_name in reset_names
+    ]
+    if "cold" in reset_names:
+        directory_deletions.append(
+            (
+                suite_root / "work" / "input" / ".game-screen-pick" / "cache",
+                f"{reset_run} processing cache",
+            )
+        )
+    directory_deletions.append((suite_root / "baseline", "Acceptance baseline"))
+    file_deletions = [(suite_root / "acceptance.json", "Acceptance record")]
+    if "cold" in reset_names:
+        file_deletions.append(
+            (
+                suite_root / "review-worksheet.json",
+                "Acceptance review worksheet",
+            )
+        )
+    for path, label in directory_deletions:
+        _validate_directory_deletion(path, label, owned_root=suite_root)
+    for path, label in file_deletions:
+        _validate_file_deletion(path, label, owned_root=suite_root)
+
+
 def _validate_cache_reuse_reset_prerequisites(
     state: dict[str, object] | None,
     processing_cache_folder: Path,
+    suite_root: Path,
 ) -> None:
     """本処理の完了recordと実cacheがある場合だけ再利用resetを許可する。"""
+    _validate_directory_deletion(
+        processing_cache_folder,
+        "cache-reuse processing cache",
+        owned_root=suite_root,
+    )
     phases = state.get("phases") if state is not None else None
     fresh_processing = phases.get("cold") if isinstance(phases, dict) else None
     if (
@@ -785,7 +926,11 @@ def _cleanup_release_work(
     if suite != "release":
         return True
     try:
-        _remove_directory_strict(suite_root / "work", "Release acceptance work")
+        _remove_directory_strict(
+            suite_root / "work",
+            "Release acceptance work",
+            owned_root=suite_root,
+        )
     except ValueError:
         failure: dict[str, object] = {
             "phase": "acceptance_cleanup",
@@ -801,12 +946,79 @@ def _cleanup_release_work(
     return True
 
 
-def _remove_directory_strict(path: Path, label: str) -> None:
+def _validate_directory_deletion(
+    path: Path,
+    label: str,
+    *,
+    owned_root: Path,
+) -> None:
+    """suite所有rootから対象までが通常directoryだけであることを検証する。"""
+    _validate_deletion_chain(
+        path,
+        label,
+        owned_root=owned_root,
+        target_kind="directory",
+    )
+
+
+def _validate_file_deletion(
+    path: Path,
+    label: str,
+    *,
+    owned_root: Path,
+) -> None:
+    """suite所有rootから対象fileまでに外部参照がないことを検証する。"""
+    _validate_deletion_chain(
+        path,
+        label,
+        owned_root=owned_root,
+        target_kind="file",
+    )
+
+
+def _validate_deletion_chain(
+    path: Path,
+    label: str,
+    *,
+    owned_root: Path,
+    target_kind: str,
+) -> None:
+    root = Path(os.path.abspath(owned_root))
+    target = Path(os.path.abspath(path))
+    try:
+        relative = target.relative_to(root)
+    except ValueError:
+        raise ValueError(f"{label}はsuite所有directory外にあります") from None
+    current = root
+    chain = [root]
+    for part in relative.parts:
+        current /= part
+        chain.append(current)
+    for candidate in chain:
+        try:
+            mode = candidate.lstat().st_mode
+        except FileNotFoundError:
+            return
+        if stat.S_ISLNK(mode):
+            raise ValueError(f"{label}の途中階層がsymbolic linkです")
+        is_target = candidate == target
+        if not is_target or target_kind == "directory":
+            if not stat.S_ISDIR(mode):
+                raise ValueError(f"{label}の途中階層が通常directoryではありません")
+        elif not stat.S_ISREG(mode):
+            raise ValueError(f"{label}が通常fileではありません")
+
+
+def _remove_directory_strict(
+    path: Path,
+    label: str,
+    *,
+    owned_root: Path,
+) -> None:
     """reset対象directoryが完全に削除された場合だけ後続処理を許可する。"""
-    if not path.exists() and not path.is_symlink():
+    _validate_directory_deletion(path, label, owned_root=owned_root)
+    if not path.exists():
         return
-    if path.is_symlink():
-        raise ValueError(f"{label}はsymbolic linkのため削除できません")
     try:
         shutil.rmtree(path)
     except OSError:
@@ -815,12 +1027,16 @@ def _remove_directory_strict(path: Path, label: str) -> None:
         raise ValueError(f"{label}を完全に削除できません")
 
 
-def _remove_file_strict(path: Path, label: str) -> None:
+def _remove_file_strict(
+    path: Path,
+    label: str,
+    *,
+    owned_root: Path,
+) -> None:
     """suite-owned regular fileだけを削除し外部参照を辿らない。"""
-    if not path.exists() and not path.is_symlink():
+    _validate_file_deletion(path, label, owned_root=owned_root)
+    if not path.exists():
         return
-    if path.is_symlink() or not path.is_file():
-        raise ValueError(f"{label}が通常fileではありません")
     try:
         path.unlink()
     except OSError:
@@ -829,8 +1045,13 @@ def _remove_file_strict(path: Path, label: str) -> None:
         raise ValueError(f"{label}を完全に削除できません")
 
 
-def _remove_invalid_attempt_output(output_folder: Path) -> None:
+def _remove_invalid_attempt_output(output_folder: Path, suite_root: Path) -> None:
     """完成済みCanonical outputを保持し、不完全なsuite-owned outputだけ除く。"""
+    _validate_directory_deletion(
+        output_folder,
+        "Acceptance Output Folder",
+        owned_root=suite_root,
+    )
     if not output_folder.exists() and not output_folder.is_symlink():
         return
     if output_folder.is_symlink() or not output_folder.is_dir():
@@ -838,7 +1059,11 @@ def _remove_invalid_attempt_output(output_folder: Path) -> None:
     try:
         load_validated_canonical_selection_report(output_folder)
     except ValueError:
-        _remove_directory_strict(output_folder, "不完全なAcceptance Output Folder")
+        _remove_directory_strict(
+            output_folder,
+            "不完全なAcceptance Output Folder",
+            owned_root=suite_root,
+        )
 
 
 def _execute_run_attempt(
@@ -939,7 +1164,11 @@ def _release_fixed_three_cache(
     )
     if fixed_three.get("operation_status") != "completed":
         raise ValueError("Fixed3 comparison完了前にauto cacheを開始できません")
-    _remove_directory_strict(cache_folder, "Fixed3 comparison cache")
+    _remove_directory_strict(
+        cache_folder,
+        "Fixed3 comparison cache",
+        owned_root=state_path.parent,
+    )
     state["fixed3_cache_released"] = True
     write_atomic_json(state_path, state)
 
@@ -1047,14 +1276,17 @@ def _reconcile_full_comparison_context(
         return
     if fixed_three_matches:
         return
-    _remove_directory_strict(
-        suite_root / "outputs" / "fixed3",
-        "旧contextのFixed3 comparison output",
+    deletion_targets = (
+        (
+            suite_root / "outputs" / "fixed3",
+            "旧contextのFixed3 comparison output",
+        ),
+        (cache_folder, "旧contextのFixed3 comparison cache"),
     )
-    _remove_directory_strict(
-        cache_folder,
-        "旧contextのFixed3 comparison cache",
-    )
+    for path, label in deletion_targets:
+        _validate_directory_deletion(path, label, owned_root=suite_root)
+    for path, label in deletion_targets:
+        _remove_directory_strict(path, label, owned_root=suite_root)
     comparison_runs.pop("fixed3", None)
     state["comparison_runs"] = comparison_runs
     comparison_attempts = state.get("comparison_run_attempts")

--- a/src/video_selection/acceptance/target_suite_runner.py
+++ b/src/video_selection/acceptance/target_suite_runner.py
@@ -83,6 +83,11 @@ StoragePreflight = Callable[[AcceptanceProfile, Path], dict[str, object]]
 
 _STATE_SCHEMA = "game-screen-pick/target-acceptance-state@1.3.0"
 _ACTIVE_RUN_STATE_KEYS = ("active_phase", "active_comparison_run")
+_RESET_RUN_NAMES: dict[AcceptanceRunReset, tuple[str, ...]] = {
+    "parallelism-baseline": ("fixed3", "cold", "warm"),
+    "fresh-processing": ("cold", "warm"),
+    "cache-reuse": ("warm",),
+}
 
 
 class TargetSuiteRunner:
@@ -789,11 +794,7 @@ def _reset_acceptance_run_suffix(
     state_path: Path,
 ) -> None:
     """指定runと依存する後続runだけをstateとartifactから破棄する。"""
-    reset_names = {
-        "parallelism-baseline": {"fixed3", "cold", "warm"},
-        "fresh-processing": {"cold", "warm"},
-        "cache-reuse": {"warm"},
-    }[reset_run]
+    reset_names = frozenset(_RESET_RUN_NAMES[reset_run])
     reset_steps = tuple(step for step in execution_steps if step.name in reset_names)
     directory_deletions = [
         (
@@ -856,11 +857,7 @@ def _validate_reset_run_deletion_boundaries(
     suite_root: Path,
 ) -> None:
     """materialize前にreset対象の全path chainを非破壊検証する。"""
-    reset_names = {
-        "parallelism-baseline": ("fixed3", "cold", "warm"),
-        "fresh-processing": ("cold", "warm"),
-        "cache-reuse": ("warm",),
-    }[reset_run]
+    reset_names = _RESET_RUN_NAMES[reset_run]
     directory_deletions = [
         (
             suite_root / "outputs" / run_name,

--- a/src/video_selection/media/ffmpeg_media_runtime.py
+++ b/src/video_selection/media/ffmpeg_media_runtime.py
@@ -89,6 +89,7 @@ _SHOWINFO_DURATION_PATTERN = re.compile(r"\bduration:\s*(-?\d+)")
 _SHOWINFO_SIZE_PATTERN = re.compile(r"\bs:(\d+)x(\d+)")
 _FRAME_RANGE_SEEK_PADDING = Fraction(1)
 _FRAME_RANGE_END_PADDING = Fraction(1, 10)
+_PCM_PTS_QUANTIZATION_TOLERANCE_SAMPLES = 3
 
 
 class FfmpegMediaRuntime:
@@ -869,9 +870,10 @@ class FfmpegMediaRuntime:
             f"aresample={sample_rate}:async=0,"
             "aformat=sample_fmts=s16:channel_layouts=mono,"
             f"atrim=end_sample={maximum_sample_count},"
-            f"asetnsamples=n={maximum_sample_count}:p=0,"
             f"asettb=expr=1/{sample_rate},"
-            "ashowinfo"
+            "ashowinfo@observed,"
+            f"asetnsamples=n={maximum_sample_count}:p=0,"
+            "ashowinfo@chunk"
         )
         command = self._decode_command_prefix(
             media_path,
@@ -893,12 +895,14 @@ class FfmpegMediaRuntime:
             ]
         )
         try:
+            observed_timing: list[tuple[int, int]] = []
             chunks = tuple(
                 iter_pcm_audio_chunks(
                     command,
                     stream.index,
                     sample_rate,
                     initial_sample_start=sample_start,
+                    observed_timing=observed_timing,
                 )
             )
         except _DECODE_ERRORS as error:
@@ -914,12 +918,16 @@ class FfmpegMediaRuntime:
                 "audio sample rangeがcanonical chunkへ収まりません",
             )
         chunk = chunks[0]
-        if chunk.pts != absolute_start_pts:
+        if not _pcm_range_timing_is_continuous(
+            observed_timing,
+            absolute_start_pts,
+            chunk.sample_count,
+        ):
             raise MediaRuntimeError(
                 MediaRuntimeFailureReason.AUDIO_EXTRACTION_FAILED,
                 "audio sample rangeのtimestampが連続していません",
             )
-        return chunk
+        return replace(chunk, pts=absolute_start_pts)
 
     def read_embedded_subtitles(
         self,
@@ -1423,6 +1431,24 @@ def _remove_scan_proxy_sentinel(folder: Path) -> tuple[Path, ...]:
         )
     files[0].unlink()
     return files[1:]
+
+
+def _pcm_range_timing_is_continuous(
+    observed_timing: list[tuple[int, int]],
+    expected_start_pts: int,
+    expected_sample_count: int,
+) -> bool:
+    """小さなpacket量子化だけを許しrange内のsample gridを検証する。"""
+    observed_sample_count = 0
+    for pts, sample_count in observed_timing:
+        expected_pts = expected_start_pts + observed_sample_count
+        if (
+            sample_count < 1
+            or abs(pts - expected_pts) > _PCM_PTS_QUANTIZATION_TOLERANCE_SAMPLES
+        ):
+            return False
+        observed_sample_count += sample_count
+    return observed_sample_count == expected_sample_count
 
 
 def _ffmpeg_number(value: float) -> str:

--- a/src/video_selection/media/ffmpeg_media_runtime.py
+++ b/src/video_selection/media/ffmpeg_media_runtime.py
@@ -853,10 +853,16 @@ class FfmpegMediaRuntime:
         if relative_start < 0:
             msg = "PCM Audio rangeがmedia originより前です"
             raise ValueError(msg)
+        range_duration = _ffmpeg_number(maximum_sample_count / sample_rate)
         input_options = (
-            ()
+            ("-t", range_duration)
             if relative_start == 0
-            else ("-ss", _ffmpeg_number(float(relative_start)))
+            else (
+                "-ss",
+                _ffmpeg_number(float(relative_start)),
+                "-t",
+                range_duration,
+            )
         )
         absolute_start_pts = round(stream_origin * sample_rate) + sample_start
         audio_filter = (
@@ -865,7 +871,7 @@ class FfmpegMediaRuntime:
             f"atrim=end_sample={maximum_sample_count},"
             f"asetnsamples=n={maximum_sample_count}:p=0,"
             f"asettb=expr=1/{sample_rate},"
-            "asetpts=N,ashowinfo"
+            "ashowinfo"
         )
         command = self._decode_command_prefix(
             media_path,
@@ -879,8 +885,6 @@ class FfmpegMediaRuntime:
                 "-dn",
                 "-af",
                 audio_filter,
-                "-t",
-                _ffmpeg_number(maximum_sample_count / sample_rate),
                 "-f",
                 "s16le",
                 "-acodec",
@@ -909,7 +913,13 @@ class FfmpegMediaRuntime:
                 MediaRuntimeFailureReason.AUDIO_EXTRACTION_FAILED,
                 "audio sample rangeがcanonical chunkへ収まりません",
             )
-        return replace(chunks[0], pts=absolute_start_pts)
+        chunk = chunks[0]
+        if chunk.pts != absolute_start_pts:
+            raise MediaRuntimeError(
+                MediaRuntimeFailureReason.AUDIO_EXTRACTION_FAILED,
+                "audio sample rangeのtimestampが連続していません",
+            )
+        return chunk
 
     def read_embedded_subtitles(
         self,

--- a/src/video_selection/media/ffmpeg_pcm_reader.py
+++ b/src/video_selection/media/ffmpeg_pcm_reader.py
@@ -23,6 +23,7 @@ def iter_pcm_audio_chunks(
     sample_rate: int,
     *,
     initial_sample_start: int = 0,
+    observed_timing: list[_AudioMetadata] | None = None,
 ) -> Iterator[PcmAudioChunk]:
     """一つのFFmpeg processから連続PCM chunkを順次返す。"""
     process = subprocess.Popen(
@@ -36,7 +37,7 @@ def iter_pcm_audio_chunks(
     metadata_queue: queue.Queue[_MetadataItem] = queue.Queue()
     stderr_thread = threading.Thread(
         target=_collect_ashowinfo,
-        args=(process.stderr, metadata_queue),
+        args=(process.stderr, metadata_queue, observed_timing),
         daemon=True,
     )
     stderr_thread.start()
@@ -64,20 +65,29 @@ def iter_pcm_audio_chunks(
 def _collect_ashowinfo(
     stderr: IO[bytes],
     metadata_queue: queue.Queue[_MetadataItem],
+    observed_timing: list[_AudioMetadata] | None,
 ) -> None:
     try:
         for raw_line in stderr:
             line = raw_line.decode("utf-8", errors="replace")
-            if "Parsed_ashowinfo" not in line or " n:" not in line:
+            is_observed_timing = "[ashowinfo@observed " in line
+            is_chunk_timing = "[ashowinfo@chunk " in line
+            is_default_timing = "Parsed_ashowinfo" in line
+            if (
+                not is_observed_timing and not is_chunk_timing and not is_default_timing
+            ) or " n:" not in line:
                 continue
             pts_match = _PTS_PATTERN.search(line)
             sample_count_match = _SAMPLE_COUNT_PATTERN.search(line)
             if pts_match is None or sample_count_match is None:
                 msg = "ashowinfo metadataが不正です"
                 raise ValueError(msg)
-            metadata_queue.put(
-                (int(pts_match.group(1)), int(sample_count_match.group(1)))
-            )
+            metadata = (int(pts_match.group(1)), int(sample_count_match.group(1)))
+            if is_observed_timing:
+                if observed_timing is not None:
+                    observed_timing.append(metadata)
+            else:
+                metadata_queue.put(metadata)
     except BaseException as error:
         metadata_queue.put(error)
     finally:

--- a/tests/video_selection/acceptance/test_acceptance_suite_lock.py
+++ b/tests/video_selection/acceptance/test_acceptance_suite_lock.py
@@ -28,8 +28,7 @@ def test_lock_rejects_overlap_and_reopens_after_release(tmp_path: Path) -> None:
             with AcceptanceSuiteLock(lock_path):
                 pass
     with AcceptanceSuiteLock(lock_path):
-        reacquired = True
+        pass
 
     # Assert
-    assert reacquired is True
     assert lock_path.is_file()

--- a/tests/video_selection/acceptance/test_acceptance_suite_lock.py
+++ b/tests/video_selection/acceptance/test_acceptance_suite_lock.py
@@ -1,0 +1,35 @@
+"""Acceptance Suite Lockのtest。"""
+
+from pathlib import Path
+
+import pytest
+
+from src.video_selection.acceptance.acceptance_suite_lock import (
+    AcceptanceSuiteLock,
+)
+
+
+def test_lock_rejects_overlap_and_reopens_after_release(tmp_path: Path) -> None:
+    """保持中だけ後発が拒否され終了後は同じlockが再取得されること。
+
+    Arrange:
+        - 一つのsuite lock pathが用意される
+    Act:
+        - 先発保持中と解放後に同じlockが取得される
+    Assert:
+        - 保持中だけ後発が拒否され残存fileを削除せず再取得できること
+    """
+    # Arrange
+    lock_path = tmp_path / ".locks" / "release.lock"
+
+    # Act
+    with AcceptanceSuiteLock(lock_path):
+        with pytest.raises(ValueError, match="Acceptance suiteは実行中"):
+            with AcceptanceSuiteLock(lock_path):
+                pass
+    with AcceptanceSuiteLock(lock_path):
+        reacquired = True
+
+    # Assert
+    assert reacquired is True
+    assert lock_path.is_file()

--- a/tests/video_selection/acceptance/test_acceptance_suite_lock.py
+++ b/tests/video_selection/acceptance/test_acceptance_suite_lock.py
@@ -23,10 +23,12 @@ def test_lock_rejects_overlap_and_reopens_after_release(tmp_path: Path) -> None:
     lock_path = tmp_path / ".locks" / "release.lock"
 
     # Act
-    with AcceptanceSuiteLock(lock_path):
-        with pytest.raises(ValueError, match="Acceptance suiteは実行中"):
-            with AcceptanceSuiteLock(lock_path):
-                pass
+    with (
+        AcceptanceSuiteLock(lock_path),
+        pytest.raises(ValueError, match="Acceptance suiteは実行中"),
+        AcceptanceSuiteLock(lock_path),
+    ):
+        pass
     with AcceptanceSuiteLock(lock_path):
         pass
 

--- a/tests/video_selection/acceptance/test_acceptance_suite_lock.py
+++ b/tests/video_selection/acceptance/test_acceptance_suite_lock.py
@@ -24,13 +24,64 @@ def test_lock_rejects_overlap_and_reopens_after_release(tmp_path: Path) -> None:
 
     # Act
     with (
-        AcceptanceSuiteLock(lock_path),
+        AcceptanceSuiteLock(lock_path, owned_root=tmp_path),
         pytest.raises(ValueError, match="Acceptance suiteは実行中"),
-        AcceptanceSuiteLock(lock_path),
+        AcceptanceSuiteLock(lock_path, owned_root=tmp_path),
     ):
         pass
-    with AcceptanceSuiteLock(lock_path):
+    with AcceptanceSuiteLock(lock_path, owned_root=tmp_path):
         pass
 
     # Assert
     assert lock_path.is_file()
+
+
+@pytest.mark.parametrize("symlink_component", ["lock-directory", "lock-file"])
+def test_lock_rejects_symlinked_path_without_external_change(
+    tmp_path: Path,
+    symlink_component: str,
+) -> None:
+    """lock pathのsymlinkが外部fileを作成・変更せず拒否されること。
+
+    Arrange:
+        - suite所有root内のlock directoryまたはlock fileが外部へ向けられる
+        - 外部treeの事前snapshotが取得される
+    Act:
+        - suite lockの取得が試行される
+    Assert:
+        - symbolic linkとして拒否され外部treeが変更されないこと
+    """
+    # Arrange
+    owned_root = tmp_path / "artifacts"
+    owned_root.mkdir()
+    external_root = tmp_path / "external"
+    external_root.mkdir()
+    external_lock = external_root / "release.lock"
+    external_lock.write_bytes(b"external-lock")
+    lock_directory = owned_root / ".locks"
+    lock_path = lock_directory / "release.lock"
+    if symlink_component == "lock-directory":
+        lock_directory.symlink_to(external_root, target_is_directory=True)
+    else:
+        lock_directory.mkdir()
+        lock_path.symlink_to(external_lock)
+    external_before = {
+        path.relative_to(external_root).as_posix(): path.read_bytes()
+        for path in external_root.rglob("*")
+        if path.is_file()
+    }
+
+    # Act
+    with (
+        pytest.raises(ValueError, match="symbolic link"),
+        AcceptanceSuiteLock(lock_path, owned_root=owned_root),
+    ):
+        pass
+
+    # Assert
+    external_after = {
+        path.relative_to(external_root).as_posix(): path.read_bytes()
+        for path in external_root.rglob("*")
+        if path.is_file()
+    }
+    assert external_after == external_before

--- a/tests/video_selection/acceptance/test_suite_owned_deletion_boundary.py
+++ b/tests/video_selection/acceptance/test_suite_owned_deletion_boundary.py
@@ -1,0 +1,64 @@
+"""Suite-Owned Deletion Boundaryのtest。"""
+
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from src.video_selection.acceptance.suite_owned_deletion_boundary import (
+    SuiteOwnedDeletionBoundary,
+)
+
+
+def test_directory_removal_keeps_open_parent_when_path_is_replaced(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """検証済みancestorの差替え後も外部directoryが削除されないこと。
+
+    Arrange:
+        - suite内の削除対象と同名directoryを持つ外部treeが用意される
+        - recursive deletion直前にancestorを外部へのsymlinkへ差し替える
+    Act:
+        - suite-owned directoryの削除が実行される
+    Assert:
+        - 開いていたsuite側targetだけが削除され外部treeが変更されないこと
+    """
+    # Arrange
+    suite_root = tmp_path / "suite"
+    target = suite_root / "outputs" / "cold"
+    target.mkdir(parents=True)
+    (target / "suite.bin").write_bytes(b"suite")
+    external_root = tmp_path / "external"
+    external_target = external_root / "cold"
+    external_target.mkdir(parents=True)
+    external_file = external_target / "external.bin"
+    external_file.write_bytes(b"external")
+    original_rmtree: Callable[..., None] = shutil.rmtree
+    attack_performed = False
+
+    def replace_ancestor_before_removal(
+        path: str | Path,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        nonlocal attack_performed
+        if not attack_performed:
+            attack_performed = True
+            outputs = suite_root / "outputs"
+            moved_outputs = suite_root / "outputs-before-race"
+            outputs.rename(moved_outputs)
+            outputs.symlink_to(external_root, target_is_directory=True)
+        original_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(shutil, "rmtree", replace_ancestor_before_removal)
+    boundary = SuiteOwnedDeletionBoundary(suite_root)
+
+    # Act
+    boundary.remove_directory(target, "Acceptance output")
+
+    # Assert
+    assert attack_performed is True
+    assert external_file.read_bytes() == b"external"
+    assert not (suite_root / "outputs-before-race" / "cold").exists()

--- a/tests/video_selection/acceptance/test_target_suite_runner.py
+++ b/tests/video_selection/acceptance/test_target_suite_runner.py
@@ -1328,8 +1328,8 @@ def test_reset_suite_fails_when_suite_root_survives_deletion(
     runner = _runner(execute)
     assert runner.run(profile_path=profile_path, suite="release") == 3
     monkeypatch.setattr(
-        "src.video_selection.acceptance.target_suite_runner.shutil.rmtree",
-        lambda _path: None,
+        "src.video_selection.acceptance.suite_owned_deletion_boundary.shutil.rmtree",
+        lambda _path, *_args, **_kwargs: None,
     )
 
     # Act
@@ -1450,7 +1450,7 @@ def test_release_finalization_fails_when_private_work_survives_cleanup(
     worksheet_path = suite_root / "review-worksheet.json"
     _complete_review_worksheet(worksheet_path)
     monkeypatch.setattr(
-        "src.video_selection.acceptance.target_suite_runner.shutil.rmtree",
+        "src.video_selection.acceptance.suite_owned_deletion_boundary.shutil.rmtree",
         lambda _path, *_args, **_kwargs: None,
     )
 
@@ -1508,7 +1508,7 @@ def test_privacy_failure_also_reports_release_cleanup_failure(
         reject_privacy,
     )
     monkeypatch.setattr(
-        "src.video_selection.acceptance.target_suite_runner.shutil.rmtree",
+        "src.video_selection.acceptance.suite_owned_deletion_boundary.shutil.rmtree",
         lambda _path, *_args, **_kwargs: None,
     )
 

--- a/tests/video_selection/acceptance/test_target_suite_runner.py
+++ b/tests/video_selection/acceptance/test_target_suite_runner.py
@@ -5,6 +5,8 @@ import shutil
 from collections.abc import Callable
 from dataclasses import fields, replace
 from pathlib import Path
+from threading import Event, Lock, Thread
+from typing import Never
 
 import pytest
 
@@ -28,6 +30,7 @@ from src.video_selection.acceptance.target_suite_runner import (
     EnvironmentProbe,
     ModelResolver,
     OllamaDeploymentProbe,
+    RevisionProbe,
     TargetSuiteRunner,
 )
 from src.video_selection.configuration.resolve_effective_configuration import (
@@ -51,6 +54,81 @@ from tests.video_selection.fakes.fake_model_runtime import FakeModelRuntime
 from tests.video_selection.fakes.fake_video_stage_media_runtime import (
     FakeVideoStageMediaRuntime,
 )
+
+
+def test_concurrent_runner_preserves_live_suite_evidence(tmp_path: Path) -> None:
+    """同じsuiteの後発runnerがliveな証拠を変更せず拒否されること。
+
+    Arrange:
+        - cold attemptの途中で待機する先発runnerが起動される
+        - 先発が確定したstate、journal、cacheのsnapshotが取得される
+    Act:
+        - 同じprofileとsuiteで後発runnerが起動される
+    Assert:
+        - 後発が明示的に拒否されsuite内の全fileが変更されないこと
+        - 先発は待機解除後に通常どおり完了し同じsuiteを再開できること
+    """
+    # Arrange
+    profile_path = _profile(tmp_path)
+    first_attempt_started = Event()
+    release_first_attempt = Event()
+    call_guard = Lock()
+    first_call = True
+
+    def execute(
+        run_name: str,
+        configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        nonlocal first_call
+        with call_guard:
+            should_wait = first_call
+            first_call = False
+        if should_wait:
+            first_attempt_started.set()
+            assert release_first_attempt.wait(timeout=5)
+        return _successful_run_attempt(configuration, run_name)
+
+    runner = _runner(execute)
+    first_results: list[int] = []
+    first_errors: list[BaseException] = []
+
+    def run_first() -> None:
+        try:
+            first_results.append(runner.run(profile_path=profile_path, suite="release"))
+        except BaseException as error:
+            first_errors.append(error)
+
+    first_thread = Thread(target=run_first)
+    first_thread.start()
+    assert first_attempt_started.wait(timeout=5)
+    suite_root = tmp_path / "artifacts" / "target-acceptance" / "release"
+    evidence_before = {
+        path.relative_to(suite_root).as_posix(): path.read_bytes()
+        for path in sorted(suite_root.rglob("*"))
+        if path.is_file()
+    }
+
+    # Act
+    try:
+        with pytest.raises(ValueError, match="Acceptance suiteは実行中"):
+            runner.run(profile_path=profile_path, suite="release")
+        evidence_after = {
+            path.relative_to(suite_root).as_posix(): path.read_bytes()
+            for path in sorted(suite_root.rglob("*"))
+            if path.is_file()
+        }
+    finally:
+        release_first_attempt.set()
+        first_thread.join(timeout=5)
+
+    # Assert
+    assert not first_thread.is_alive()
+    assert first_errors == []
+    assert first_results == [3]
+    assert evidence_after == evidence_before
+    assert runner.run(profile_path=profile_path, suite="release") == 3
 
 
 def test_interrupt_after_cold_resumes_only_warm_then_waits_for_human_review(
@@ -961,6 +1039,222 @@ def test_reset_run_stops_before_state_change_when_suffix_deletion_fails(
     assert read_json_object(state_path) == state_before
     assert external_marker.read_text(encoding="utf-8") == "external"
     assert calls == []
+
+
+@pytest.mark.parametrize(
+    "symlink_component",
+    ("work", "input", "processing-root", "cache"),
+)
+def test_fresh_processing_reset_rejects_symlinked_cache_ancestor(
+    tmp_path: Path,
+    symlink_component: str,
+) -> None:
+    """cache途中階層がsymlinkのresetで全証拠と外部内容が保持されること。
+
+    Arrange:
+        - coldとwarmが完了したrelease suiteが用意される
+        - processing cacheの各階層が外部directoryへのsymlinkへ置換される
+    Act:
+        - fresh-processingからのresetが試行される
+    Assert:
+        - resetが削除前に拒否され外部marker、state、既存outputが保持されること
+        - phaseが追加実行されないこと
+    """
+    # Arrange
+    profile_path = _profile(tmp_path)
+    calls: list[str] = []
+
+    def execute(
+        run_name: str,
+        configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        calls.append(run_name)
+        return _successful_run_attempt(configuration, run_name)
+
+    runner = _runner(execute)
+    assert runner.run(profile_path=profile_path, suite="release") == 3
+    suite_root = tmp_path / "artifacts" / "target-acceptance" / "release"
+    state_path = suite_root / "acceptance-state.json"
+    evidence_before = {
+        path.relative_to(suite_root).as_posix(): path.read_bytes()
+        for path in sorted((suite_root / "outputs").rglob("*"))
+        if path.is_file()
+    }
+    component_path = {
+        "work": suite_root / "work",
+        "input": suite_root / "work" / "input",
+        "processing-root": (suite_root / "work" / "input" / ".game-screen-pick"),
+        "cache": (suite_root / "work" / "input" / ".game-screen-pick" / "cache"),
+    }[symlink_component]
+    external_root = tmp_path / f"external-{symlink_component}"
+    component_path.rename(external_root)
+    component_path.symlink_to(external_root, target_is_directory=True)
+    materialized_video = next(external_root.rglob("scenario-001.mkv"), None)
+    if materialized_video is not None:
+        materialized_video.write_bytes(b"external-scenario")
+    external_marker = external_root / "keep"
+    external_marker.write_text("external", encoding="utf-8")
+    external_before = {
+        path.relative_to(external_root).as_posix(): path.read_bytes()
+        for path in sorted(external_root.rglob("*"))
+        if path.is_file()
+    }
+    state_before = state_path.read_bytes()
+    calls.clear()
+
+    # Act
+    with pytest.raises(ValueError, match="symbolic link"):
+        runner.run(
+            profile_path=profile_path,
+            suite="release",
+            reset_run="fresh-processing",
+        )
+
+    # Assert
+    evidence_after = {
+        path.relative_to(suite_root).as_posix(): path.read_bytes()
+        for path in sorted((suite_root / "outputs").rglob("*"))
+        if path.is_file()
+    }
+    external_after = {
+        path.relative_to(external_root).as_posix(): path.read_bytes()
+        for path in sorted(external_root.rglob("*"))
+        if path.is_file()
+    }
+    assert external_marker.read_text(encoding="utf-8") == "external"
+    assert external_after == external_before
+    assert state_path.read_bytes() == state_before
+    assert evidence_after == evidence_before
+    assert calls == []
+
+
+def test_reset_suite_rejects_symlinked_suite_root_without_external_change(
+    tmp_path: Path,
+) -> None:
+    """suite rootが外部symlinkなら全resetが非破壊で拒否されること。
+
+    Arrange:
+        - cold/warm完了済みrelease suiteが外部directoryへ移される
+        - 元suite rootがその外部directoryへのsymlinkへ置換される
+    Act:
+        - suite全体のresetが試行される
+    Assert:
+        - 外部treeを変更せずresetが拒否されphaseも再実行されないこと
+    """
+    # Arrange
+    profile_path = _profile(tmp_path)
+    calls: list[str] = []
+
+    def execute(
+        run_name: str,
+        configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        calls.append(run_name)
+        return _successful_run_attempt(configuration, run_name)
+
+    runner = _runner(execute)
+    assert runner.run(profile_path=profile_path, suite="release") == 3
+    suite_root = tmp_path / "artifacts" / "target-acceptance" / "release"
+    external_suite = tmp_path / "external-release-suite"
+    suite_root.rename(external_suite)
+    suite_root.symlink_to(external_suite, target_is_directory=True)
+    external_marker = external_suite / "keep"
+    external_marker.write_text("external", encoding="utf-8")
+    external_before = {
+        path.relative_to(external_suite).as_posix(): path.read_bytes()
+        for path in sorted(external_suite.rglob("*"))
+        if path.is_file()
+    }
+    calls.clear()
+
+    # Act
+    with pytest.raises(ValueError, match="symbolic link"):
+        runner.run(
+            profile_path=profile_path,
+            suite="release",
+            reset_suite=True,
+        )
+
+    # Assert
+    external_after = {
+        path.relative_to(external_suite).as_posix(): path.read_bytes()
+        for path in sorted(external_suite.rglob("*"))
+        if path.is_file()
+    }
+    assert external_after == external_before
+    assert external_marker.read_text(encoding="utf-8") == "external"
+    assert calls == []
+
+
+def test_fixed_three_cache_release_rejects_symlinked_cache_ancestor(
+    tmp_path: Path,
+) -> None:
+    """fixed3 cacheの親がsymlinkならauto cold前に非破壊で拒否されること。
+
+    Arrange:
+        - fixed3完了時にprocessing cacheの親が外部symlinkへ置換される
+    Act:
+        - full suiteがauto coldへ移行する
+    Assert:
+        - 外部cacheを変更せずcache解放が拒否されauto coldが始まらないこと
+    """
+    # Arrange
+    profile_path = _profile(tmp_path)
+    calls: list[str] = []
+    external_root = tmp_path / "external-fixed3-cache"
+    external_before: dict[str, bytes] = {}
+
+    def execute(
+        run_name: str,
+        configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        calls.append(run_name)
+        result = _successful_run_attempt(configuration, run_name)
+        record = result[1]
+        record["video_scan_parallelism"] = {
+            "mode": "fixed",
+            "configured_workers": 3,
+            "initial_workers": 3,
+            "peak_workers": 3,
+            "scan_wall_seconds": 120.0,
+        }
+        record["stage_artifact_content_digest"] = "9" * 64
+        if configuration.video_scan_workers == 3:
+            processing_root = configuration.processing_cache_folder.parent
+            processing_root.rename(external_root)
+            processing_root.symlink_to(external_root, target_is_directory=True)
+            marker = external_root / "keep"
+            marker.write_text("external", encoding="utf-8")
+            external_before.update(
+                {
+                    path.relative_to(external_root).as_posix(): path.read_bytes()
+                    for path in sorted(external_root.rglob("*"))
+                    if path.is_file()
+                }
+            )
+        return result
+
+    runner = _runner(execute)
+
+    # Act
+    with pytest.raises(ValueError, match="symbolic link"):
+        runner.run(profile_path=profile_path, suite="full")
+
+    # Assert
+    external_after = {
+        path.relative_to(external_root).as_posix(): path.read_bytes()
+        for path in sorted(external_root.rglob("*"))
+        if path.is_file()
+    }
+    assert external_after == external_before
+    assert (external_root / "keep").read_text(encoding="utf-8") == "external"
+    assert calls == ["fixed3"]
 
 
 def test_release_rejects_parallelism_baseline_reset(tmp_path: Path) -> None:
@@ -2133,6 +2427,76 @@ def test_completed_phases_resume_worksheet_finalization_without_rerun(
     assert (suite_root / "review-worksheet.json").is_file()
 
 
+def test_completed_phases_restore_worksheet_without_target_preflight(
+    tmp_path: Path,
+) -> None:
+    """完了証拠からのworksheet復旧が現在のtargetへ依存しないこと。
+
+    Arrange:
+        - cold/warm完了後かつworksheet未生成のresume stateが用意される
+        - Git、target、Ollama、modelの各preflightが利用不能にされる
+    Act:
+        - 同じrelease suiteがworksheet生成から再開される
+    Assert:
+        - preflightとphaseを呼ばずretained evidenceだけでworksheetが生成されること
+    """
+    # Arrange
+    profile_path = _profile(tmp_path)
+    initial_calls: list[str] = []
+
+    def execute_initial(
+        run_name: str,
+        configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        initial_calls.append(run_name)
+        return _successful_run_attempt(configuration, run_name)
+
+    initial_runner = _runner(execute_initial)
+    suite_root, _cold_configuration = _prepare_resume_without_worksheet(
+        tmp_path,
+        initial_runner,
+        profile_path,
+    )
+    preflight_calls: list[str] = []
+    resume_run_calls: list[str] = []
+    materialization_calls: list[str] = []
+
+    def unavailable(name: str) -> Never:
+        preflight_calls.append(name)
+        raise AssertionError(f"{name}はworksheet復旧で呼び出されません")
+
+    def execute_resume(
+        run_name: str,
+        _configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        resume_run_calls.append(run_name)
+        raise AssertionError("完了phaseは再実行されません")
+
+    resume_runner = _runner(
+        execute_resume,
+        revision_probe=lambda _path: unavailable("git"),
+        environment_probe=lambda: unavailable("target"),
+        ollama_deployment_probe=lambda _host: unavailable("ollama"),
+        model_resolver=lambda _configuration: unavailable("model"),
+        materialization_calls=materialization_calls,
+    )
+
+    # Act
+    result = resume_runner.run(profile_path=profile_path, suite="release")
+
+    # Assert
+    assert result == 3
+    assert initial_calls == ["cold", "warm"]
+    assert preflight_calls == []
+    assert resume_run_calls == []
+    assert materialization_calls == []
+    assert (suite_root / "review-worksheet.json").is_file()
+
+
 def test_resume_rejects_changed_completed_cold_report(tmp_path: Path) -> None:
     """完了phase後に変更されたcold reportからworksheetが生成されないこと。
 
@@ -3254,6 +3618,7 @@ def _runner(
     model_identity_seed: str = "acceptance-runner",
     model_resolver: ModelResolver | None = None,
     environment_probe: EnvironmentProbe | None = None,
+    revision_probe: RevisionProbe | None = None,
     ollama_deployment_probe: OllamaDeploymentProbe | None = None,
     materialization_calls: list[str] | None = None,
     storage_preflight: Callable[
@@ -3296,7 +3661,7 @@ def _runner(
                 "visible_ram_bytes": 32 * 1024**3,
             }
         ),
-        revision_probe=lambda _path: ("a" * 40, False),
+        revision_probe=revision_probe or (lambda _path: ("a" * 40, False)),
         ollama_deployment_probe=ollama_deployment_probe
         or (
             lambda _host: {

--- a/tests_ffmpeg/support/ffmpeg_fixture_factory.py
+++ b/tests_ffmpeg/support/ffmpeg_fixture_factory.py
@@ -325,6 +325,31 @@ def generate_quantized_audio(output_path: Path) -> Path:
     return output_path
 
 
+def generate_discontinuous_audio(output_path: Path) -> Path:
+    """後半のpacket PTSに250msのgapを持つaudio fixtureを生成する。"""
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:sample_rate=48000:duration=2",
+            "-af",
+            r"asetpts=PTS+gte(T\,1)*12000",
+            "-c:a",
+            "pcm_s16le",
+            str(output_path),
+        ],
+        check=True,
+    )
+    return output_path
+
+
 def generate_corrupt_video(output_path: Path) -> Path:
     """headerを保ち途中のMPEG-TS packetを破損させたfixtureを生成する。"""
     valid_path = output_path.with_name(f".{output_path.stem}.valid.ts")

--- a/tests_ffmpeg/video_selection/media/test_ffmpeg_media_runtime.py
+++ b/tests_ffmpeg/video_selection/media/test_ffmpeg_media_runtime.py
@@ -37,6 +37,7 @@ from tests_ffmpeg.support.ffmpeg_fixture_factory import (
     generate_cfr_video,
     generate_corrupt_video,
     generate_delayed_video_with_audio,
+    generate_discontinuous_audio,
     generate_nonzero_start_video,
     generate_odd_dimension_video,
     generate_quantized_audio,
@@ -1704,6 +1705,43 @@ def test_extract_pcm_audio_chunks_returns_canonical_seek_ranges(
         if stream.start_pts is not None and stream.time_base is not None
     )
     assert all(any(chunk.pcm_bytes) for chunk in chunks)
+
+
+def test_extract_pcm_audio_chunk_rejects_observed_timestamp_discontinuity(
+    tmp_path: Path,
+) -> None:
+    """range先頭の観測PTSがsample gridと不連続なら確定されないこと。
+
+    Arrange:
+        - 1秒以降のpacket PTSが連続sample gridからずれるaudioが用意される
+        - 不連続より後から始まるcheckpoint rangeが指定される
+    Act:
+        - rangeが独立したFFmpeg processで抽出される
+    Assert:
+        - 観測PTSが期待値へ置換されずaudio抽出失敗として拒否されること
+    """
+    # Arrange
+    audio_path = generate_discontinuous_audio(tmp_path / "discontinuous-audio.mkv")
+    runtime = FfmpegMediaRuntime()
+    probe = runtime.probe(audio_path)
+    stream = probe.streams[0]
+    assert stream.start_pts is not None
+    assert stream.time_base is not None
+    media_origin = stream.start_pts * stream.time_base
+
+    # Act
+    with pytest.raises(MediaRuntimeError, match="timestamp") as captured:
+        runtime.extract_pcm_audio_chunk(
+            audio_path,
+            stream,
+            media_origin,
+            16_000,
+            17_000,
+            15_000,
+        )
+
+    # Assert
+    assert captured.value.reason is MediaRuntimeFailureReason.AUDIO_EXTRACTION_FAILED
 
 
 def test_scan_pcm_audio_normalizes_quantized_packet_pts_to_sample_grid(

--- a/tests_ffmpeg/video_selection/media/test_ffmpeg_media_runtime.py
+++ b/tests_ffmpeg/video_selection/media/test_ffmpeg_media_runtime.py
@@ -1744,6 +1744,80 @@ def test_extract_pcm_audio_chunk_rejects_observed_timestamp_discontinuity(
     assert captured.value.reason is MediaRuntimeFailureReason.AUDIO_EXTRACTION_FAILED
 
 
+def test_extract_pcm_audio_chunk_rejects_mid_range_timestamp_discontinuity(
+    tmp_path: Path,
+) -> None:
+    """range途中の観測PTS不連続がcoalesce前に拒否されること。
+
+    Arrange:
+        - 1秒以降のpacket PTSに250msのgapを持つaudioが用意される
+        - gapの前から後までを含むcheckpoint rangeが指定される
+    Act:
+        - rangeが一つのcanonical chunkとして抽出される
+    Assert:
+        - 中間frameの不連続が隠されずaudio抽出失敗として拒否されること
+    """
+    # Arrange
+    audio_path = generate_discontinuous_audio(tmp_path / "mid-range-gap.mkv")
+    runtime = FfmpegMediaRuntime()
+    stream = runtime.probe(audio_path).streams[0]
+    assert stream.start_pts is not None
+    assert stream.time_base is not None
+    media_origin = stream.start_pts * stream.time_base
+
+    # Act
+    with pytest.raises(MediaRuntimeError, match="timestamp") as captured:
+        runtime.extract_pcm_audio_chunk(
+            audio_path,
+            stream,
+            media_origin,
+            16_000,
+            0,
+            32_000,
+        )
+
+    # Assert
+    assert captured.value.reason is MediaRuntimeFailureReason.AUDIO_EXTRACTION_FAILED
+
+
+def test_extract_pcm_audio_chunk_preserves_supported_timestamp_quantization(
+    tmp_path: Path,
+) -> None:
+    """既存仕様内のpacket PTS量子化がcanonical rangeへ正規化されること。
+
+    Arrange:
+        - 後半packet PTSが3 output sampleずれるaudio fixtureが用意される
+        - 量子化後から始まるcheckpoint rangeが指定される
+    Act:
+        - rangeが独立したFFmpeg processで抽出される
+    Assert:
+        - rangeが拒否されずcanonical sample gridのPTSで返されること
+    """
+    # Arrange
+    audio_path = generate_quantized_audio(tmp_path / "quantized-range.mkv")
+    runtime = FfmpegMediaRuntime()
+    stream = runtime.probe(audio_path).streams[0]
+    assert stream.start_pts is not None
+    assert stream.time_base is not None
+    media_origin = stream.start_pts * stream.time_base
+
+    # Act
+    chunk = runtime.extract_pcm_audio_chunk(
+        audio_path,
+        stream,
+        media_origin,
+        16_000,
+        17_000,
+        15_000,
+    )
+
+    # Assert
+    assert chunk is not None
+    assert chunk.sample_start == 17_000
+    assert chunk.sample_count == 15_000
+    assert chunk.pts * chunk.time_base == Fraction(17_000, 16_000)
+
+
 def test_scan_pcm_audio_normalizes_quantized_packet_pts_to_sample_grid(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## 概要

- state・active attempt・journalを読む前にsuite単位の非待機OS lockを取得し、同時起動した後発が証拠を変更しないようにする
- lock pathはartifact rootからdirectory handle相対かつsymlink非追従で作成・openし、外部pathへ向けられたlockを拒否する
- suite所有rootから削除対象までの全階層をmaterialize前に検証し、実削除も開いた親directory基準で行ってpath差替え競合から外部treeを守る
- checkpointed PCM rangeはcoalesce前の各frame PTSを検証し、既存対応範囲の3 output sample量子化だけをcanonical gridへ正規化する
- cold/warm完了後は、Git・target・Ollama・model preflightへ依存せずretained evidenceからworksheetだけを復旧する

## 入出力・再開契約

- 同じ起動入力とsemantic inputでは、中断なしと再開後の選択Candidate、順序、公開WebP、canonical reportを変えない
- 長時間処理の確定済みrun、Completed Stage、Durable Work Unitを保持する
- retained evidenceの欠落・改変、許容範囲を超えるPCM timestamp不連続、unsafe deletion pathは別結果を作らず明示停止する
- lock fileは残存してもOS lock解放後に同じcommandで再開できる

## 文書

- CONTEXT.mdへAcceptance Suite Lock、Suite-Owned Deletion Boundary、Acceptance Worksheet Recovery、PCM Range Continuity Validationを追加・更新
- docs/target-acceptance.mdとdocs/pipeline-resume.mdへ運用境界とMermaid処理フローを反映

## 検証

- UV_CACHE_DIR=/private/tmp/uv-cache uv run task test: lint、format、型検査、通常test 1241件成功
- UV_CACHE_DIR=/private/tmp/uv-cache uv run task test-ffmpeg: 実FFmpeg統合48件成功
- suite runner・lock・descriptor deletion focused test 79件成功
- FFmpeg media runtime focused test 45件成功

Closes #243
Parent: #215
Acceptance parent: #189
Review source: #202
