### PR TITLE
fix: Candidate Annotationの重複特徴を安全に修復する

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -376,6 +376,10 @@ _Avoid_: confidence score, enemy name inference, absence of major evidence, Spoi
 Candidate Annotationの主推論がschemaには適合するがContext Cue参照またはSpoiler Evidenceの関係だけに違反したとき、分類と他の観測を凍結し、違反した従属fieldだけを一度修復してAnnotation全体を再検証する境界。
 _Avoid_: second Candidate Annotation, classification retry, deterministic fallback, silent candidate drop
 
+**Combat Subject Evidence Set Repair**:
+Candidate Annotationの主推論を同じsemantic入力で一度再試行しても、Combat Subject Evidenceの有限集合である`colors`または`traits`に同じenum値だけが重複した場合、最初の出現順を保って重複を除去し、Candidate Annotation全体をstrict validatorへ通し直す境界。欠落field、未知field、型違反、未知enum、件数上限、domain関係違反は修復せずfatalにする。
+_Avoid_: schema relaxation, inferred evidence, silent candidate drop, Stage cache invalidation
+
 **Combat Encounter Verification**:
 Candidate Annotationの主推論が掲載可能とした戦闘、または掲載可能な非戦闘としたScene Kind `combat`のgameplayまたは`recurring_gameplay` actionのRepresentative Frame一枚だけに対し、音声、Context Cue、前後場面、主推論の説明文を与えず実行する条件付きOllama推論。敵・boss固有の名前とHP・status bar、または戦うplayer・相手本体から戦闘の有無を確認し、Combat Encounter KindとCombat Encounter Basisを必ず整合する組として返す。主推論の戦闘種別はそのまま採用しない。敵名やHP・status barだけでは通常戦闘にも主要戦闘にもせず、両方の積極的根拠がなければ`uncertain`とする。敵本体が画面外・画面端・エフェクト内でも敵status UIがあれば戦闘とし、Combat Visibility Verificationへ進める。player自身の通常HUD、portrait、操作button、minimapだけでは戦闘にしない。最初の確認が非戦闘なら、先の回答を推測しない別promptで同じ画素を独立再確認する。Scene Kind `combat`で二回とも非戦闘なら、戦闘sceneとして説明できないframeとしてExplanation Valueを`none`にする。それ以外の`recurring_gameplay` actionではCombat Visibility Verificationへ進め、敵本体の直接観測との不一致を検出する。
 _Avoid_: combat visibility, contextual combat classification, final selection

--- a/src/video_selection/vision/ollama_vision_runtime.py
+++ b/src/video_selection/vision/ollama_vision_runtime.py
@@ -1077,16 +1077,33 @@ class OllamaVisionRuntime:
                     decoded=decoded,
                     validation_code=error.validation_code,
                 )
+                if conservative_repair is None:
+                    conservative_repair = (
+                        _repair_repeated_candidate_combat_subject_duplicates(
+                            stage_kind=stage_kind,
+                            attempt=attempt,
+                            decoded=decoded,
+                            previous_validation_code=previous_validation_code,
+                            validation_code=error.validation_code,
+                        )
+                    )
                 if conservative_repair is not None:
-                    value = parser(conservative_repair)
-                    previous_validation_code = error.validation_code
-                elif attempt >= 2 or error.reason not in _RETRYABLE_REASONS:
+                    try:
+                        value = parser(conservative_repair)
+                    except VisionRuntimeError as repaired_error:
+                        error = repaired_error
+                        conservative_repair = None
+                    else:
+                        previous_validation_code = error.validation_code
+                if conservative_repair is None and (
+                    attempt >= 2 or error.reason not in _RETRYABLE_REASONS
+                ):
                     raise VisionRuntimeError(
                         error.reason,
                         validation_code=error.validation_code,
                         attempt_count=attempt,
                     ) from None
-                else:
+                if conservative_repair is None:
                     previous_validation_code = error.validation_code
                     if (
                         stage_kind == "candidate_annotation"
@@ -1826,6 +1843,48 @@ def _repair_repeated_combat_visibility_correlation(
     repaired = dict(decoded)
     repaired["combat_interaction_visibility"] = "none"
     return repaired
+
+
+def _repair_repeated_candidate_combat_subject_duplicates(
+    *,
+    stage_kind: StageKind,
+    attempt: int,
+    decoded: Mapping[str, object] | None,
+    previous_validation_code: str | None,
+    validation_code: str | None,
+) -> Mapping[str, object] | None:
+    """再試行後も残る戦闘対象の有限set重複だけを決定的に一意化する。"""
+    schema_code = "candidate_annotation_schema_invalid"
+    if (
+        attempt < 2
+        or stage_kind != "candidate_annotation"
+        or decoded is None
+        or previous_validation_code != schema_code
+        or validation_code != schema_code
+    ):
+        return None
+    repaired = cast(dict[str, object], copy.deepcopy(decoded))
+    raw_observations = repaired.get("frame_observations")
+    if not isinstance(raw_observations, list):
+        return None
+    changed = False
+    for raw_observation in raw_observations:
+        if not isinstance(raw_observation, dict):
+            return None
+        evidence = raw_observation.get("combat_subject_evidence")
+        if not isinstance(evidence, dict):
+            return None
+        for field in ("colors", "traits"):
+            values = evidence.get(field)
+            if not isinstance(values, list) or not all(
+                isinstance(value, str) for value in values
+            ):
+                return None
+            unique_values = list(dict.fromkeys(values))
+            if unique_values != values:
+                evidence[field] = unique_values
+                changed = True
+    return repaired if changed else None
 
 
 def _decode_content(

--- a/src/video_selection/vision/ollama_vision_runtime.py
+++ b/src/video_selection/vision/ollama_vision_runtime.py
@@ -1005,6 +1005,28 @@ class OllamaVisionRuntime:
         previous_validation_code: str | None = None
         repair_code: str | None = None
         candidate_relationship_draft: Mapping[str, object] | None = None
+
+        def retry_candidate_dialogue_validation(
+            error: VisionRuntimeError,
+            attempt: int,
+        ) -> bool:
+            """画面内台詞の専用validationを追加の視覚確認へ渡す。"""
+            nonlocal previous_validation_code
+            nonlocal repair_code
+            nonlocal candidate_relationship_draft
+            if (
+                stage_kind != "candidate_annotation"
+                or error.validation_code
+                != "candidate_annotation_dialogue_visibility_unverified"
+                or attempt >= 3
+            ):
+                return False
+            previous_validation_code = error.validation_code
+            candidate_relationship_draft = None
+            repair_code = _repair_validation_code(error)
+            self._sleep_before_retry(error.retry_after_seconds, stage_kind)
+            return True
+
         for attempt in (1, 2, 3):
             if stage_kind != "scene_catalog":
                 self._require_candidate_annotation_active()
@@ -1049,16 +1071,7 @@ class OllamaVisionRuntime:
                     else decoded
                 )
             except VisionRuntimeError as error:
-                if (
-                    stage_kind == "candidate_annotation"
-                    and error.validation_code
-                    == "candidate_annotation_dialogue_visibility_unverified"
-                    and attempt < 3
-                ):
-                    previous_validation_code = error.validation_code
-                    candidate_relationship_draft = None
-                    repair_code = _repair_validation_code(error)
-                    self._sleep_before_retry(error.retry_after_seconds, stage_kind)
+                if retry_candidate_dialogue_validation(error, attempt):
                     continue
                 if relationship_repair:
                     error = _relationship_repair_error(error)
@@ -1091,6 +1104,11 @@ class OllamaVisionRuntime:
                     try:
                         value = parser(conservative_repair)
                     except VisionRuntimeError as repaired_error:
+                        if retry_candidate_dialogue_validation(
+                            repaired_error,
+                            attempt,
+                        ):
+                            continue
                         error = repaired_error
                         conservative_repair = None
                     else:

--- a/tests/video_selection/vision/test_ollama_vision_runtime.py
+++ b/tests/video_selection/vision/test_ollama_vision_runtime.py
@@ -1507,6 +1507,132 @@ def test_candidate_annotation_keeps_single_image_combat_subject_evidence() -> No
     assert sum("images" in message for message in messages) == 1
 
 
+def test_repeated_candidate_combat_trait_duplicates_are_deduplicated() -> None:
+    """再試行後も重複する戦闘対象特徴が決定的に一意化されること。
+
+    Arrange:
+        - 同じ有限enum特徴を重複して返すCandidate Annotation応答が用意される
+    Act:
+        - 公開Vision RuntimeでCandidate Annotationが実行される
+    Assert:
+        - 初回はSchema違反として再試行されること
+        - 再試行後は特徴だけが入力順を保って一意化されること
+    """
+    # Arrange
+    payloads: list[Mapping[str, object]] = []
+
+    def requester(
+        _method: str,
+        _url: str,
+        payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        assert payload is not None
+        payloads.append(payload)
+        response = _frame_observation_payload(
+            (("frame-a", "battle", "gameplay_action", "none", "hud"),)
+        )
+        observation = _first_frame_observation(response)
+        observation["combat_subject_evidence"] = {
+            "body_plan": "quadruped",
+            "scale": "large",
+            "surface": "organic",
+            "colors": ["green", "green", "brown"],
+            "traits": ["large_mouth", "large_mouth", "bulbous_body"],
+            "distinctiveness": "distinctive",
+        }
+        return _response(response)
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+        model_state_resolver=_resolved_artifact,
+    )
+
+    # Act
+    annotation, diagnostics = runtime.annotate_candidate(
+        _annotation_request(),
+        _catalog(),
+        _resolved_model(ModelRole.CANDIDATE_ANNOTATION),
+        num_ctx=32768,
+    )
+
+    # Assert
+    assert annotation.combat_subject_evidence == CombatSubjectEvidence(
+        body_plan="quadruped",
+        scale="large",
+        surface="organic",
+        colors=("brown", "green"),
+        traits=("bulbous_body", "large_mouth"),
+        distinctiveness="distinctive",
+    )
+    assert diagnostics.attempt_count == 2
+    assert diagnostics.validation_code == "candidate_annotation_schema_invalid"
+    assert len(payloads) == 2
+
+
+def test_candidate_combat_duplicate_repair_keeps_other_schema_errors_fatal() -> None:
+    """戦闘対象特徴の重複修復で別のSchema違反が隠されないこと。
+
+    Arrange:
+        - 重複特徴に加えて未知fieldを持つ応答が繰り返し用意される
+    Act:
+        - 公開Vision RuntimeでCandidate Annotationが実行される
+    Assert:
+        - 2回目にも全体のSchema違反がfatalとして返されること
+    """
+    # Arrange
+    request_count = 0
+
+    def requester(
+        _method: str,
+        _url: str,
+        _payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        nonlocal request_count
+        request_count += 1
+        response = _frame_observation_payload(
+            (("frame-a", "battle", "gameplay_action", "none", "hud"),)
+        )
+        observation = _first_frame_observation(response)
+        observation["combat_subject_evidence"] = {
+            "body_plan": "quadruped",
+            "scale": "large",
+            "surface": "organic",
+            "colors": ["green"],
+            "traits": ["large_mouth", "large_mouth"],
+            "distinctiveness": "distinctive",
+        }
+        observation["unexpected"] = True
+        return _response(response)
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+        model_state_resolver=_resolved_artifact,
+    )
+
+    # Act
+    with pytest.raises(VisionRuntimeError) as failure:
+        runtime.annotate_candidate(
+            _annotation_request(),
+            _catalog(),
+            _resolved_model(ModelRole.CANDIDATE_ANNOTATION),
+            num_ctx=32768,
+        )
+
+    # Assert
+    assert failure.value.reason is VisionRuntimeFailureReason.SCHEMA_INVALID
+    assert failure.value.validation_code == "candidate_annotation_schema_invalid"
+    assert failure.value.attempt_count == 2
+    assert request_count == 2
+
+
 def test_incomplete_distinctive_combat_subject_evidence_is_retried() -> None:
     """不完全なdistinctive Combat Subject Evidenceがdomain retryされること。
 

--- a/tests/video_selection/vision/test_ollama_vision_runtime.py
+++ b/tests/video_selection/vision/test_ollama_vision_runtime.py
@@ -1633,6 +1633,75 @@ def test_candidate_combat_duplicate_repair_keeps_other_schema_errors_fatal() -> 
     assert request_count == 2
 
 
+def test_candidate_combat_duplicate_repair_preserves_dialogue_recheck() -> None:
+    """戦闘対象特徴の重複修復後にも画面内台詞が独立再確認されること。
+
+    Arrange:
+        - 最初の2応答で重複特徴と文脈依存の画面内台詞判定が用意される
+        - 3回目では重複がなく画面内台詞もない応答が用意される
+    Act:
+        - 公開Vision RuntimeでCandidate Annotationが実行される
+    Assert:
+        - 重複修復後の専用validationが3回目の視覚再確認へ渡されること
+    """
+    # Arrange
+    payloads: list[Mapping[str, object]] = []
+
+    def requester(
+        _method: str,
+        _url: str,
+        payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        assert payload is not None
+        payloads.append(payload)
+        response = _frame_observation_payload(
+            (("frame-a", "exploration", "event_dialogue", "high", "dialogue"),)
+        )
+        observation = _first_frame_observation(response)
+        visible = len(payloads) < 3
+        observation.update(
+            {
+                "cinematic_event_presentation": True,
+                "on_screen_dialogue_text_visible": visible,
+                "dialogue_text_presentation": ("dialogue_box" if visible else "none"),
+                "combat_subject_evidence": {
+                    "body_plan": "unknown",
+                    "scale": "unknown",
+                    "surface": "unknown",
+                    "colors": [],
+                    "traits": (["tail", "tail"] if len(payloads) < 3 else ["tail"]),
+                    "distinctiveness": "unclear",
+                },
+            }
+        )
+        return _response(response)
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+        model_state_resolver=_resolved_artifact,
+    )
+
+    # Act
+    annotation, diagnostics = runtime.annotate_candidate(
+        _annotation_request(),
+        _catalog(),
+        _resolved_model(ModelRole.CANDIDATE_ANNOTATION),
+        num_ctx=32768,
+    )
+
+    # Assert
+    assert annotation.explanation_value == "none"
+    assert diagnostics.attempt_count == 3
+    assert diagnostics.validation_code == (
+        "candidate_annotation_dialogue_visibility_unverified"
+    )
+    assert len(payloads) == 3
+
+
 def test_incomplete_distinctive_combat_subject_evidence_is_retried() -> None:
     """不完全なdistinctive Combat Subject Evidenceがdomain retryされること。
 


### PR DESCRIPTION
## 概要

- Candidate Annotationが再試行後もCombat Subject Evidenceのcolorsまたはtraitsへ同じ有限enum値を重複して返した場合だけ、最初の出現順を保って一意化します
- 正規化後はAnnotation全体をstrict validatorへ通し直し、未知field、型違反、未知enum、件数上限、domain関係違反は引き続きfatalにします
- 重複除去後に画面内台詞の専用validationが発生した場合も、既存の3回目の独立視覚確認へ進めます
- Completed Stageを無効化せず、未完了のCandidateだけを再開できる境界をCONTEXT.mdへ記録します

## 原因

Windows 11 Pro / WSL2 / RTX 5090のfull target acceptanceで、Ollamaの構造化出力がcombat_subject_evidence.traitsのuniqueItems制約を2回続けて守らず、schema_invalidで停止しました。JSON、必須field、型、他のenumは有効でした。

## レビュー対応

Codex Reviewの指摘に基づき、重複除去後のparserがcandidate_annotation_dialogue_visibility_unverifiedを返す複合条件をred testで再現しました。通常応答と重複修復後の応答を同じ台詞再確認handlerへ通し、3回目の視覚再確認が維持されるようにしました。

## 検証

- uv run task test: 1250 passed
- uv run task test-ffmpeg: 50 passed
- Vision Runtime focused tests: 108 passed
- supported targetで失敗した同一Candidateをprivacy-safeにreplayし、重複応答を正規化後、後続の戦闘確認まで完了
- raw prompt、raw response、Context Cue本文、実path、動画名は保存・公開していません

## 影響

- 正常なCandidate Annotationの意味結果、公開interface、Stage Fingerprintは変更しません
- 失敗Candidateのskip、drop、other fallbackは行いません
- 既存のCompleted Stageは再計算対象にしません

Refs #238
Refs #189