### PR TITLE
fix: 台詞再確認後の重複特徴を修復する

### DIFF
--- a/src/video_selection/vision/ollama_vision_runtime.py
+++ b/src/video_selection/vision/ollama_vision_runtime.py
@@ -1096,7 +1096,6 @@ class OllamaVisionRuntime:
                             stage_kind=stage_kind,
                             attempt=attempt,
                             decoded=decoded,
-                            previous_validation_code=previous_validation_code,
                             validation_code=error.validation_code,
                         )
                     )
@@ -1868,7 +1867,6 @@ def _repair_repeated_candidate_combat_subject_duplicates(
     stage_kind: StageKind,
     attempt: int,
     decoded: Mapping[str, object] | None,
-    previous_validation_code: str | None,
     validation_code: str | None,
 ) -> Mapping[str, object] | None:
     """再試行後も残る戦闘対象の有限set重複だけを決定的に一意化する。"""
@@ -1877,7 +1875,6 @@ def _repair_repeated_candidate_combat_subject_duplicates(
         attempt < 2
         or stage_kind != "candidate_annotation"
         or decoded is None
-        or previous_validation_code != schema_code
         or validation_code != schema_code
     ):
         return None

--- a/tests/video_selection/vision/test_ollama_vision_runtime.py
+++ b/tests/video_selection/vision/test_ollama_vision_runtime.py
@@ -1702,6 +1702,80 @@ def test_candidate_combat_duplicate_repair_preserves_dialogue_recheck() -> None:
     assert len(payloads) == 3
 
 
+def test_dialogue_recheck_combat_trait_duplicates_are_deduplicated() -> None:
+    """画面内台詞の再確認応答に残る重複特徴が決定的に一意化されること。
+
+    Arrange:
+        - 初回は画面内台詞の独立再確認が必要な応答が用意される
+        - 2回目は台詞なしだが有限enum特徴だけが重複した応答が用意される
+    Act:
+        - 公開Vision RuntimeでCandidate Annotationが実行される
+    Assert:
+        - 再確認結果を保ったまま特徴だけが入力順で一意化されること
+    """
+    # Arrange
+    payloads: list[Mapping[str, object]] = []
+
+    def requester(
+        _method: str,
+        _url: str,
+        payload: Mapping[str, object] | None,
+        _timeout: float,
+    ) -> object:
+        assert payload is not None
+        payloads.append(payload)
+        response = _frame_observation_payload(
+            (("frame-a", "exploration", "event_dialogue", "high", "dialogue"),)
+        )
+        observation = _first_frame_observation(response)
+        visible = len(payloads) == 1
+        observation.update(
+            {
+                "cinematic_event_presentation": True,
+                "on_screen_dialogue_text_visible": visible,
+                "dialogue_text_presentation": ("dialogue_box" if visible else "none"),
+                "combat_subject_evidence": {
+                    "body_plan": "unknown",
+                    "scale": "unknown",
+                    "surface": "unknown",
+                    "colors": [],
+                    "traits": (["tail"] if visible else ["tail", "tail"]),
+                    "distinctiveness": "unclear",
+                },
+            }
+        )
+        return _response(response)
+
+    runtime = OllamaVisionRuntime(
+        "http://localhost:11434",
+        timeout_seconds=60.0,
+        requester=requester,
+        sleeper=lambda _seconds: None,
+        model_state_resolver=_resolved_artifact,
+    )
+
+    # Act
+    annotation, diagnostics = runtime.annotate_candidate(
+        _annotation_request(),
+        _catalog(),
+        _resolved_model(ModelRole.CANDIDATE_ANNOTATION),
+        num_ctx=32768,
+    )
+
+    # Assert
+    assert annotation.combat_subject_evidence == CombatSubjectEvidence(
+        body_plan="unknown",
+        scale="unknown",
+        surface="unknown",
+        colors=(),
+        traits=("tail",),
+        distinctiveness="unclear",
+    )
+    assert diagnostics.attempt_count == 2
+    assert diagnostics.validation_code == "candidate_annotation_schema_invalid"
+    assert len(payloads) == 2
+
+
 def test_incomplete_distinctive_combat_subject_evidence_is_retried() -> None:
     """不完全なdistinctive Combat Subject Evidenceがdomain retryされること。
 


### PR DESCRIPTION
## 概要

full target acceptanceで確認した「画面内台詞の独立再確認後に、Combat Subject Evidenceの有限集合だけが重複する」Candidate Annotationを安全に完了できるようにします。

## 変更内容

- `candidate_annotation_dialogue_visibility_unverified` など別のretry理由の後でも、2回目以降の応答が `colors` / `traits` の同一enum値重複だけでSchema違反になった場合は、既存のCombat Subject Evidence Set Repairを適用
- 重複は最初の出現順を保って一意化し、Candidate Annotation全体を既存のstrict validatorへ再投入
- unknown field、型違反、unknown enum、件数上限、domain関係違反は引き続きfatal
- 公開 `OllamaVisionRuntime.annotate_candidate` を通る回帰テストを追加

## 実機診断

PR #250 merge commit `2198fb5` のfull target acceptanceで、既存Completed Stageを保持したresetなし再開を実施しました。

- retry attempt: cache hit 6768、cache miss 0、unexpected recompute 0
- 同じglobal `stage_index=6757`で2回失敗
- privacy-safeな1候補replayでは、初回応答はJSON Schemaを通過後に画面内台詞の再確認へ進行
- 2回目応答は `frame_observations[0].combat_subject_evidence.traits` の `uniqueItems` 違反だけを確認
- raw prompt、raw response、Context Cue本文、実path、動画名は保存・表示・公開していません

## Cache / resume

この変更は従来Completed Stageを生成できなかったfatal経路だけを完了可能にします。既存の成功済みCandidate Annotationの意味結果は変えないためStage contractを更新せず、保持済みCompleted Stageをそのまま再利用します。

## 検証

- `uv run task test`: 1251 passed
- `uv run task test-ffmpeg`: 50 passed
- Vision Runtime focused: 109 passed
- 新規回帰テストは修正前に `schema_invalid` で失敗し、修正後に成功

Closes #238
Related to #189