### PR TITLE
fix: commit変更後もAcceptance試行を累積する

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,7 +93,7 @@ _Avoid_: path文字列prefix検査, targetだけのsymlink検査, path検証とp
 _Avoid_: Canonical Selection Report, runtime log, baseline snapshot, raw benchmark output
 
 **Acceptance Run**:
-Acceptance PhaseまたはAcceptance Comparison Runを総称する論理的な完了・集約単位。一つ以上のAcceptance Run Attemptを持ち、再開をまたぐ全試行を集約して完了recordと予算判定を確定する。
+Acceptance PhaseまたはAcceptance Comparison Runを総称する論理的な完了・集約単位。一つ以上のAcceptance Run Attemptを持ち、commitだけが変わる再開を含む全試行を集約して完了recordと予算判定を確定する。
 _Avoid_: Acceptance Run Attempt, one process lifetime, Processing Stage, production run
 
 **Acceptance Phase**:
@@ -109,11 +109,11 @@ target acceptanceの論理runと、その結果に依存する後続runだけを
 _Avoid_: suite全体reset, Processing Stage reset, cache migration, automatic Stage invalidation
 
 **Video Scan Comparison Context**:
-Parallelism BaselineとFresh Processingのwall timeを同一条件の証拠として比較するために共有する、source revision・実効設定/model identity・target runtimeを正規化したprivacy-safe identity。bootごとのvisible RAM差は含めず、両runの全attemptで一致するものだけを同一比較として扱う。
+Parallelism BaselineとFresh Processingのwall timeを同一条件の証拠として比較するために共有する、実効設定/model/endpoint identity・target runtimeを正規化したprivacy-safe identity。bootごとのvisible RAM差とsource commitは含めず、両runの全attemptで一致するものだけを同一比較として扱う。source commitは各attemptのprovenanceへ完全な値で残し、commitだけが変わる再開ではそれ以前のattemptも同じ論理runへ累積する。
 _Avoid_: Acceptance Run execution context, raw host snapshot, Stage artifact digest
 
 **Acceptance Run Attempt**:
-一つのAcceptance PhaseまたはAcceptance Comparison Runについて、開始から正常終了、中断、またはoperation failureまで連続して計測された実行区間。Completed Stageを再利用してrunを再開しても、それ以前のattemptを性能証拠から除外しない。process強制終了時もactive markerとAcceptance Attempt Journalから`process_abandoned`として閉じる。
+一つのAcceptance PhaseまたはAcceptance Comparison Runについて、開始から正常終了、中断、またはoperation failureまで連続して計測された実行区間。Completed Stageを再利用してrunを再開しても、source commitの変更を含むそれ以前のattemptを性能証拠から除外しない。process強制終了時もactive markerとAcceptance Attempt Journalから`process_abandoned`として閉じる。
 _Avoid_: Acceptance Run, Acceptance Phase, Acceptance Comparison Run, retry inside model inference, Processing Stage
 
 **Acceptance Attempt Journal**:

--- a/docs/target-acceptance.md
+++ b/docs/target-acceptance.md
@@ -187,9 +187,12 @@ Video Scan Comparison Contextが変わった場合だけ、旧Parallelism Baseli
 processing cacheを
 破棄してParallelism Baselineを現在contextで再測定する。共有Video Identity cacheは保持する。
 
-Video Scan Comparison Contextはsource revision、実効configuration/model/endpoint identity、
-target runtimeから作り、boot単位で微小に変わるvisible RAMは除外する。Parallelism Baselineと
-Fresh Processingの全attemptが同じcontextの場合だけwall time改善gateを評価する。
+Video Scan Comparison Contextは実効configuration/model/endpoint identityとtarget runtimeから
+作り、boot単位で微小に変わるvisible RAMとsource commitは除外する。source commitは各attemptと
+最終Acceptance Recordのprovenanceへ完全な値で残すが、commitだけが変わる再開では
+Parallelism Baselineを再測定せず、それ以前を含む全attemptの時間、作業量、resource peakを
+同じ論理runへ累積する。Parallelism BaselineとFresh Processingの全attemptが同じcontextの場合だけ
+wall time改善gateを評価し、両runのStage artifact content digest一致も引き続き要求する。
 Fresh Processingが一度でも開始された
 後にcontextが変わった場合は、新旧環境の性能証拠を混在させず、追加runを始める前に
 `--reset-run parallelism-baseline`を要求する。
@@ -253,8 +256,9 @@ kill後も残ったVideo Identity、Durable Work Unit、Completed Stage manifest
 phaseとcomparisonが同時にactiveな場合、または保存run名がplanに存在しない場合は、
 attempt、state、journalを推測で変更せずfail-fastする。
 
-identityを変えた場合や意図的に特定runからやり直す場合だけ、対象runまたはsuiteを
-明示的にresetする。
+比較対象となる実効configuration/model/endpoint identityまたはtarget runtimeを変えた場合や、
+意図的に特定runからやり直す場合だけ、対象runまたはsuiteを明示的にresetする。source commitだけの
+変更ではresetせず、StageとDurable Work Unitそれぞれのfingerprintで再利用可否を判定する。
 
 ```bash
 uv run task acceptance-target \

--- a/src/video_selection/acceptance/video_scan_parallelism_comparison.py
+++ b/src/video_selection/acceptance/video_scan_parallelism_comparison.py
@@ -11,7 +11,6 @@ _COMPARISON_IDENTITY_KEYS = (
     "effective_configuration_digest",
     "ollama_endpoint_identity",
     "model_identity_digest",
-    "commit",
 )
 
 
@@ -156,17 +155,12 @@ def _video_scan_comparison_context(
         execution_context.get("identity"),
         "execution context identity",
     )
-    source_revision = _mapping(
-        execution_context.get("source_revision"),
-        "execution context source_revision",
-    )
     target = _mapping(
         execution_context.get("target"),
         "execution context target",
     )
     return {
         "identity": {key: identity.get(key) for key in _COMPARISON_IDENTITY_KEYS},
-        "source_revision": source_revision,
         "target": {
             key: value for key, value in target.items() if key != "visible_ram_bytes"
         },

--- a/tests/video_selection/acceptance/test_target_suite_runner.py
+++ b/tests/video_selection/acceptance/test_target_suite_runner.py
@@ -1957,6 +1957,119 @@ def test_interrupted_auto_cold_preserves_cache_after_fixed_three_release(
     assert state["fixed3_cache_released"] is True
 
 
+def test_full_suite_resumes_failed_fixed_three_after_commit_change(
+    tmp_path: Path,
+) -> None:
+    """commit変更後も未完了fixed3がcheckpointから再開されること。
+
+    Arrange:
+        - 旧commitでfixed3が失敗しprocessing cacheへpartitionが確定される
+        - 同じsuite、設定、model、targetのままsource commitだけが変更される
+    Act:
+        - full suiteが新commitから再開される
+    Assert:
+        - 確定済みpartitionが保持されfixed3、cold、warmが完了されること
+        - fixed3の全attempt時間が性能証拠へ累積されること
+    """
+    # Arrange
+    profile_path = _profile(tmp_path)
+    revision = {"commit": "a" * 40}
+    calls: list[tuple[str, str | int]] = []
+    fixed_three_failed = False
+    partition_reused = False
+
+    def execute(
+        run_name: str,
+        configuration: EffectiveConfiguration,
+        _models: ResolvedModels,
+        _suite_root: Path,
+    ) -> AcceptanceRunAttemptExecutionResult:
+        nonlocal fixed_three_failed, partition_reused
+        calls.append((run_name, configuration.video_scan_workers))
+        fixed_three = configuration.video_scan_workers == 3
+        partition_marker = configuration.processing_cache_folder / "preserved-partition"
+        if fixed_three and not fixed_three_failed:
+            fixed_three_failed = True
+            partition_marker.parent.mkdir(parents=True, exist_ok=True)
+            partition_marker.write_text("completed", encoding="utf-8")
+            failed = _interrupted_run_attempt(run_name)
+            failed.update(
+                {
+                    "failure_reason": "decoder_failure",
+                    "failure_exit_code": 1,
+                    "video_scan_parallelism": {
+                        "mode": "fixed",
+                        "configured_workers": 3,
+                        "decode_backend": "nvdec",
+                        "auto_max_workers": 6,
+                        "initial_workers": 3,
+                        "final_workers": 3,
+                        "peak_workers": 3,
+                        "completed_scans": 0,
+                        "scan_wall_seconds": 20.0,
+                        "changes": [],
+                    },
+                }
+            )
+            return 1, failed, None, None
+        if fixed_three:
+            partition_reused = (
+                partition_marker.read_text(encoding="utf-8") == "completed"
+            )
+        result = _successful_run_attempt(configuration, run_name)
+        record = result[1]
+        workers = 3 if fixed_three else 6
+        record["video_scan_parallelism"] = {
+            "mode": "fixed" if fixed_three else "auto",
+            "configured_workers": 3 if fixed_three else "auto",
+            "decode_backend": "nvdec",
+            "auto_max_workers": 6,
+            "initial_workers": 3,
+            "final_workers": workers,
+            "peak_workers": workers,
+            "completed_scans": 1,
+            "scan_wall_seconds": 120.0 if fixed_three else 80.0,
+            "changes": [],
+        }
+        record["stage_artifact_content_digest"] = "8" * 64
+        return result
+
+    runner = _runner(
+        execute,
+        revision_probe=lambda _path: (revision["commit"], False),
+    )
+    failed = runner.run(profile_path=profile_path, suite="full")
+    revision["commit"] = "b" * 40
+
+    # Act
+    resumed = runner.run(profile_path=profile_path, suite="full")
+
+    # Assert
+    state = read_json_object(
+        tmp_path / "artifacts" / "target-acceptance" / "full" / "acceptance-state.json"
+    )
+    assert failed == 1
+    assert resumed == 3
+    assert partition_reused is True
+    assert calls == [
+        ("fixed3", 3),
+        ("fixed3", 3),
+        ("cold", "auto"),
+        ("warm", "auto"),
+    ]
+    assert state is not None
+    comparison_runs = state["comparison_runs"]
+    assert isinstance(comparison_runs, dict)
+    fixed_three = comparison_runs["fixed3"]
+    assert isinstance(fixed_three, dict)
+    assert fixed_three["attempt_count"] == 2
+    assert fixed_three["duration_seconds"] == 14.0
+    assert fixed_three["cache_hit_count"] == 1
+    assert fixed_three["cache_miss_count"] == 2
+    assert fixed_three["completed_stage_counts"] == {"scan-video": 2}
+    assert state["fixed3_cache_released"] is True
+
+
 def test_full_suite_remeasures_fixed_three_after_context_change_before_auto_cold(
     tmp_path: Path,
 ) -> None:

--- a/tests/video_selection/acceptance/test_video_scan_parallelism_comparison.py
+++ b/tests/video_selection/acceptance/test_video_scan_parallelism_comparison.py
@@ -83,6 +83,91 @@ def test_different_execution_contexts_fail_the_comparison() -> None:
     assert comparison["passed"] is False
 
 
+def test_commit_change_preserves_the_comparison_context() -> None:
+    """commitだけが異なる再開attemptが同じ比較条件として扱われること。
+
+    Arrange:
+        - 設定、model、targetが同じでsource commitだけが異なるrunが用意される
+    Act:
+        - Video Scan parallelism比較が構築される
+    Assert:
+        - execution context gateと比較全体が合格されること
+    """
+    # Arrange
+    fixed = _run_record(
+        workers=3,
+        mode="fixed",
+        wall_seconds=120.0,
+        artifact_digest="a" * 64,
+    )
+    automatic = _run_record(
+        workers=6,
+        mode="auto",
+        wall_seconds=80.0,
+        artifact_digest="a" * 64,
+    )
+    automatic["execution_context"] = _execution_context(commit="e" * 40)
+
+    # Act
+    comparison = build_video_scan_parallelism_comparison(fixed, automatic)
+
+    # Assert
+    gates = comparison["gates"]
+    assert isinstance(gates, dict)
+    assert gates["execution_context_equal"] is True
+    assert comparison["passed"] is True
+
+
+@pytest.mark.parametrize(
+    "identity_key",
+    (
+        "configuration_digest",
+        "effective_configuration_digest",
+        "ollama_endpoint_identity",
+        "model_identity_digest",
+    ),
+)
+def test_comparison_identity_change_breaks_the_comparison(
+    identity_key: str,
+) -> None:
+    """比較対象identityが異なるrunが比較不能にされること。
+
+    Arrange:
+        - targetとcommitが同じで比較対象identityだけが異なるrunが用意される
+    Act:
+        - Video Scan parallelism比較が構築される
+    Assert:
+        - execution context gateと比較全体が不合格にされること
+    """
+    # Arrange
+    fixed = _run_record(
+        workers=3,
+        mode="fixed",
+        wall_seconds=120.0,
+        artifact_digest="a" * 64,
+    )
+    automatic = _run_record(
+        workers=6,
+        mode="auto",
+        wall_seconds=80.0,
+        artifact_digest="a" * 64,
+    )
+    changed_context = _execution_context()
+    changed_identity = changed_context["identity"]
+    assert isinstance(changed_identity, dict)
+    changed_identity[identity_key] = "e" * 64
+    automatic["execution_context"] = changed_context
+
+    # Act
+    comparison = build_video_scan_parallelism_comparison(fixed, automatic)
+
+    # Assert
+    gates = comparison["gates"]
+    assert isinstance(gates, dict)
+    assert gates["execution_context_equal"] is False
+    assert comparison["passed"] is False
+
+
 @pytest.mark.parametrize(
     ("automatic_change", "failed_gate"),
     [
@@ -235,16 +320,21 @@ def _run_record(
     }
 
 
-def _execution_context(*, cpu: str = "stable") -> dict[str, object]:
+def _execution_context(
+    *,
+    cpu: str = "stable",
+    commit: str = "d" * 40,
+) -> dict[str, object]:
     """比較test用のprivacy-safe execution contextを返す。"""
     return {
         "identity": {
+            "configuration_digest": "f" * 64,
             "effective_configuration_digest": "a" * 64,
             "ollama_endpoint_identity": "b" * 64,
             "model_identity_digest": "c" * 64,
-            "commit": "d" * 40,
+            "commit": commit,
         },
-        "source_revision": {"commit": "d" * 40, "dirty": False},
+        "source_revision": {"commit": commit, "dirty": False},
         "target": {
             "cpu": cpu,
             "logical_cpu_count": 24,


### PR DESCRIPTION
## 概要

- Git commitとsource revisionをVideo Scan Comparison Contextの比較条件から除外
- commitは各attemptのprovenanceへ残し、commit跨ぎでも過去attemptの時間・作業量・resource peakを累積
- 実効設定、model、Ollama endpoint、target runtimeの一致条件とStage artifact content digest gateは維持
- commit変更後に失敗済みfixed3をcheckpointから再開する回帰テストと運用文書を追加

## 検証

- `uv run task test`
  - lint: pass
  - format: pass
  - mypy: pass
  - pytest: 1247 passed
- Acceptance比較・再開の対象テスト: 90 passed

## 影響

- 公開output、Stage fingerprint、checkpoint versionは変更なし
- Git commitだけが変わる再開でresetを要求しない
- 設定・model・endpoint・targetが変わる場合は従来どおり再測定または明示resetを要求

Relates to #247
Relates to #189