### PR TITLE
fix: Video Scanのproxy PTS重複を防ぐ

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -213,7 +213,7 @@ Video SourceからVideo Scan Stageが選ぶ一つの表示映像stream。`attach
 _Avoid_: audio stream, cover art, user-selected stream index
 
 **Heartbeat Proxy**:
-Video Scan Stageがnative heartbeatごとに永続化する、長辺960px、FFmpeg MJPEG `q:v=3`、metadataなしのcache画像。Scan Proxy Analysisでは1件ずつRGB decode・測定して解放し、全proxyのdecoded RGBを同時保持しない。scene signal用の一時320px画像、Frame Candidate Proxy、公開画像とは区別し、pathをidentityにしない。
+Video Scan Stageがnative heartbeatごとに永続化する、長辺960px、FFmpeg MJPEG `q:v=3`、metadataなしのcache画像。空signalを許容するsentinelを含め、image encoder用PTSはsource timingと分離した単調増加の連番へ正規化する。exact source timingは正規化前に記録し、encoder用PTSをsemantic identityへ含めない。Scan Proxy Analysisでは1件ずつRGB decode・測定して解放し、全proxyのdecoded RGBを同時保持しない。scene signal用の一時320px画像、Frame Candidate Proxy、公開画像とは区別し、pathをidentityにしない。
 _Avoid_: scene signal image, Frame Candidate, selected output
 
 **Frame Candidate Extraction Stage**:

--- a/docs/pipeline-resume.md
+++ b/docs/pipeline-resume.md
@@ -203,6 +203,12 @@ algorithm versionを意味入力とprovenanceへ記録します。
 | Pillow・libwebp・WebP contract | Selected Imageとpublication | Final SelectionまでのStage |
 | worker数・resource sample・進捗表示 | semantic outputは再計算しない | 全semantic checkpoint |
 
+heartbeatとscene signalのproxy encoderへ渡すPTSは、sentinelを含めて単調増加する
+連番へ正規化します。exact source timingは正規化より前の`showinfo`から記録するため、
+このencoder用PTSはsemantic outputではありません。source timing、proxy件数、JPEG bytesが
+同じまま非単調PTSだけを修復する実装変更ではScan engine versionを上げず、確定済みの
+Video Scan partitionを再利用します。
+
 model tagの更新確認結果だけが変わり、実際に解決されたidentityが同じ場合は既存Stageを
 再利用します。Ollama server versionまたはmodel identityが変わっても、その依存を持たない
 Video Identity、Video Scan、Frame Candidate、PCM、STTを捨てません。各Stageまたは

--- a/src/video_selection/media/ffmpeg_media_runtime.py
+++ b/src/video_selection/media/ffmpeg_media_runtime.py
@@ -1137,7 +1137,7 @@ class FfmpegMediaRuntime:
                 ),
                 (
                     "[heartbeat_sentinel][heartbeat_actual]"
-                    "concat=n=2:v=1:a=0[heartbeat_output]"
+                    "concat=n=2:v=1:a=0,setpts=N/(1*TB)[heartbeat_output]"
                 ),
                 (
                     "[scene_source]"
@@ -1154,7 +1154,10 @@ class FfmpegMediaRuntime:
                     f"{_bounded_scale_filter(320)},"
                     "format=yuvj420p,setpts=PTS-STARTPTS[scene_sentinel]"
                 ),
-                ("[scene_sentinel][scene_actual]concat=n=2:v=1:a=0[scene_output]"),
+                (
+                    "[scene_sentinel][scene_actual]"
+                    "concat=n=2:v=1:a=0,setpts=N/(1*TB)[scene_output]"
+                ),
             )
         )
         command.extend(

--- a/tests_ffmpeg/video_selection/media/test_ffmpeg_media_runtime.py
+++ b/tests_ffmpeg/video_selection/media/test_ffmpeg_media_runtime.py
@@ -63,6 +63,35 @@ def _write_failing_tool(path: Path) -> None:
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
 
 
+def _write_strict_proxy_pts_tool(path: Path) -> None:
+    script = f"""#!{sys.executable}
+import sys
+from pathlib import Path
+
+arguments = sys.argv[1:]
+graph = arguments[arguments.index("-filter_complex") + 1]
+required = (
+    "concat=n=2:v=1:a=0,setpts=N/(1*TB)[heartbeat_output]",
+    "concat=n=2:v=1:a=0,setpts=N/(1*TB)[scene_output]",
+)
+if not all(item in graph for item in required):
+    print("[mjpeg] Invalid pts (0) <= last (0)", file=sys.stderr)
+    raise SystemExit(7)
+
+for pattern in (item for item in arguments if "%012d.jpg" in item):
+    first = Path(pattern.replace("%012d", "000000000001"))
+    second = Path(pattern.replace("%012d", "000000000002"))
+    first.write_bytes(b"sentinel")
+    second.write_bytes(b"proxy")
+
+print("[showinfo@timeline] n: 0 pts: 1000 duration: 1 s:64x48", file=sys.stderr)
+print("[showinfo@heartbeat] n: 0 pts: 1000 duration: 1 s:64x48", file=sys.stderr)
+print("[showinfo@scene] n: 0 pts: 1000 duration: 1 s:64x48", file=sys.stderr)
+"""
+    path.write_text(script, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
 def _write_capable_tool(
     path: Path,
     tool: str,
@@ -835,6 +864,104 @@ def test_scan_video_partitions_match_uninterrupted_scan(
         (frame.source_pts, frame.image_path.read_bytes())
         for frame in uninterrupted.scene_frames
     ]
+
+
+def test_scan_partition_accepts_scene_change_at_owned_start(
+    tmp_path: Path,
+) -> None:
+    """partition先頭のscene changeがproxy PTS重複なく返されること。
+
+    Arrange:
+        - 1秒境界に明確なscene changeを持つ3秒動画が用意される
+    Act:
+        - scene changeを先頭に含む1秒partitionが実FFmpegでscanされる
+    Assert:
+        - heartbeatとsceneがexactなpartition先頭PTSで返されること
+    """
+    # Arrange
+    video_path = generate_scene_change_video(tmp_path / "boundary-scene.mkv")
+    runtime = FfmpegMediaRuntime()
+    stream = runtime.probe(video_path).streams[0]
+    assert stream.start_pts is not None
+    assert stream.time_base is not None
+    start_offset = Fraction(1) / stream.time_base
+    end_offset = Fraction(2) / stream.time_base
+    assert start_offset.denominator == 1
+    assert end_offset.denominator == 1
+    start_pts = stream.start_pts + start_offset.numerator
+    end_pts = stream.start_pts + end_offset.numerator
+
+    # Act
+    scan = runtime.scan_video_partition(
+        video_path,
+        stream,
+        tmp_path / "boundary-scene-partition",
+        media_origin=stream.start_pts * stream.time_base,
+        start_pts=start_pts,
+        end_pts=end_pts,
+        heartbeat_interval_seconds=1.0,
+        scene_change_threshold=0.25,
+        scene_min_interval_seconds=0.5,
+        decode_backend="cpu",
+    )
+
+    # Assert
+    assert isinstance(scan, NativeVideoScan)
+    assert [frame.source_pts for frame in scan.heartbeats] == [start_pts]
+    assert [frame.source_pts for frame in scan.scene_frames] == [start_pts]
+
+
+def test_scan_partition_supplies_monotonic_pts_to_proxy_encoder(
+    tmp_path: Path,
+) -> None:
+    """proxy encoderへ単調増加するPTSが渡されること。
+
+    Arrange:
+        - 重複PTSを拒否する外部FFmpegと有限partitionが用意される
+    Act:
+        - 公開MediaRuntimeからpartition scanが実行される
+    Assert:
+        - encoder failureにならずheartbeatとsceneが返されること
+    """
+    # Arrange
+    strict_ffmpeg = tmp_path / "strict-ffmpeg"
+    _write_strict_proxy_pts_tool(strict_ffmpeg)
+    runtime = FfmpegMediaRuntime(ffmpeg_executable=str(strict_ffmpeg))
+    stream = MediaStream(
+        index=0,
+        kind="video",
+        codec_name="h264",
+        time_base=Fraction(1, 1000),
+        start_pts=0,
+        duration_ts=2000,
+        width=64,
+        height=48,
+        sample_rate=None,
+        channels=None,
+        language=None,
+        is_default=True,
+        is_forced=False,
+        is_attached_picture=False,
+    )
+
+    # Act
+    scan = runtime.scan_video_partition(
+        tmp_path / "source.mkv",
+        stream,
+        tmp_path / "strict-proxy-pts",
+        media_origin=Fraction(0),
+        start_pts=1000,
+        end_pts=2000,
+        heartbeat_interval_seconds=1.0,
+        scene_change_threshold=0.25,
+        scene_min_interval_seconds=0.5,
+        decode_backend="cpu",
+    )
+
+    # Assert
+    assert isinstance(scan, NativeVideoScan)
+    assert [frame.source_pts for frame in scan.heartbeats] == [1000]
+    assert [frame.source_pts for frame in scan.scene_frames] == [1000]
 
 
 def test_scan_partition_allows_no_owned_heartbeat_or_scene(


### PR DESCRIPTION
## 概要

- heartbeat／scene proxyのsentinel連結後に、MJPEG encoder用PTSを単調増加する連番へ正規化
- exact source timingを正規化前の`showinfo`から取得する既存契約を維持
- semantic outputが変わらないためScan engine versionを維持し、完了済みpartition cacheを再利用
- 実FFmpegと重複PTSを拒否するencoder境界の回帰テストを追加
- 再開時のcache互換性をdomain/context documentationへ追記

## 原因

full-scale target acceptanceの特定15分partitionで、sentinelとactual proxyのPTSが
MJPEG encoder上で重複し、次のエラーでVideo Scanが停止していました。

```text
[mjpeg] Invalid pts (0) <= last (0)
Error submitting video frame to the encoder
```

同じpartitionを単独実行しても再現したため、NVDEC並列負荷ではなくproxy出力PTSの問題です。

## 実測確認

- 問題の実partition: 修正前は単独再現、修正候補では成功
- 修正前に成功する実partition: heartbeat 900枚・scene 13枚をrelative pathごとにSHA-256比較し不一致0枚
- 保存済みVideo Identityおよび31個の完了partitionは変更せず保持

## 検証

- `uv run pytest tests_ffmpeg/video_selection/media/test_ffmpeg_media_runtime.py -q`（47 passed）
- `uv run task test`（1241 passed）

Closes #245
