### PR TITLE
feat: 複数動画からブログ掲載用画像を選定できるようにする

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,12 +1,16 @@
 # Game Screen Pick
 
-単一のゲーム動画全体から、ブログへ掲載しやすい画像を選び出すための文脈。
+1本以上のゲーム動画全体から、ブログへ掲載しやすい画像を選び出すための文脈。
 
 ## Language
 
 **Input Video**:
-一回の画像選定で扱う1本のゲーム録画。動画のほぼ先頭から末尾までを選定対象にする。
+一回の画像選定へ渡すゲーム録画の1本。各動画のほぼ先頭から末尾までを選定対象にする。
 _Avoid_: screenshot folder, selected clip, representative segment
+
+**Input Videos**:
+一回の画像選定で扱う、順序を持った1本以上のInput Video。重複したpathは含めず、各動画の入力元をSelected Imageまで追跡する。
+_Avoid_: unordered folder scan, concatenated temporary video, duplicate input
 
 **Game Title**:
 Ollamaが画像の意味を判断するときに使うゲーム名。明示されなければ動画名から推測する。
@@ -17,7 +21,7 @@ _Avoid_: title-specific selection rule, paid metadata lookup
 _Avoid_: hard-coded title tuning, required external API lookup
 
 **Sample Position**:
-Input Video全体へ等間隔に置かれた候補抽出時刻。処理量に上限を持ちつつ、動画の四半期など一部だけへ偏らない。
+各Input Video全体へ等間隔に置かれた候補抽出時刻。全動画合計の処理量に上限を持ちつつ、動画の四半期など一部だけへ偏らない。
 _Avoid_: beginning-only sampling, random timestamp
 
 **Frame Candidate**:
@@ -49,11 +53,11 @@ title、map、menu、resultなど、ブログ上は有用でも多すぎると�
 _Avoid_: hard reject, cinematic scene as a whole
 
 **Selected Image**:
-二段階評価を通過し、Transition Frameと近い重複を除きながら、品質・scene・見た目・動画時刻の分散を考慮して選ばれたfull resolution画像。
+二段階評価を通過し、Transition Frameと近い重複を除きながら、品質・入力動画・scene・見た目・動画時刻の分散を考慮して選ばれたfull resolution画像。入力動画と動画内時刻を追跡できる。
 _Avoid_: resized evaluation frame, unreviewed candidate
 
 **Selected Contact Sheet**:
-全Selected Imageを順位と動画時刻付きで一枚にまとめた、人間確認用の`selected-contact-sheet.jpg`。
+全Selected Imageを順位・入力動画・動画時刻付きで一枚にまとめた、人間確認用の`selected-contact-sheet.jpg`。
 _Avoid_: Ollama batch input, machine-only report
 
 **Output Folder**:
@@ -61,7 +65,7 @@ Selected Image、Selected Contact Sheet、reportと再開用作業状態を置�
 _Avoid_: unconditional overwrite target, append-only destination
 
 **Run Manifest**:
-Input Videoの指紋、選定条件、sample位置、model digest、algorithm versionを固定する再開条件。同じmanifestの実行だけがOutput Folderを再利用できる。
+全Input Videosの順序・指紋、選定条件、動画ごとのsample位置、model digest、algorithm versionを固定する再開条件。同じmanifestの実行だけがOutput Folderを再利用できる。
 _Avoid_: progress counter, human approval record
 
 **Assessment Cache**:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game-screen-pick
 
-1本のゲーム動画全体から、ブログへ掲載しやすい画像を指定枚数選定します。
+1本以上のゲーム動画全体から、ブログへ掲載しやすい画像を指定枚数選定します。
 Ollamaのvision modelを二段階で利用し、画面遷移中のフレームや近い重複を
 避けながら、通常進行画面を少し多めに含む多様な画像を出力します。
 
@@ -19,7 +19,7 @@ uv sync
 ## 実行方法
 
 ```bash
-uv run game-screen-pick [オプション] <入力動画> <出力フォルダ>
+uv run game-screen-pick [オプション] <入力動画>... <出力フォルダ>
 ```
 
 標準では30枚を選び、一次評価に`qwen3.8:27b`、二次評価に
@@ -30,13 +30,14 @@ OLLAMA_HOST=192.168.1.31:11434 \
   uv run game-screen-pick \
   --game-title "冒険家エリオットの千年物語" \
   -n 30 \
-  ./recording.mp4 \
-  ./recording-selected
+  ./recording-part-1.mp4 \
+  ./recording-part-2.mp4 \
+  ./recordings-selected
 ```
 
-`--game-title`を省略すると、動画ファイル名から末尾の`Part 7`や`#02`を
-除いた文字列をゲームタイトルとして使います。日付だけのファイル名など、
-推測できない名前では明示してください。
+`--game-title`を省略すると、全動画のファイル名から末尾の`Part 7`や`#02`を
+除いた文字列をゲームタイトルとして使います。推測結果が動画間で一致しない
+場合や、日付だけのファイル名など推測できない名前では明示してください。
 
 ### オプション
 
@@ -73,22 +74,26 @@ recording-selected/
 ```
 
 - `selected-XX.jpg`: ブログ掲載候補のfull resolution画像
-- `selected-contact-sheet.jpg`: 選定画像を順位・動画時刻付きで一覧できる画像
-- `report.json`: 選定時刻、score、scene、model評価を含むmachine-readable report
+- `selected-contact-sheet.jpg`: 選定画像を順位・入力動画・動画時刻付きで一覧できる画像
+- `report.json`: 入力元、選定時刻、score、scene、model評価を含むmachine-readable report
 
 新規実行時の出力フォルダは空である必要があります。途中で中断した場合は、
-同じ動画・選択条件・modelで同じコマンドを再実行してください。抽出済みframeと
+同じ動画一覧・順序・選択条件・modelで同じコマンドを再実行してください。抽出済みframeと
 完了済みOllama batchを再利用します。条件が異なる既存フォルダは上書きせず、
 新しい出力フォルダを要求します。完了済み実行では全成果物のsizeとSHA-256を
 検証し、Ollamaへ接続せずに結果を返します。
 
+候補数は全入力動画の合計で4,000件までです。指定した抽出間隔で上限を超える
+場合は、`--sample-interval-seconds`を広げてください。同じ入力動画を重複して
+指定することはできません。
+
 ## 選定の流れ
 
-1. 動画のほぼ先頭から末尾までを等間隔でsampleする
+1. 各動画のほぼ先頭から末尾までを等間隔でsampleする
 2. 暗転、白飛び、単色frameを機械的に除外する
 3. 品質と時間分散から選択枚数の最大12倍を一次候補にする
 4. 一次modelがブログ掲載価値、遷移、sceneを評価する
-5. 場面・見た目・動画時刻を分散させ、最大3倍を二次候補にする
+5. 入力動画・場面・見た目・動画時刻を分散させ、最大3倍を二次候補にする
 6. 二次modelが各候補の直前・対象・直後を見て再評価する
 7. 遷移frameを除外し、近い重複とtitle/map/menuへの偏りを抑えて選定する
 8. 個別画像、JSON report、一覧contact sheetを出力する

--- a/docs/adr/0005-select-images-across-multiple-videos.md
+++ b/docs/adr/0005-select-images-across-multiple-videos.md
@@ -1,0 +1,7 @@
+# Select Images Across Multiple Videos
+
+Issue #272 extends the Issue #271 pipeline from one input video to an ordered set of one or more videos. The CLI keeps its existing positional shape by treating every path except the last as an input video and the last path as the output folder; a single input remains valid. Each video is sampled across its own full timeline, while the 4,000-frame candidate limit applies to the combined run.
+
+Candidates retain their source video through both Ollama stages and final artifact generation. When enough output slots and valid candidates exist, secondary and final selection cover every source at least once, then balance source, scene, visual, and within-video timeline diversity globally. The report and contact sheet identify the source of every selected image.
+
+Resumability remains a run-level guarantee. The manifest binds the ordered input list, full SHA-256 and metadata for every video, per-video sample positions, model metadata, prompts, and selection settings; changing or reordering any input requires a new output folder.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.6.1"
+version = "1.7.0"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/src/application/run_video.py
+++ b/src/application/run_video.py
@@ -1,19 +1,19 @@
-"""単一動画選定applicationの実行境界."""
+"""動画選定applicationの実行境界."""
 
 import logging
 
 from ..models.video_selection_request import VideoSelectionRequest
-from ..services.single_video_selector import SingleVideoSelector
+from ..services.video_selector import VideoSelector
 
 logger = logging.getLogger(__name__)
 
 
 def run_video_application(request: VideoSelectionRequest) -> None:
-    """単一動画からブログ掲載用画像を選定する."""
+    """1本以上の動画からブログ掲載用画像を選定する."""
     if request.debug:
         logging.getLogger().setLevel(logging.DEBUG)
     try:
-        SingleVideoSelector(request).run()
+        VideoSelector(request).run()
     except KeyboardInterrupt as error:
         logger.info("中断されました。同じコマンドで保存済み進捗から再開できます。")
         raise SystemExit(130) from error

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+from pathlib import Path
 
 import click
 
@@ -149,12 +150,11 @@ def validate_ffmpeg_workers(value: int | str | None) -> int | None:
 )
 @click.option("--debug", is_flag=True, help="デバッグログを有効化")
 @click.argument(
-    "input_video",
-    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=str),
-)
-@click.argument(
-    "output_dir",
-    type=click.Path(file_okay=False, dir_okay=True, path_type=str),
+    "paths",
+    nargs=-1,
+    required=True,
+    type=click.Path(path_type=str),
+    metavar="INPUT_VIDEO... OUTPUT_DIR",
 )
 def execute(
     output_count: int,
@@ -168,13 +168,22 @@ def execute(
     ffmpeg_workers: int,
     sample_interval_seconds: float | None,
     debug: bool,
-    input_video: str,
-    output_dir: str,
+    paths: tuple[str, ...],
 ) -> None:
-    """単一のゲーム動画全体からブログ掲載用画像を選定する."""
+    """1本以上のゲーム動画全体からブログ掲載用画像を選定する."""
+    if len(paths) < 2:
+        raise click.UsageError("入力動画を1本以上と出力フォルダを指定してください")
+    input_videos = paths[:-1]
+    output_dir = paths[-1]
+    for input_video in input_videos:
+        if not Path(input_video).is_file():
+            raise click.BadParameter(
+                f"入力動画が見つかりません: {input_video}",
+                param_hint="INPUT_VIDEOS",
+            )
     run_video_application(
         VideoSelectionRequest(
-            input_video=input_video,
+            input_videos=input_videos,
             output_dir=output_dir,
             output_count=output_count,
             game_title=game_title,

--- a/src/models/video_selection.py
+++ b/src/models/video_selection.py
@@ -1,4 +1,4 @@
-"""単一動画の画像選定で共有する値オブジェクト."""
+"""動画の画像選定で共有する値オブジェクト."""
 
 from dataclasses import dataclass
 
@@ -26,6 +26,8 @@ class FrameCandidate:
     path: str
     quality_score: float = 0.0
     difference_hash: int = 0
+    video_index: int = 0
+    source_label: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/models/video_selection_request.py
+++ b/src/models/video_selection_request.py
@@ -1,12 +1,13 @@
 """1本以上の動画を扱う画像選定リクエスト."""
 
-from dataclasses import InitVar, dataclass
+from dataclasses import dataclass
 
 MAXIMUM_OUTPUT_COUNT = 600
 MINIMUM_SAMPLE_INTERVAL_SECONDS = 0.25
+_MISSING = object()
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class VideoSelectionRequest:
     """CLIから動画の画像選定へ渡すリクエスト."""
 
@@ -22,14 +23,50 @@ class VideoSelectionRequest:
     ffmpeg_workers: int
     sample_interval_seconds: float | None
     debug: bool
-    input_videos: tuple[str, ...] = ()
-    input_video: InitVar[str | None] = None
+    input_videos: tuple[str, ...]
 
-    def __post_init__(self, input_video: str | None) -> None:
-        """旧単一入力constructorを正規化し、1本以上を保証する."""
+    def __init__(
+        self,
+        input_video: str | None = None,
+        output_dir: str | object = _MISSING,
+        output_count: int | object = _MISSING,
+        game_title: str | None | object = _MISSING,
+        game_context: str | object = _MISSING,
+        primary_model: str | object = _MISSING,
+        secondary_model: str | object = _MISSING,
+        ollama_host: str | None | object = _MISSING,
+        ollama_timeout: float | object = _MISSING,
+        allow_cpu: bool | object = _MISSING,
+        ffmpeg_workers: int | object = _MISSING,
+        sample_interval_seconds: float | None | object = _MISSING,
+        debug: bool | object = _MISSING,
+        *,
+        input_videos: tuple[str, ...] = (),
+    ) -> None:
+        """旧位置指定と新しい複数入力keywordを同じrequestへ正規化する."""
+        values = {
+            "output_dir": output_dir,
+            "output_count": output_count,
+            "game_title": game_title,
+            "game_context": game_context,
+            "primary_model": primary_model,
+            "secondary_model": secondary_model,
+            "ollama_host": ollama_host,
+            "ollama_timeout": ollama_timeout,
+            "allow_cpu": allow_cpu,
+            "ffmpeg_workers": ffmpeg_workers,
+            "sample_interval_seconds": sample_interval_seconds,
+            "debug": debug,
+        }
+        missing = [name for name, value in values.items() if value is _MISSING]
+        if missing:
+            raise TypeError(f"必須引数が不足しています: {', '.join(missing)}")
         if input_video is not None:
-            if self.input_videos:
+            if input_videos:
                 raise ValueError("input_videoとinput_videosは同時に指定できません")
-            object.__setattr__(self, "input_videos", (input_video,))
-        if not self.input_videos:
+            input_videos = (input_video,)
+        if not input_videos:
             raise ValueError("入力動画を1本以上指定してください")
+        for name, value in values.items():
+            object.__setattr__(self, name, value)
+        object.__setattr__(self, "input_videos", tuple(input_videos))

--- a/src/models/video_selection_request.py
+++ b/src/models/video_selection_request.py
@@ -62,7 +62,7 @@ class VideoSelectionRequest:
         if missing:
             raise TypeError(f"必須引数が不足しています: {', '.join(missing)}")
         if input_video is not None:
-            if input_videos:
+            if len(input_videos) > 1:
                 raise ValueError("input_videoとinput_videosは同時に指定できません")
             input_videos = (input_video,)
         if not input_videos:

--- a/src/models/video_selection_request.py
+++ b/src/models/video_selection_request.py
@@ -1,6 +1,6 @@
-"""単一動画の画像選定リクエスト."""
+"""1本以上の動画を扱う画像選定リクエスト."""
 
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass
 
 MAXIMUM_OUTPUT_COUNT = 600
 MINIMUM_SAMPLE_INTERVAL_SECONDS = 0.25
@@ -8,9 +8,8 @@ MINIMUM_SAMPLE_INTERVAL_SECONDS = 0.25
 
 @dataclass(frozen=True)
 class VideoSelectionRequest:
-    """CLIから単一動画の画像選定へ渡すリクエスト."""
+    """CLIから動画の画像選定へ渡すリクエスト."""
 
-    input_video: str
     output_dir: str
     output_count: int
     game_title: str | None
@@ -23,3 +22,14 @@ class VideoSelectionRequest:
     ffmpeg_workers: int
     sample_interval_seconds: float | None
     debug: bool
+    input_videos: tuple[str, ...] = ()
+    input_video: InitVar[str | None] = None
+
+    def __post_init__(self, input_video: str | None) -> None:
+        """旧単一入力constructorを正規化し、1本以上を保証する."""
+        if input_video is not None:
+            if self.input_videos:
+                raise ValueError("input_videoとinput_videosは同時に指定できません")
+            object.__setattr__(self, "input_videos", (input_video,))
+        if not self.input_videos:
+            raise ValueError("入力動画を1本以上指定してください")

--- a/src/models/video_selection_request.py
+++ b/src/models/video_selection_request.py
@@ -70,3 +70,10 @@ class VideoSelectionRequest:
         for name, value in values.items():
             object.__setattr__(self, name, value)
         object.__setattr__(self, "input_videos", tuple(input_videos))
+
+    @property
+    def input_video(self) -> str | None:
+        """旧単一入力属性をread-onlyで公開し、複数入力ではNoneを返す."""
+        if len(self.input_videos) != 1:
+            return None
+        return self.input_videos[0]

--- a/src/services/single_video_selector.py
+++ b/src/services/single_video_selector.py
@@ -1,0 +1,5 @@
+"""旧単一動画selector import pathの互換shim."""
+
+from .video_selector import VideoSelector as SingleVideoSelector
+
+__all__ = ["SingleVideoSelector"]

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -1352,6 +1352,14 @@ def make_timestamps(
         last_frame_offset = last_frame_timestamp_seconds - start_time_seconds
         end = min(end, last_frame_offset)
         start = min(start, end)
+        if end - start < required_output_span:
+            required_start = end - required_output_span
+            earliest_start = (
+                0.0
+                if minimum_total_margin >= duration_seconds
+                else min(minimum_start_margin, end)
+            )
+            start = min(end, max(earliest_start, required_start))
     span = end - start
     if requested_interval_seconds is not None:
         interval = requested_interval_seconds

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -516,14 +516,9 @@ class VideoSelector:
 
     def _source_for(self, candidate: FrameCandidate) -> VideoSource:
         """候補が属する入力動画を返す."""
-        if candidate.video_index < 0:
+        if not 0 <= candidate.video_index < len(self.sources):
             raise RuntimeError(f"候補の入力動画IDが不正です: {candidate.frame_id}")
-        try:
-            return self.sources[candidate.video_index]
-        except IndexError as error:
-            raise RuntimeError(
-                f"候補の入力動画IDが不正です: {candidate.frame_id}"
-            ) from error
+        return self.sources[candidate.video_index]
 
     def _preselect_candidates(
         self,
@@ -1249,15 +1244,12 @@ def select_diverse_candidates(
     )
     time_scale = max(60.0, timeline_span / max(1, count))
     while len(selected) < count:
-        unrepresented_sources = source_indexes - set(source_counts)
-        source_pool = (
-            [
-                candidate
-                for candidate in remaining
-                if candidate.video_index in unrepresented_sources
-            ]
-            if len(selected) < min(count, len(source_indexes))
-            else remaining
+        source_pool = _source_balanced_pool(
+            remaining,
+            selected_count=len(selected),
+            requested_count=count,
+            source_indexes=source_indexes,
+            source_counts=source_counts,
         )
 
         def utility(candidate: FrameCandidate) -> tuple[float, float, float]:
@@ -1331,15 +1323,12 @@ def select_final_frames(
     time_scale = max(60.0, timeline_span / max(1, count))
 
     while len(selected) < count:
-        unrepresented_sources = source_indexes - set(source_counts)
-        source_pool = (
-            [
-                candidate
-                for candidate in remaining
-                if candidate.video_index in unrepresented_sources
-            ]
-            if len(selected) < min(count, len(source_indexes))
-            else remaining
+        source_pool = _source_balanced_pool(
+            remaining,
+            selected_count=len(selected),
+            requested_count=count,
+            source_indexes=source_indexes,
+            source_counts=source_counts,
         )
         preferred = [
             candidate
@@ -1413,6 +1402,25 @@ def select_final_frames(
             item.candidate.timestamp_seconds,
         ),
     )
+
+
+def _source_balanced_pool(
+    remaining: list[FrameCandidate],
+    *,
+    selected_count: int,
+    requested_count: int,
+    source_indexes: set[int],
+    source_counts: Counter[int],
+) -> list[FrameCandidate]:
+    """出力枠が許す間は、まだ選ばれていない入力動画の候補を優先する."""
+    if selected_count >= min(requested_count, len(source_indexes)):
+        return remaining
+    unrepresented_sources = source_indexes - set(source_counts)
+    return [
+        candidate
+        for candidate in remaining
+        if candidate.video_index in unrepresented_sources
+    ]
 
 
 def _nearest_distances(

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -10,6 +10,7 @@ import time
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
+from heapq import heapify, heappop, heappush
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -204,20 +205,40 @@ class VideoSelector:
         """入力・モデル・manifestを検証して実行状態を確定する."""
         self._prepare_paths()
         self.game_title = self._resolve_game_title()
-        sources: list[VideoSource] = []
-        for index, video in enumerate(self.videos):
+        probed_sources: list[tuple[Path, VideoMetadata, float]] = []
+        for video in self.videos:
             metadata = self.frame_extractor.probe(video)
             end_margin_seconds = max(
                 MINIMUM_ENDPOINT_MARGIN_SECONDS,
                 frame_interval_seconds(metadata.average_frame_rate),
             )
+            probed_sources.append((video, metadata, end_margin_seconds))
+
+        metadata_items = [item[1] for item in probed_sources]
+        automatic_counts: tuple[int | None, ...]
+        if self.request.sample_interval_seconds is None:
+            minimum_counts = (1,) * len(metadata_items)
+            automatic_counts = allocate_automatic_sample_counts(
+                metadata_items,
+                self.request.output_count,
+            )
+        else:
+            minimum_counts = _allocate_minimum_sample_counts(
+                metadata_items,
+                self.request.output_count,
+            )
+            automatic_counts = (None,) * len(metadata_items)
+
+        sources: list[VideoSource] = []
+        for index, (video, metadata, end_margin_seconds) in enumerate(probed_sources):
             timestamps = make_timestamps(
                 metadata.duration_seconds,
-                self.request.output_count,
+                minimum_counts[index],
                 self.request.sample_interval_seconds,
                 minimum_end_margin_seconds=end_margin_seconds,
                 start_time_seconds=metadata.start_time_seconds,
                 last_frame_timestamp_seconds=metadata.last_frame_timestamp_seconds,
+                automatic_sample_count=automatic_counts[index],
             )
             sources.append(
                 VideoSource(
@@ -543,100 +564,10 @@ class VideoSelector:
                 f"{self.request.output_count}件を下回りました"
             )
 
-        target = min(
-            max(
-                self.request.output_count * PRIMARY_CANDIDATE_MULTIPLIER,
-                len({candidate.video_index for candidate in usable}),
-            ),
-            len(usable),
-        )
-        bin_count = min(60, target)
-        bins: list[list[FrameCandidate]] = [[] for _ in range(bin_count)]
-        offsets: dict[int, float] = {}
-        elapsed = 0.0
-        for source in self.sources:
-            offsets[source.index] = elapsed
-            elapsed += source.metadata.duration_seconds
-        span = max(elapsed, 0.001)
-
-        def bin_index_for(candidate: FrameCandidate) -> int:
-            source = self._source_for(candidate)
-            relative_timestamp = max(
-                0.0,
-                candidate.timestamp_seconds - source.metadata.start_time_seconds,
-            )
-            global_timestamp = offsets[candidate.video_index] + relative_timestamp
-            return min(bin_count - 1, int(global_timestamp / span * bin_count))
-
-        for candidate in usable:
-            bins[bin_index_for(candidate)].append(candidate)
-        for bucket in bins:
-            bucket.sort(key=lambda item: (-item.quality_score, item.timestamp_seconds))
-
-        selected: list[FrameCandidate] = []
-        selected_ids: set[str] = set()
-        selected_by_bin: list[list[FrameCandidate]] = [[] for _ in range(bin_count)]
-        for video_index in sorted({candidate.video_index for candidate in usable}):
-            source_candidates = [
-                candidate
-                for candidate in usable
-                if candidate.video_index == video_index
-            ]
-            chosen = max(
-                source_candidates,
-                key=lambda item: (item.quality_score, -item.timestamp_seconds),
-            )
-            selected.append(chosen)
-            selected_ids.add(chosen.frame_id)
-            selected_by_bin[bin_index_for(chosen)].append(chosen)
-        while len(selected) < target:
-            progressed = False
-            for bin_index, bucket in enumerate(bins):
-                remaining = [
-                    candidate
-                    for candidate in bucket
-                    if candidate.frame_id not in selected_ids
-                ]
-                if not remaining:
-                    continue
-                diverse = next(
-                    (
-                        candidate
-                        for candidate in remaining
-                        if all(
-                            difference_hash_distance(
-                                candidate.difference_hash,
-                                chosen.difference_hash,
-                            )
-                            >= MINIMUM_DISTINCT_DHASH_DISTANCE
-                            for chosen in selected_by_bin[bin_index]
-                        )
-                    ),
-                    None,
-                )
-                chosen = diverse or remaining[0]
-                selected.append(chosen)
-                selected_ids.add(chosen.frame_id)
-                selected_by_bin[bin_index].append(chosen)
-                progressed = True
-                if len(selected) == target:
-                    break
-            if not progressed:
-                break
-
-        if len(selected) < target:
-            remaining = sorted(
-                (
-                    candidate
-                    for candidate in usable
-                    if candidate.frame_id not in selected_ids
-                ),
-                key=lambda item: (-item.quality_score, item.timestamp_seconds),
-            )
-            selected.extend(remaining[: target - len(selected)])
-        result = sorted(
-            selected[:target],
-            key=lambda item: (item.video_index, item.timestamp_seconds),
+        result = select_primary_candidates(
+            usable,
+            [source.metadata for source in self.sources],
+            self.request.output_count,
         )
         write_json_atomic(
             self.work_dir / "primary-candidates.json",
@@ -1026,6 +957,150 @@ def infer_game_title(video: Path) -> str:
     return title
 
 
+def allocate_automatic_sample_counts(
+    metadata_items: Sequence[VideoMetadata],
+    output_count: int,
+) -> tuple[int, ...]:
+    """全入力へ共有する自動sample budgetを動画時間に応じて配分する."""
+    if not metadata_items:
+        raise ValueError("入力動画を1本以上指定してください")
+    if output_count <= 0:
+        raise ValueError("選択枚数は正の整数で指定してください")
+    if len(metadata_items) == 1:
+        metadata = metadata_items[0]
+        return (
+            len(
+                make_timestamps(
+                    metadata.duration_seconds,
+                    output_count,
+                    None,
+                    minimum_end_margin_seconds=max(
+                        MINIMUM_ENDPOINT_MARGIN_SECONDS,
+                        frame_interval_seconds(metadata.average_frame_rate),
+                    ),
+                    start_time_seconds=metadata.start_time_seconds,
+                    last_frame_timestamp_seconds=(
+                        metadata.last_frame_timestamp_seconds
+                    ),
+                )
+            ),
+        )
+    capacities = tuple(_sample_capacity(metadata) for metadata in metadata_items)
+    base_counts = tuple(
+        min(
+            capacity,
+            math.ceil(metadata.duration_seconds / DEFAULT_MAX_SAMPLE_INTERVAL_SECONDS)
+            + 1,
+        )
+        for metadata, capacity in zip(metadata_items, capacities, strict=True)
+    )
+    desired_count = max(
+        output_count * PRIMARY_CANDIDATE_MULTIPLIER * 3,
+        120,
+        sum(base_counts),
+        len(metadata_items),
+    )
+    target_count = min(
+        desired_count,
+        sum(capacities),
+        MAXIMUM_RAW_CANDIDATES,
+    )
+    if target_count < len(metadata_items):
+        raise ValueError("入力動画数が候補数の上限4,000件を超えます")
+    minimum_counts = (
+        base_counts if sum(base_counts) <= target_count else (1,) * len(metadata_items)
+    )
+    return _allocate_sample_counts(
+        capacities,
+        [metadata.duration_seconds for metadata in metadata_items],
+        target_count,
+        minimum_counts,
+    )
+
+
+def _allocate_minimum_sample_counts(
+    metadata_items: Sequence[VideoMetadata],
+    output_count: int,
+) -> tuple[int, ...]:
+    """明示interval用の最小sample数を全入力へ配分する."""
+    capacities = tuple(_sample_capacity(metadata) for metadata in metadata_items)
+    target_count = min(
+        sum(capacities),
+        max(output_count, len(metadata_items)),
+    )
+    return _allocate_sample_counts(
+        capacities,
+        [metadata.duration_seconds for metadata in metadata_items],
+        target_count,
+        (1,) * len(metadata_items),
+    )
+
+
+def _allocate_sample_counts(
+    capacities: Sequence[int],
+    weights: Sequence[float],
+    target_count: int,
+    minimum_counts: Sequence[int],
+) -> tuple[int, ...]:
+    """上限と最小値を守り、重み付きで整数sample数を配分する."""
+    if not (len(capacities) == len(weights) == len(minimum_counts) and capacities):
+        raise ValueError("sample配分条件が不正です")
+    counts = list(minimum_counts)
+    if any(
+        minimum < 0 or minimum > capacity
+        for minimum, capacity in zip(counts, capacities, strict=True)
+    ):
+        raise ValueError("sample配分の最小値が上限を超えています")
+    remaining = target_count - sum(counts)
+    if remaining < 0 or target_count > sum(capacities):
+        raise ValueError("sample配分数が不正です")
+
+    heap = [
+        (-max(weight, 0.001) / (counts[index] + 1), index)
+        for index, (weight, capacity) in enumerate(
+            zip(weights, capacities, strict=True)
+        )
+        if counts[index] < capacity
+    ]
+    heapify(heap)
+    while remaining:
+        if not heap:
+            raise ValueError("sample配分数が入力動画の上限を超えています")
+        _, index = heappop(heap)
+        counts[index] += 1
+        remaining -= 1
+        if counts[index] < capacities[index]:
+            priority = -max(weights[index], 0.001) / (counts[index] + 1)
+            heappush(heap, (priority, index))
+    return tuple(counts)
+
+
+def _sample_capacity(metadata: VideoMetadata) -> int:
+    """入力動画へ0.25秒間隔で配置できる最大sample数を返す."""
+    end_margin = max(
+        MINIMUM_ENDPOINT_MARGIN_SECONDS,
+        frame_interval_seconds(metadata.average_frame_rate),
+    )
+    minimum_total_margin = MINIMUM_ENDPOINT_MARGIN_SECONDS + end_margin
+    if minimum_total_margin >= metadata.duration_seconds:
+        relative_start = 0.0
+        relative_end = max(0.0, metadata.duration_seconds - end_margin)
+    else:
+        relative_start = MINIMUM_ENDPOINT_MARGIN_SECONDS
+        relative_end = metadata.duration_seconds - end_margin
+    if metadata.last_frame_timestamp_seconds is not None:
+        relative_end = min(
+            relative_end,
+            metadata.last_frame_timestamp_seconds - metadata.start_time_seconds,
+        )
+    span = max(0.0, relative_end - relative_start)
+    return min(
+        MAXIMUM_RAW_CANDIDATES,
+        math.floor(span / MINIMUM_SAMPLE_INTERVAL_SECONDS + INTERVAL_COUNT_TOLERANCE)
+        + 1,
+    )
+
+
 def make_timestamps(
     duration_seconds: float,
     output_count: int,
@@ -1034,8 +1109,14 @@ def make_timestamps(
     minimum_end_margin_seconds: float = MINIMUM_ENDPOINT_MARGIN_SECONDS,
     start_time_seconds: float = 0.0,
     last_frame_timestamp_seconds: float | None = None,
+    automatic_sample_count: int | None = None,
 ) -> tuple[float, ...]:
     """動画のほぼ先頭から末尾までを等間隔で覆う時刻列を返す."""
+    if automatic_sample_count is not None:
+        if automatic_sample_count <= 0:
+            raise ValueError("自動sample数は正の整数で指定してください")
+        if requested_interval_seconds is not None:
+            raise ValueError("明示intervalと自動sample数は同時に指定できません")
     if requested_interval_seconds is not None:
         if (
             not math.isfinite(requested_interval_seconds)
@@ -1065,7 +1146,8 @@ def make_timestamps(
     )
     default_start_margin = min(0.5, duration_seconds / 4.0)
     default_end_margin = max(default_start_margin, minimum_end_margin)
-    required_output_span = max(0, output_count - 1) * MINIMUM_SAMPLE_INTERVAL_SECONDS
+    required_count = automatic_sample_count or output_count
+    required_output_span = max(0, required_count - 1) * MINIMUM_SAMPLE_INTERVAL_SECONDS
     available_margin = max(0.0, duration_seconds - required_output_span)
     minimum_total_margin = minimum_start_margin + minimum_end_margin
     default_total_margin = default_start_margin + default_end_margin
@@ -1099,7 +1181,7 @@ def make_timestamps(
         )
         if sample_count > MAXIMUM_RAW_CANDIDATES:
             raise ValueError("指定したsample intervalでは候補数が上限4,000件を超えます")
-    else:
+    elif automatic_sample_count is None:
         base_count = (
             math.ceil(duration_seconds / DEFAULT_MAX_SAMPLE_INTERVAL_SECONDS) + 1
         )
@@ -1108,6 +1190,8 @@ def make_timestamps(
             120,
         )
         sample_count = max(base_count, desired_count)
+    else:
+        sample_count = automatic_sample_count
     maximum_by_interval = (
         math.floor(span / MINIMUM_SAMPLE_INTERVAL_SECONDS + INTERVAL_COUNT_TOLERANCE)
         + 1
@@ -1217,6 +1301,171 @@ def candidate_to_json(candidate: FrameCandidate) -> dict[str, Any]:
     payload = asdict(candidate)
     payload["difference_hash"] = f"{candidate.difference_hash:016x}"
     return payload
+
+
+def select_primary_candidates(
+    candidates: Sequence[FrameCandidate],
+    metadata_items: Sequence[VideoMetadata],
+    output_count: int,
+) -> list[FrameCandidate]:
+    """品質、入力元、全体時刻を分散した一次評価候補を選ぶ."""
+    if output_count <= 0:
+        raise ValueError("選択枚数は正の整数で指定してください")
+    if not candidates:
+        return []
+    if any(
+        not 0 <= candidate.video_index < len(metadata_items) for candidate in candidates
+    ):
+        raise ValueError("候補の入力動画IDが不正です")
+
+    target = min(
+        output_count * PRIMARY_CANDIDATE_MULTIPLIER,
+        len(candidates),
+    )
+    bin_count = min(60, target)
+    offsets: list[float] = []
+    elapsed = 0.0
+    for metadata in metadata_items:
+        offsets.append(elapsed)
+        elapsed += metadata.duration_seconds
+    span = max(elapsed, 0.001)
+
+    def bin_index_for(candidate: FrameCandidate) -> int:
+        metadata = metadata_items[candidate.video_index]
+        relative_timestamp = max(
+            0.0,
+            candidate.timestamp_seconds - metadata.start_time_seconds,
+        )
+        global_timestamp = offsets[candidate.video_index] + relative_timestamp
+        return min(bin_count - 1, int(global_timestamp / span * bin_count))
+
+    bins: list[list[FrameCandidate]] = [[] for _ in range(bin_count)]
+    candidates_by_source: dict[int, list[FrameCandidate]] = {}
+    for candidate in candidates:
+        bins[bin_index_for(candidate)].append(candidate)
+        candidates_by_source.setdefault(candidate.video_index, []).append(candidate)
+    for bucket in bins:
+        bucket.sort(key=_primary_candidate_order)
+    for source_candidates in candidates_by_source.values():
+        source_candidates.sort(key=_primary_candidate_order)
+
+    ranked_sources = sorted(
+        candidates_by_source,
+        key=lambda video_index: (
+            -candidates_by_source[video_index][0].quality_score,
+            video_index,
+        ),
+    )
+    represented_sources = ranked_sources[:target]
+    representatives_per_source = (
+        SECONDARY_CANDIDATE_MULTIPLIER
+        if len(candidates_by_source) <= output_count
+        else 1
+    )
+    selected: list[FrameCandidate] = []
+    selected_ids: set[str] = set()
+    selected_by_bin: list[list[FrameCandidate]] = [[] for _ in range(bin_count)]
+    selected_by_source: dict[int, list[FrameCandidate]] = {
+        video_index: [] for video_index in represented_sources
+    }
+    for _ in range(representatives_per_source):
+        for video_index in represented_sources:
+            if len(selected) == target:
+                break
+            chosen = _next_source_representative(
+                candidates_by_source[video_index],
+                selected_by_source[video_index],
+            )
+            if chosen is None:
+                continue
+            selected.append(chosen)
+            selected_ids.add(chosen.frame_id)
+            selected_by_source[video_index].append(chosen)
+            selected_by_bin[bin_index_for(chosen)].append(chosen)
+
+    while len(selected) < target:
+        progressed = False
+        for bin_index, bucket in enumerate(bins):
+            remaining = [
+                candidate
+                for candidate in bucket
+                if candidate.frame_id not in selected_ids
+            ]
+            if not remaining:
+                continue
+            diverse = next(
+                (
+                    candidate
+                    for candidate in remaining
+                    if all(
+                        difference_hash_distance(
+                            candidate.difference_hash,
+                            chosen.difference_hash,
+                        )
+                        >= MINIMUM_DISTINCT_DHASH_DISTANCE
+                        for chosen in selected_by_bin[bin_index]
+                    )
+                ),
+                None,
+            )
+            chosen = diverse or remaining[0]
+            selected.append(chosen)
+            selected_ids.add(chosen.frame_id)
+            selected_by_bin[bin_index].append(chosen)
+            progressed = True
+            if len(selected) == target:
+                break
+        if not progressed:
+            break
+
+    if len(selected) < target:
+        remaining = sorted(
+            (
+                candidate
+                for candidate in candidates
+                if candidate.frame_id not in selected_ids
+            ),
+            key=_primary_candidate_order,
+        )
+        selected.extend(remaining[: target - len(selected)])
+    return sorted(
+        selected[:target],
+        key=lambda item: (item.video_index, item.timestamp_seconds, item.frame_id),
+    )
+
+
+def _primary_candidate_order(candidate: FrameCandidate) -> tuple[float, float, str]:
+    """一次候補の品質順を安定して比較するkeyを返す."""
+    return (-candidate.quality_score, candidate.timestamp_seconds, candidate.frame_id)
+
+
+def _next_source_representative(
+    candidates: Sequence[FrameCandidate],
+    selected: Sequence[FrameCandidate],
+) -> FrameCandidate | None:
+    """同じ入力元から、既選択候補と見た目が異なる次候補を返す."""
+    selected_ids = {candidate.frame_id for candidate in selected}
+    remaining = [
+        candidate for candidate in candidates if candidate.frame_id not in selected_ids
+    ]
+    if not remaining:
+        return None
+    diverse = next(
+        (
+            candidate
+            for candidate in remaining
+            if all(
+                difference_hash_distance(
+                    candidate.difference_hash,
+                    chosen.difference_hash,
+                )
+                >= MINIMUM_DISTINCT_DHASH_DISTANCE
+                for chosen in selected
+            )
+        ),
+        None,
+    )
+    return diverse or remaining[0]
 
 
 def select_diverse_candidates(

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -12,7 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
 from heapq import heapify, heappop, heappush
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 import cv2
 import numpy as np
@@ -51,7 +51,7 @@ from .video_frame_extractor import VideoFrameExtractor
 
 logger = logging.getLogger(__name__)
 
-ALGORITHM_VERSION = "multi-video-selection-v4"
+ALGORITHM_VERSION = "multi-video-selection-v5"
 PROMPT_VERSION = "blog-image-selection-v3"
 DEFAULT_MAX_SAMPLE_INTERVAL_SECONDS = 10.0
 MINIMUM_ENDPOINT_MARGIN_SECONDS = 0.05
@@ -149,11 +149,12 @@ class VideoSelector:
             primary_assessments,
             secondary_count,
         )
-        secondary_candidates, secondary_assessments = self._assess_with_source_backfill(
-            primary_eligible,
-            secondary_candidates,
-            model=self.request.secondary_model,
-            stage="secondary",
+        secondary_candidates, secondary_assessments = (
+            self._assess_secondary_with_primary_backfill(
+                primary_candidates,
+                primary_assessments,
+                secondary_candidates,
+            )
         )
         selected = select_final_frames(
             secondary_candidates,
@@ -578,6 +579,11 @@ class VideoSelector:
         *,
         model: str,
         stage: str,
+        expand_candidate_pool: Callable[
+            [Sequence[FrameCandidate], dict[str, FrameAssessment]],
+            Sequence[FrameCandidate],
+        ]
+        | None = None,
     ) -> tuple[list[FrameCandidate], dict[str, FrameAssessment]]:
         """候補を評価し、未代表の入力元から同じstageの候補を追補する."""
         if stage not in {"primary", "secondary"}:
@@ -585,6 +591,7 @@ class VideoSelector:
         primary_stage = _is_primary_stage(stage)
         stage_label = "一次" if primary_stage else "二次"
         candidates_path = self.work_dir / f"{stage}-candidates.json"
+        pool = list(candidate_pool)
         candidates = list(initial_candidates)
         write_json_atomic(
             candidates_path,
@@ -615,12 +622,27 @@ class VideoSelector:
             if not uncovered_sources and survivor_count >= self.request.output_count:
                 break
             backfill = select_source_backfill_candidates(
-                candidate_pool,
+                pool,
                 candidates,
                 assessments,
                 source_count=len(self.sources),
                 output_count=self.request.output_count,
             )
+            if not backfill and expand_candidate_pool is not None:
+                additions = expand_candidate_pool(candidates, assessments)
+                pool_ids = {candidate.frame_id for candidate in pool}
+                pool.extend(
+                    candidate
+                    for candidate in additions
+                    if candidate.frame_id not in pool_ids
+                )
+                backfill = select_source_backfill_candidates(
+                    pool,
+                    candidates,
+                    assessments,
+                    source_count=len(self.sources),
+                    output_count=self.request.output_count,
+                )
             if not backfill:
                 labels = ", ".join(
                     self.sources[index].label for index in uncovered_sources
@@ -661,6 +683,75 @@ class VideoSelector:
                 len(backfill),
             )
         return candidates, assessments
+
+    def _assess_secondary_with_primary_backfill(
+        self,
+        primary_candidates: list[FrameCandidate],
+        primary_assessments: dict[str, FrameAssessment],
+        initial_candidates: Sequence[FrameCandidate],
+    ) -> tuple[list[FrameCandidate], dict[str, FrameAssessment]]:
+        """二次候補が尽きた場合は未評価候補を一次評価から補充する."""
+        primary_backfill_round = 0
+
+        def expand_primary_pool(
+            secondary_candidates: Sequence[FrameCandidate],
+            secondary_assessments: dict[str, FrameAssessment],
+        ) -> Sequence[FrameCandidate]:
+            nonlocal primary_backfill_round
+            source_order, target_count = _source_backfill_requirements(
+                secondary_candidates,
+                secondary_assessments,
+                source_count=len(self.sources),
+                output_count=self.request.output_count,
+            )
+            while True:
+                new_candidates = _select_unassessed_source_candidates(
+                    self._usable_candidates,
+                    primary_candidates,
+                    source_order,
+                    target_count,
+                )
+                if not new_candidates:
+                    return ()
+                primary_backfill_round += 1
+                new_assessments = self._assess_candidates(
+                    model=self.request.primary_model,
+                    stage=f"primary-secondary-backfill-{primary_backfill_round:04d}",
+                    candidates=new_candidates,
+                )
+                primary_candidates.extend(new_candidates)
+                primary_candidates.sort(
+                    key=lambda item: (
+                        item.video_index,
+                        item.timestamp_seconds,
+                        item.frame_id,
+                    )
+                )
+                primary_assessments.update(new_assessments)
+                write_json_atomic(
+                    self.work_dir / "primary-candidates.json",
+                    [candidate_to_json(candidate) for candidate in primary_candidates],
+                )
+                eligible = [
+                    candidate
+                    for candidate in new_candidates
+                    if not new_assessments[candidate.frame_id].is_transition
+                ]
+                if eligible:
+                    return eligible
+
+        primary_eligible = [
+            candidate
+            for candidate in primary_candidates
+            if not primary_assessments[candidate.frame_id].is_transition
+        ]
+        return self._assess_with_source_backfill(
+            primary_eligible,
+            initial_candidates,
+            model=self.request.secondary_model,
+            stage="secondary",
+            expand_candidate_pool=expand_primary_pool,
+        )
 
     def _extract_context_frames(
         self,
@@ -1394,7 +1485,7 @@ def candidate_to_json(candidate: FrameCandidate) -> dict[str, Any]:
 
 def _is_primary_stage(stage: str) -> bool:
     """一次評価と、その追補評価のstage名を判定する."""
-    return stage == "primary" or stage.startswith("primary-backfill-")
+    return stage == "primary" or stage.startswith("primary-")
 
 
 def select_primary_candidates(
@@ -1537,6 +1628,28 @@ def select_source_backfill_candidates(
     output_count: int,
 ) -> list[FrameCandidate]:
     """入力元の欠落または生存候補の不足を未評価候補で追補する."""
+    source_order, target_count = _source_backfill_requirements(
+        assessed_candidates,
+        assessments,
+        source_count=source_count,
+        output_count=output_count,
+    )
+    return _select_unassessed_source_candidates(
+        all_candidates,
+        assessed_candidates,
+        source_order,
+        target_count,
+    )
+
+
+def _source_backfill_requirements(
+    assessed_candidates: Sequence[FrameCandidate],
+    assessments: dict[str, FrameAssessment],
+    *,
+    source_count: int,
+    output_count: int,
+) -> tuple[tuple[int, ...], int]:
+    """追補対象の入力元順と、一度に評価する候補数を返す."""
     if source_count <= 0 or output_count <= 0:
         raise ValueError("入力動画数と選択枚数は正の整数で指定してください")
     survivor_counts = Counter(
@@ -1556,8 +1669,31 @@ def select_source_backfill_candidates(
     )
     shortfall = max(0, output_count - survivor_count)
     if not uncovered_sources and not shortfall:
-        return []
+        return (), 0
+    if uncovered_sources:
+        return (
+            uncovered_sources,
+            len(uncovered_sources) * SECONDARY_CANDIDATE_MULTIPLIER,
+        )
+    source_order = tuple(
+        sorted(
+            range(source_count),
+            key=lambda video_index: (
+                survivor_counts[video_index],
+                video_index,
+            ),
+        )
+    )
+    return source_order, shortfall * SECONDARY_CANDIDATE_MULTIPLIER
 
+
+def _select_unassessed_source_candidates(
+    all_candidates: Sequence[FrameCandidate],
+    assessed_candidates: Sequence[FrameCandidate],
+    source_order: Sequence[int],
+    target_count: int,
+) -> list[FrameCandidate]:
+    """指定した入力元順で未評価候補を見た目も分散して選ぶ."""
     assessed_ids = {candidate.frame_id for candidate in assessed_candidates}
     assessed_by_source: dict[int, list[FrameCandidate]] = {}
     available_by_source: dict[int, list[FrameCandidate]] = {}
@@ -1569,20 +1705,6 @@ def select_source_backfill_candidates(
     for candidates in available_by_source.values():
         candidates.sort(key=_primary_candidate_order)
 
-    if uncovered_sources:
-        source_order = uncovered_sources
-        target_count = len(uncovered_sources) * SECONDARY_CANDIDATE_MULTIPLIER
-    else:
-        source_order = tuple(
-            sorted(
-                available_by_source,
-                key=lambda video_index: (
-                    survivor_counts[video_index],
-                    video_index,
-                ),
-            )
-        )
-        target_count = shortfall * SECONDARY_CANDIDATE_MULTIPLIER
     selected_by_source: dict[int, list[FrameCandidate]] = {
         video_index: [] for video_index in source_order
     }

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -1,4 +1,4 @@
-"""単一動画全体からブログ掲載用画像を選ぶproduction pipeline."""
+"""1本以上の動画全体からブログ掲載用画像を選ぶproduction pipeline."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ import re
 import time
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -50,7 +50,7 @@ from .video_frame_extractor import VideoFrameExtractor
 
 logger = logging.getLogger(__name__)
 
-ALGORITHM_VERSION = "single-video-selection-v1"
+ALGORITHM_VERSION = "multi-video-selection-v1"
 PROMPT_VERSION = "blog-image-selection-v3"
 DEFAULT_MAX_SAMPLE_INTERVAL_SECONDS = 10.0
 MINIMUM_ENDPOINT_MARGIN_SECONDS = 0.05
@@ -65,7 +65,23 @@ MAXIMUM_OUTPUT_DHASH_DISTANCE = 10
 MINIMUM_DISTINCT_DHASH_DISTANCE = 5
 
 
-class SingleVideoSelector:
+@dataclass(frozen=True)
+class VideoSource:
+    """一つの入力動画と、その動画に固有の抽出条件."""
+
+    index: int
+    path: Path
+    metadata: VideoMetadata
+    end_margin_seconds: float
+    timestamps: tuple[float, ...]
+
+    @property
+    def label(self) -> str:
+        """コンタクトシートで入力元を識別する短い表示名を返す."""
+        return f"v{self.index + 1:02d} {self.path.name}"
+
+
+class VideoSelector:
     """フレーム抽出、Ollama評価、選定、成果物生成を順に実行する."""
 
     def __init__(
@@ -80,13 +96,12 @@ class SingleVideoSelector:
         self.frame_extractor = frame_extractor or VideoFrameExtractor()
         self._provided_assessor = assessor
         self.assessor: OllamaFrameAssessor | None = None
-        self.video = Path()
+        self.videos: tuple[Path, ...] = ()
+        self.sources: tuple[VideoSource, ...] = ()
         self.output_dir = Path()
         self.work_dir = Path()
         self.game_title = ""
-        self.metadata = VideoMetadata(0, 0, 0, "", "")
-        self.end_margin_seconds = MINIMUM_ENDPOINT_MARGIN_SECONDS
-        self.timestamps: tuple[float, ...] = ()
+        self.total_duration_seconds = 0.0
         self.model_metadata: dict[str, dict[str, Any]] = {}
         self._live_validated_models: set[str] = set()
         self.manifest_digest = ""
@@ -170,9 +185,17 @@ class SingleVideoSelector:
                 "指定してください"
             )
 
-        self.video = Path(self.request.input_video).expanduser().resolve()
-        if not self.video.is_file():
-            raise FileNotFoundError(f"入力動画が見つかりません: {self.video}")
+        self.videos = tuple(
+            Path(input_video).expanduser().resolve()
+            for input_video in self.request.input_videos
+        )
+        if not self.videos:
+            raise ValueError("入力動画を1本以上指定してください")
+        if len(set(self.videos)) != len(self.videos):
+            raise ValueError("同じ入力動画を重複して指定できません")
+        for video in self.videos:
+            if not video.is_file():
+                raise FileNotFoundError(f"入力動画が見つかりません: {video}")
         self.output_dir = Path(self.request.output_dir).expanduser().resolve()
         self.work_dir = self.output_dir / ".game-screen-pick"
         self._preflight_output_dir()
@@ -180,29 +203,46 @@ class SingleVideoSelector:
     def _prepare_run(self) -> None:
         """入力・モデル・manifestを検証して実行状態を確定する."""
         self._prepare_paths()
-        self.game_title = (
-            self.request.game_title.strip()
-            if self.request.game_title and self.request.game_title.strip()
-            else infer_game_title(self.video)
-        )
-        self.metadata = self.frame_extractor.probe(self.video)
-        self.end_margin_seconds = max(
-            MINIMUM_ENDPOINT_MARGIN_SECONDS,
-            frame_interval_seconds(self.metadata.average_frame_rate),
-        )
-        self.timestamps = make_timestamps(
-            self.metadata.duration_seconds,
-            self.request.output_count,
-            self.request.sample_interval_seconds,
-            minimum_end_margin_seconds=self.end_margin_seconds,
-            start_time_seconds=self.metadata.start_time_seconds,
-            last_frame_timestamp_seconds=(self.metadata.last_frame_timestamp_seconds),
-        )
-        if len(self.timestamps) < self.request.output_count:
+        self.game_title = self._resolve_game_title()
+        sources: list[VideoSource] = []
+        for index, video in enumerate(self.videos):
+            metadata = self.frame_extractor.probe(video)
+            end_margin_seconds = max(
+                MINIMUM_ENDPOINT_MARGIN_SECONDS,
+                frame_interval_seconds(metadata.average_frame_rate),
+            )
+            timestamps = make_timestamps(
+                metadata.duration_seconds,
+                self.request.output_count,
+                self.request.sample_interval_seconds,
+                minimum_end_margin_seconds=end_margin_seconds,
+                start_time_seconds=metadata.start_time_seconds,
+                last_frame_timestamp_seconds=metadata.last_frame_timestamp_seconds,
+            )
+            sources.append(
+                VideoSource(
+                    index=index,
+                    path=video,
+                    metadata=metadata,
+                    end_margin_seconds=end_margin_seconds,
+                    timestamps=timestamps,
+                )
+            )
+        self.sources = tuple(sources)
+        sample_count = sum(len(source.timestamps) for source in self.sources)
+        if sample_count > MAXIMUM_RAW_CANDIDATES:
             raise ValueError(
-                f"抽出可能な候補{len(self.timestamps)}件が"
+                "全入力動画の候補数が上限4,000件を超えます。"
+                "sample intervalを広げてください"
+            )
+        if sample_count < self.request.output_count:
+            raise ValueError(
+                f"抽出可能な候補{sample_count}件が"
                 f"選択枚数{self.request.output_count}件を下回ります"
             )
+        self.total_duration_seconds = sum(
+            source.metadata.duration_seconds for source in self.sources
+        )
         has_existing_manifest = self._restore_existing_manifest()
         if has_existing_manifest and (self.work_dir / "completion.json").is_file():
             return
@@ -225,6 +265,18 @@ class SingleVideoSelector:
         self.manifest_digest = json_digest(manifest)
         manifest["manifest_digest"] = self.manifest_digest
         self._prepare_output_dir(manifest)
+
+    def _resolve_game_title(self) -> str:
+        """明示タイトル、または全入力から一致して推測したタイトルを返す."""
+        if self.request.game_title and self.request.game_title.strip():
+            return self.request.game_title.strip()
+        inferred = [infer_game_title(video) for video in self.videos]
+        if len(set(inferred)) != 1:
+            raise ValueError(
+                "複数の動画ファイル名から同じゲームタイトルを推測できません。"
+                "--game-titleを指定してください"
+            )
+        return inferred[0]
 
     def _preflight_output_dir(self) -> None:
         """再開不能なoutputを外部処理より前に拒否する."""
@@ -310,30 +362,13 @@ class SingleVideoSelector:
 
     def _build_manifest(self) -> dict[str, Any]:
         """結果に影響する入力だけを含む再開manifestを作る."""
-        stat = self.video.stat()
         return {
             "algorithm_version": ALGORITHM_VERSION,
             "prompt_version": PROMPT_VERSION,
-            "input": {
-                "path": str(self.video),
-                "size": stat.st_size,
-                "mtime_ns": stat.st_mtime_ns,
-                "sha256": file_sha256(self.video),
-                "duration_seconds": self.metadata.duration_seconds,
-                "width": self.metadata.width,
-                "height": self.metadata.height,
-                "codec_name": self.metadata.codec_name,
-                "average_frame_rate": self.metadata.average_frame_rate,
-                "video_stream_index": self.metadata.video_stream_index,
-                "start_time_seconds": self.metadata.start_time_seconds,
-                "last_frame_timestamp_seconds": (
-                    self.metadata.last_frame_timestamp_seconds
-                ),
-            },
+            "inputs": [self._input_manifest(source) for source in self.sources],
             "game_title": self.game_title,
             "game_context": self.request.game_context.strip(),
             "output_count": self.request.output_count,
-            "timestamps": list(self.timestamps),
             "models": {
                 "primary": {
                     "name": self.request.primary_model,
@@ -353,9 +388,30 @@ class SingleVideoSelector:
                 "secondary": SECONDARY_BATCH_SIZE,
             },
             "context_offset_seconds": CONTEXT_OFFSET_SECONDS,
-            "end_margin_seconds": self.end_margin_seconds,
             "model_options": MODEL_OPTIONS,
             "require_gpu": not self.request.allow_cpu,
+        }
+
+    def _input_manifest(self, source: VideoSource) -> dict[str, Any]:
+        """入力動画一つ分の再開条件を返す."""
+        stat = source.path.stat()
+        metadata = source.metadata
+        return {
+            "video_index": source.index + 1,
+            "path": str(source.path),
+            "size": stat.st_size,
+            "mtime_ns": stat.st_mtime_ns,
+            "sha256": file_sha256(source.path),
+            "duration_seconds": metadata.duration_seconds,
+            "width": metadata.width,
+            "height": metadata.height,
+            "codec_name": metadata.codec_name,
+            "average_frame_rate": metadata.average_frame_rate,
+            "video_stream_index": metadata.video_stream_index,
+            "start_time_seconds": metadata.start_time_seconds,
+            "last_frame_timestamp_seconds": metadata.last_frame_timestamp_seconds,
+            "end_margin_seconds": source.end_margin_seconds,
+            "timestamps": list(source.timestamps),
         }
 
     def _prepare_output_dir(self, manifest: dict[str, Any]) -> None:
@@ -403,16 +459,24 @@ class SingleVideoSelector:
         return True
 
     def _extract_candidates(self) -> list[FrameCandidate]:
-        """動画全体の等間隔位置から縮小候補フレームを抽出する."""
+        """全入力動画の等間隔位置から縮小候補フレームを抽出する."""
         candidate_dir = self.work_dir / "candidate-frames"
-        candidates = [
-            FrameCandidate(
-                frame_id=f"f{index:05d}",
-                timestamp_seconds=timestamp,
-                path=str(candidate_dir / f"f{index:05d}.jpg"),
-            )
-            for index, timestamp in enumerate(self.timestamps, start=1)
-        ]
+        candidates: list[FrameCandidate] = []
+        frame_number = 1
+        for source in self.sources:
+            source_dir = candidate_dir / f"v{source.index + 1:02d}"
+            for timestamp in source.timestamps:
+                frame_id = f"f{frame_number:05d}"
+                candidates.append(
+                    FrameCandidate(
+                        frame_id=frame_id,
+                        timestamp_seconds=timestamp,
+                        path=str(source_dir / f"{frame_id}.jpg"),
+                        video_index=source.index,
+                        source_label=source.label,
+                    )
+                )
+                frame_number += 1
         pending = [
             candidate
             for candidate in candidates
@@ -441,13 +505,25 @@ class SingleVideoSelector:
 
     def _extract_candidate(self, candidate: FrameCandidate) -> None:
         """候補フレームを一枚抽出する."""
+        source = self._source_for(candidate)
         self.frame_extractor.extract_frame(
-            self.video,
+            source.path,
             candidate.timestamp_seconds,
             Path(candidate.path),
             max_width=960,
-            video_stream_index=self.metadata.video_stream_index,
+            video_stream_index=source.metadata.video_stream_index,
         )
+
+    def _source_for(self, candidate: FrameCandidate) -> VideoSource:
+        """候補が属する入力動画を返す."""
+        if candidate.video_index < 0:
+            raise RuntimeError(f"候補の入力動画IDが不正です: {candidate.frame_id}")
+        try:
+            return self.sources[candidate.video_index]
+        except IndexError as error:
+            raise RuntimeError(
+                f"候補の入力動画IDが不正です: {candidate.frame_id}"
+            ) from error
 
     def _preselect_candidates(
         self,
@@ -473,28 +549,51 @@ class SingleVideoSelector:
             )
 
         target = min(
-            self.request.output_count * PRIMARY_CANDIDATE_MULTIPLIER,
+            max(
+                self.request.output_count * PRIMARY_CANDIDATE_MULTIPLIER,
+                len({candidate.video_index for candidate in usable}),
+            ),
             len(usable),
         )
         bin_count = min(60, target)
         bins: list[list[FrameCandidate]] = [[] for _ in range(bin_count)]
-        span = max(self.metadata.duration_seconds, 0.001)
-        for candidate in usable:
+        offsets: dict[int, float] = {}
+        elapsed = 0.0
+        for source in self.sources:
+            offsets[source.index] = elapsed
+            elapsed += source.metadata.duration_seconds
+        span = max(elapsed, 0.001)
+
+        def bin_index_for(candidate: FrameCandidate) -> int:
+            source = self._source_for(candidate)
             relative_timestamp = max(
                 0.0,
-                candidate.timestamp_seconds - self.metadata.start_time_seconds,
+                candidate.timestamp_seconds - source.metadata.start_time_seconds,
             )
-            bin_index = min(
-                bin_count - 1,
-                int(relative_timestamp / span * bin_count),
-            )
-            bins[bin_index].append(candidate)
+            global_timestamp = offsets[candidate.video_index] + relative_timestamp
+            return min(bin_count - 1, int(global_timestamp / span * bin_count))
+
+        for candidate in usable:
+            bins[bin_index_for(candidate)].append(candidate)
         for bucket in bins:
             bucket.sort(key=lambda item: (-item.quality_score, item.timestamp_seconds))
 
         selected: list[FrameCandidate] = []
         selected_ids: set[str] = set()
         selected_by_bin: list[list[FrameCandidate]] = [[] for _ in range(bin_count)]
+        for video_index in sorted({candidate.video_index for candidate in usable}):
+            source_candidates = [
+                candidate
+                for candidate in usable
+                if candidate.video_index == video_index
+            ]
+            chosen = max(
+                source_candidates,
+                key=lambda item: (item.quality_score, -item.timestamp_seconds),
+            )
+            selected.append(chosen)
+            selected_ids.add(chosen.frame_id)
+            selected_by_bin[bin_index_for(chosen)].append(chosen)
         while len(selected) < target:
             progressed = False
             for bin_index, bucket in enumerate(bins):
@@ -540,7 +639,10 @@ class SingleVideoSelector:
                 key=lambda item: (-item.quality_score, item.timestamp_seconds),
             )
             selected.extend(remaining[: target - len(selected)])
-        result = sorted(selected[:target], key=lambda item: item.timestamp_seconds)
+        result = sorted(
+            selected[:target],
+            key=lambda item: (item.video_index, item.timestamp_seconds),
+        )
         write_json_atomic(
             self.work_dir / "primary-candidates.json",
             [candidate_to_json(candidate) for candidate in result],
@@ -555,15 +657,16 @@ class SingleVideoSelector:
         """二次評価候補の直前・直後フレームを抽出する."""
         context_dir = self.work_dir / "context-frames"
         jobs: list[tuple[FrameCandidate, str, float]] = []
-        stream_start = self.metadata.start_time_seconds
-        stream_end = stream_start + self.metadata.duration_seconds
-        context_end = stream_end - self.end_margin_seconds
-        if self.metadata.last_frame_timestamp_seconds is not None:
-            context_end = min(
-                context_end,
-                self.metadata.last_frame_timestamp_seconds,
-            )
         for candidate in candidates:
+            source = self._source_for(candidate)
+            stream_start = source.metadata.start_time_seconds
+            stream_end = stream_start + source.metadata.duration_seconds
+            context_end = stream_end - source.end_margin_seconds
+            if source.metadata.last_frame_timestamp_seconds is not None:
+                context_end = min(
+                    context_end,
+                    source.metadata.last_frame_timestamp_seconds,
+                )
             before = max(
                 stream_start + MINIMUM_ENDPOINT_MARGIN_SECONDS,
                 candidate.timestamp_seconds - CONTEXT_OFFSET_SECONDS,
@@ -584,11 +687,13 @@ class SingleVideoSelector:
             futures = [
                 executor.submit(
                     self.frame_extractor.extract_frame,
-                    self.video,
+                    self._source_for(candidate).path,
                     timestamp,
                     context_frame_path(context_dir, candidate, position),
                     max_width=960,
-                    video_stream_index=self.metadata.video_stream_index,
+                    video_stream_index=(
+                        self._source_for(candidate).metadata.video_stream_index
+                    ),
                 )
                 for candidate, position, timestamp in jobs
             ]
@@ -696,6 +801,7 @@ class SingleVideoSelector:
                 "candidates": [
                     {
                         "id": candidate.frame_id,
+                        "video_index": candidate.video_index + 1,
                         "timestamp_seconds": candidate.timestamp_seconds,
                         "difference_hash": f"{candidate.difference_hash:016x}",
                         "image_sha256": file_sha256(Path(candidate.path)),
@@ -731,6 +837,10 @@ class SingleVideoSelector:
     ) -> str:
         """検証済みの汎用選定方針をOllama向けpromptにする."""
         ids = ", ".join(candidate.frame_id for candidate in candidates)
+        source_ids = ", ".join(
+            f"{candidate.frame_id}={self._source_for(candidate).label}"
+            for candidate in candidates
+        )
         if stage == "primary":
             stage_note = "動画全体を時間分散と機械的品質で絞った一次候補です。"
             context_note = ""
@@ -745,11 +855,17 @@ class SingleVideoSelector:
             if self.request.game_context.strip()
             else ""
         )
-        duration_label = format_duration(self.metadata.duration_seconds)
-        return f"""ゲーム『{self.game_title}』の{duration_label}の全編録画から、
+        duration_label = format_duration(self.total_duration_seconds)
+        recording_label = (
+            f"{duration_label}の全編録画"
+            if len(self.sources) == 1
+            else f"{len(self.sources)}本、合計{duration_label}の全編録画"
+        )
+        return f"""ゲーム『{self.game_title}』の{recording_label}から、
 ブログへ実際に掲載する画像を{self.request.output_count}枚選びます。{stage_note}
 {context_note}{game_context}
 contact sheet内の対象ID: {ids}
+対象IDと入力動画: {source_ids}
 
 各画像について次を判定してください。
 - blog_score: ブログ掲載価値を0から100で厳しく評価
@@ -787,13 +903,14 @@ contact sheet内の対象ID: {ids}
         contact_candidates: list[FrameCandidate] = []
         selected_paths: list[Path] = []
         for rank, selected_frame in enumerate(selected, start=1):
+            source = self._source_for(selected_frame.candidate)
             output_path = self.output_dir / f"selected-{rank:0{width}d}.jpg"
             self.frame_extractor.extract_frame(
-                self.video,
+                source.path,
                 selected_frame.candidate.timestamp_seconds,
                 output_path,
                 max_width=None,
-                video_stream_index=self.metadata.video_stream_index,
+                video_stream_index=source.metadata.video_stream_index,
             )
             with Image.open(output_path) as image:
                 output_hash = image_difference_hash(image)
@@ -812,6 +929,9 @@ contact sheet内の対象ID: {ids}
                     "rank": rank,
                     "output_path": output_path.name,
                     "frame_id": selected_frame.candidate.frame_id,
+                    "video_index": source.index + 1,
+                    "video": str(source.path),
+                    "video_name": source.path.name,
                     "timestamp_seconds": round(
                         selected_frame.candidate.timestamp_seconds, 6
                     ),
@@ -826,6 +946,8 @@ contact sheet内の対象ID: {ids}
                     frame_id=f"{rank:0{width}d}",
                     timestamp_seconds=selected_frame.candidate.timestamp_seconds,
                     path=str(output_path),
+                    video_index=source.index,
+                    source_label=source.label,
                 )
             )
 
@@ -834,11 +956,19 @@ contact sheet内の対象ID: {ids}
             report_path,
             {
                 "manifest_digest": self.manifest_digest,
-                "video": str(self.video),
+                "videos": [
+                    {
+                        "video_index": source.index + 1,
+                        "path": str(source.path),
+                        "duration_seconds": source.metadata.duration_seconds,
+                        "sample_count": len(source.timestamps),
+                    }
+                    for source in self.sources
+                ],
                 "game_title": self.game_title,
                 "game_context": self.request.game_context.strip(),
                 "output_count": self.request.output_count,
-                "sample_count": len(self.timestamps),
+                "sample_count": sum(len(source.timestamps) for source in self.sources),
                 "models": {
                     "primary": {
                         "name": self.request.primary_model,
@@ -1056,6 +1186,8 @@ def measure_candidate(candidate: FrameCandidate) -> FrameCandidate | None:
         path=candidate.path,
         quality_score=quality_score,
         difference_hash=difference_hash,
+        video_index=candidate.video_index,
+        source_label=candidate.source_label,
     )
 
 
@@ -1108,6 +1240,8 @@ def select_diverse_candidates(
     selected: list[FrameCandidate] = []
     remaining = list(eligible)
     scene_counts: Counter[str] = Counter()
+    source_counts: Counter[int] = Counter()
+    source_indexes = {candidate.video_index for candidate in eligible}
     timeline_span = max(
         1.0,
         max(item.timestamp_seconds for item in eligible)
@@ -1115,6 +1249,16 @@ def select_diverse_candidates(
     )
     time_scale = max(60.0, timeline_span / max(1, count))
     while len(selected) < count:
+        unrepresented_sources = source_indexes - set(source_counts)
+        source_pool = (
+            [
+                candidate
+                for candidate in remaining
+                if candidate.video_index in unrepresented_sources
+            ]
+            if len(selected) < min(count, len(source_indexes))
+            else remaining
+        )
 
         def utility(candidate: FrameCandidate) -> tuple[float, float, float]:
             assessment = assessments[candidate.frame_id]
@@ -1131,15 +1275,17 @@ def select_diverse_candidates(
             total = (
                 assessment.blog_score
                 + 14.0 / (scene_counts[scene_key] + 1)
+                + 12.0 / (source_counts[candidate.video_index] + 1)
                 + min(32, visual_distance) * 0.60
                 + min(time_scale, time_distance) / time_scale * 8.0
                 - near_duplicate_penalty
             )
             return total, assessment.blog_score, -candidate.timestamp_seconds
 
-        chosen = max(remaining, key=utility)
+        chosen = max(source_pool, key=utility)
         selected.append(chosen)
         scene_counts[normalize_scene(assessments[chosen.frame_id])] += 1
+        source_counts[chosen.video_index] += 1
         remaining.remove(chosen)
     return selected
 
@@ -1175,6 +1321,8 @@ def select_final_frames(
     remaining = list(eligible)
     scene_counts: Counter[str] = Counter()
     family_counts: Counter[str] = Counter()
+    source_counts: Counter[int] = Counter()
+    source_indexes = {candidate.video_index for candidate in eligible}
     timeline_span = max(
         1.0,
         max(item.timestamp_seconds for item in eligible)
@@ -1183,14 +1331,24 @@ def select_final_frames(
     time_scale = max(60.0, timeline_span / max(1, count))
 
     while len(selected) < count:
+        unrepresented_sources = source_indexes - set(source_counts)
+        source_pool = (
+            [
+                candidate
+                for candidate in remaining
+                if candidate.video_index in unrepresented_sources
+            ]
+            if len(selected) < min(count, len(source_indexes))
+            else remaining
+        )
         preferred = [
             candidate
-            for candidate in remaining
+            for candidate in source_pool
             if screen_family(secondary[candidate.frame_id]) not in soft_caps
             or family_counts[screen_family(secondary[candidate.frame_id])]
             < soft_caps[screen_family(secondary[candidate.frame_id])]
         ]
-        pool = preferred or remaining
+        pool = preferred or source_pool
         visually_distinct = [
             candidate
             for candidate in pool
@@ -1222,6 +1380,7 @@ def select_final_frames(
             total = (
                 aggregate_score(candidate)
                 + 14.0 / (scene_counts[scene_key] + 1)
+                + 12.0 / (source_counts[candidate.video_index] + 1)
                 + min(32, visual_distance) * 0.65
                 + min(time_scale, time_distance) / time_scale * 9.0
                 - family_penalty
@@ -1234,6 +1393,7 @@ def select_final_frames(
         assessment = secondary[chosen.frame_id]
         scene_counts[normalize_scene(assessment)] += 1
         family_counts[screen_family(assessment)] += 1
+        source_counts[chosen.video_index] += 1
         remaining.remove(chosen)
 
     result = [
@@ -1247,7 +1407,11 @@ def select_final_frames(
     ]
     return sorted(
         result,
-        key=lambda item: (-item.aggregate_score, item.candidate.timestamp_seconds),
+        key=lambda item: (
+            -item.aggregate_score,
+            item.candidate.video_index,
+            item.candidate.timestamp_seconds,
+        ),
     )
 
 
@@ -1259,6 +1423,9 @@ def _nearest_distances(
     """既選択候補への最小visual/time距離を返す."""
     if not selected:
         return 64, default_time_distance
+    same_video = [
+        chosen for chosen in selected if chosen.video_index == candidate.video_index
+    ]
     return (
         min(
             difference_hash_distance(
@@ -1267,9 +1434,13 @@ def _nearest_distances(
             )
             for chosen in selected
         ),
-        min(
-            abs(candidate.timestamp_seconds - chosen.timestamp_seconds)
-            for chosen in selected
+        (
+            min(
+                abs(candidate.timestamp_seconds - chosen.timestamp_seconds)
+                for chosen in same_video
+            )
+            if same_video
+            else default_time_distance
         ),
     )
 

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -51,7 +51,7 @@ from .video_frame_extractor import VideoFrameExtractor
 
 logger = logging.getLogger(__name__)
 
-ALGORITHM_VERSION = "multi-video-selection-v3"
+ALGORITHM_VERSION = "multi-video-selection-v4"
 PROMPT_VERSION = "blog-image-selection-v3"
 DEFAULT_MAX_SAMPLE_INTERVAL_SECONDS = 10.0
 MINIMUM_ENDPOINT_MARGIN_SECONDS = 0.05
@@ -598,13 +598,21 @@ class VideoSelector:
             candidates=candidates,
         )
         backfill_round = 0
-        while len(self.sources) <= self.request.output_count:
-            uncovered_sources = _uncovered_assessment_sources(
-                candidates,
-                assessments,
-                len(self.sources),
+        while True:
+            survivor_count = sum(
+                not assessments[candidate.frame_id].is_transition
+                for candidate in candidates
             )
-            if not uncovered_sources:
+            uncovered_sources = (
+                _uncovered_assessment_sources(
+                    candidates,
+                    assessments,
+                    len(self.sources),
+                )
+                if len(self.sources) <= self.request.output_count
+                else ()
+            )
+            if not uncovered_sources and survivor_count >= self.request.output_count:
                 break
             backfill = select_source_backfill_candidates(
                 candidate_pool,
@@ -617,8 +625,13 @@ class VideoSelector:
                 labels = ", ".join(
                     self.sources[index].label for index in uncovered_sources
                 )
+                if labels:
+                    raise RuntimeError(
+                        f"{stage_label}評価で入力動画に非遷移候補がありません: {labels}"
+                    )
                 raise RuntimeError(
-                    f"{stage_label}評価で入力動画に非遷移候補がありません: {labels}"
+                    f"{stage_label}評価の非遷移候補{survivor_count}件が"
+                    f"選択枚数{self.request.output_count}件を下回りました"
                 )
             backfill_round += 1
             if not primary_stage:
@@ -1523,54 +1536,79 @@ def select_source_backfill_candidates(
     source_count: int,
     output_count: int,
 ) -> list[FrameCandidate]:
-    """非遷移候補がない入力元から未評価候補を少数ずつ補充する."""
+    """入力元の欠落または生存候補の不足を未評価候補で追補する."""
     if source_count <= 0 or output_count <= 0:
         raise ValueError("入力動画数と選択枚数は正の整数で指定してください")
-    if source_count > output_count:
+    survivor_counts = Counter(
+        candidate.video_index
+        for candidate in assessed_candidates
+        if not assessments[candidate.frame_id].is_transition
+    )
+    survivor_count = sum(survivor_counts.values())
+    uncovered_sources = (
+        _uncovered_assessment_sources(
+            assessed_candidates,
+            assessments,
+            source_count,
+        )
+        if source_count <= output_count
+        else ()
+    )
+    shortfall = max(0, output_count - survivor_count)
+    if not uncovered_sources and not shortfall:
         return []
 
-    uncovered_sources = _uncovered_assessment_sources(
-        assessed_candidates,
-        assessments,
-        source_count,
-    )
     assessed_ids = {candidate.frame_id for candidate in assessed_candidates}
-    assessed_by_source: dict[int, list[FrameCandidate]] = {
-        video_index: [] for video_index in uncovered_sources
-    }
-    available_by_source: dict[int, list[FrameCandidate]] = {
-        video_index: [] for video_index in uncovered_sources
-    }
+    assessed_by_source: dict[int, list[FrameCandidate]] = {}
+    available_by_source: dict[int, list[FrameCandidate]] = {}
     for candidate in assessed_candidates:
-        if candidate.video_index in assessed_by_source:
-            assessed_by_source[candidate.video_index].append(candidate)
+        assessed_by_source.setdefault(candidate.video_index, []).append(candidate)
     for candidate in all_candidates:
-        if (
-            candidate.video_index in available_by_source
-            and candidate.frame_id not in assessed_ids
-        ):
-            available_by_source[candidate.video_index].append(candidate)
+        if candidate.frame_id not in assessed_ids:
+            available_by_source.setdefault(candidate.video_index, []).append(candidate)
     for candidates in available_by_source.values():
         candidates.sort(key=_primary_candidate_order)
 
+    if uncovered_sources:
+        source_order = uncovered_sources
+        target_count = len(uncovered_sources) * SECONDARY_CANDIDATE_MULTIPLIER
+    else:
+        source_order = tuple(
+            sorted(
+                available_by_source,
+                key=lambda video_index: (
+                    survivor_counts[video_index],
+                    video_index,
+                ),
+            )
+        )
+        target_count = shortfall * SECONDARY_CANDIDATE_MULTIPLIER
     selected_by_source: dict[int, list[FrameCandidate]] = {
-        video_index: [] for video_index in uncovered_sources
+        video_index: [] for video_index in source_order
     }
-    for _ in range(SECONDARY_CANDIDATE_MULTIPLIER):
-        for video_index in uncovered_sources:
-            source_candidates = available_by_source[video_index]
+    selected_count = 0
+    while selected_count < target_count:
+        progressed = False
+        for video_index in source_order:
+            source_candidates = available_by_source.get(video_index, [])
             chosen = _next_source_representative(
                 source_candidates,
                 (
-                    *assessed_by_source[video_index],
+                    *assessed_by_source.get(video_index, []),
                     *selected_by_source[video_index],
                 ),
             )
             if chosen is not None:
                 selected_by_source[video_index].append(chosen)
+                selected_count += 1
+                progressed = True
+                if selected_count == target_count:
+                    break
+        if not progressed:
+            break
     selected = [
         candidate
-        for video_index in uncovered_sources
+        for video_index in source_order
         for candidate in selected_by_source[video_index]
     ]
     return sorted(
@@ -1584,7 +1622,7 @@ def _uncovered_assessment_sources(
     assessments: dict[str, FrameAssessment],
     source_count: int,
 ) -> tuple[int, ...]:
-    """一次評価で非遷移候補をまだ得ていない入力元を返す."""
+    """評価で非遷移候補をまだ得ていない入力元を返す."""
     covered_sources = {
         candidate.video_index
         for candidate in candidates
@@ -1631,6 +1669,30 @@ def _next_source_representative(
     return diverse or remaining[0]
 
 
+def source_time_scales(
+    candidates: Sequence[FrameCandidate],
+    count: int,
+) -> dict[int, float]:
+    """各入力元の相対spanと期待選定枚数から時間分散尺度を返す."""
+    if count <= 0:
+        raise ValueError("選択枚数は正の整数で指定してください")
+    timestamps_by_source: dict[int, list[float]] = {}
+    for candidate in candidates:
+        timestamps_by_source.setdefault(candidate.video_index, []).append(
+            candidate.timestamp_seconds
+        )
+    if not timestamps_by_source:
+        return {}
+    expected_count = max(1.0, count / len(timestamps_by_source))
+    return {
+        video_index: max(
+            60.0,
+            (max(timestamps) - min(timestamps)) / expected_count,
+        )
+        for video_index, timestamps in timestamps_by_source.items()
+    }
+
+
 def select_diverse_candidates(
     candidates: Sequence[FrameCandidate],
     assessments: dict[str, FrameAssessment],
@@ -1649,12 +1711,7 @@ def select_diverse_candidates(
     scene_counts: Counter[str] = Counter()
     source_counts: Counter[int] = Counter()
     source_indexes = {candidate.video_index for candidate in eligible}
-    timeline_span = max(
-        1.0,
-        max(item.timestamp_seconds for item in eligible)
-        - min(item.timestamp_seconds for item in eligible),
-    )
-    time_scale = max(60.0, timeline_span / max(1, count))
+    time_scales = source_time_scales(eligible, count)
     while len(selected) < count:
         source_pool = _source_balanced_pool(
             remaining,
@@ -1666,8 +1723,11 @@ def select_diverse_candidates(
 
         def utility(candidate: FrameCandidate) -> tuple[float, float, float]:
             assessment = assessments[candidate.frame_id]
+            time_scale = time_scales[candidate.video_index]
             visual_distance, time_distance = _nearest_distances(
-                candidate, selected, time_scale
+                candidate,
+                selected,
+                time_scale,
             )
             scene_key = normalize_scene(assessment)
             near_duplicate_penalty = (
@@ -1727,12 +1787,7 @@ def select_final_frames(
     family_counts: Counter[str] = Counter()
     source_counts: Counter[int] = Counter()
     source_indexes = {candidate.video_index for candidate in eligible}
-    timeline_span = max(
-        1.0,
-        max(item.timestamp_seconds for item in eligible)
-        - min(item.timestamp_seconds for item in eligible),
-    )
-    time_scale = max(60.0, timeline_span / max(1, count))
+    time_scales = source_time_scales(eligible, count)
 
     while len(selected) < count:
         source_pool = _source_balanced_pool(
@@ -1766,8 +1821,11 @@ def select_final_frames(
 
         def utility(candidate: FrameCandidate) -> tuple[float, float, float]:
             assessment = secondary[candidate.frame_id]
+            time_scale = time_scales[candidate.video_index]
             visual_distance, time_distance = _nearest_distances(
-                candidate, selected, time_scale
+                candidate,
+                selected,
+                time_scale,
             )
             scene_key = normalize_scene(assessment)
             family = screen_family(assessment)

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -51,7 +51,7 @@ from .video_frame_extractor import VideoFrameExtractor
 
 logger = logging.getLogger(__name__)
 
-ALGORITHM_VERSION = "multi-video-selection-v2"
+ALGORITHM_VERSION = "multi-video-selection-v3"
 PROMPT_VERSION = "blog-image-selection-v3"
 DEFAULT_MAX_SAMPLE_INTERVAL_SECONDS = 10.0
 MINIMUM_ENDPOINT_MARGIN_SECONDS = 0.05
@@ -124,8 +124,11 @@ class VideoSelector:
 
         candidates = self._extract_candidates()
         primary_candidates = self._preselect_candidates(candidates)
-        primary_candidates, primary_assessments = (
-            self._assess_primary_candidates_with_backfill(primary_candidates)
+        primary_candidates, primary_assessments = self._assess_with_source_backfill(
+            self._usable_candidates,
+            primary_candidates,
+            model=self.request.primary_model,
+            stage="primary",
         )
         primary_eligible = [
             candidate
@@ -146,15 +149,11 @@ class VideoSelector:
             primary_assessments,
             secondary_count,
         )
-        write_json_atomic(
-            self.work_dir / "secondary-candidates.json",
-            [candidate_to_json(candidate) for candidate in secondary_candidates],
-        )
-        self._extract_context_frames(secondary_candidates)
-        secondary_assessments = self._assess_candidates(
+        secondary_candidates, secondary_assessments = self._assess_with_source_backfill(
+            primary_eligible,
+            secondary_candidates,
             model=self.request.secondary_model,
             stage="secondary",
-            candidates=secondary_candidates,
         )
         selected = select_final_frames(
             secondary_candidates,
@@ -569,35 +568,46 @@ class VideoSelector:
             [source.metadata for source in self.sources],
             self.request.output_count,
         )
-        write_json_atomic(
-            self.work_dir / "primary-candidates.json",
-            [candidate_to_json(candidate) for candidate in result],
-        )
         logger.info("一次評価候補を絞りました: %d/%d件", len(result), len(usable))
         return result
 
-    def _assess_primary_candidates_with_backfill(
+    def _assess_with_source_backfill(
         self,
+        candidate_pool: Sequence[FrameCandidate],
         initial_candidates: Sequence[FrameCandidate],
+        *,
+        model: str,
+        stage: str,
     ) -> tuple[list[FrameCandidate], dict[str, FrameAssessment]]:
-        """一次候補を評価し、未代表の入力元から候補を追加評価する."""
+        """候補を評価し、未代表の入力元から同じstageの候補を追補する."""
+        if stage not in {"primary", "secondary"}:
+            raise ValueError(f"候補追補に未対応の評価stageです: {stage}")
+        primary_stage = _is_primary_stage(stage)
+        stage_label = "一次" if primary_stage else "二次"
+        candidates_path = self.work_dir / f"{stage}-candidates.json"
         candidates = list(initial_candidates)
+        write_json_atomic(
+            candidates_path,
+            [candidate_to_json(candidate) for candidate in candidates],
+        )
+        if not primary_stage:
+            self._extract_context_frames(candidates)
         assessments = self._assess_candidates(
-            model=self.request.primary_model,
-            stage="primary",
+            model=model,
+            stage=stage,
             candidates=candidates,
         )
         backfill_round = 0
         while len(self.sources) <= self.request.output_count:
-            uncovered_sources = _uncovered_primary_sources(
+            uncovered_sources = _uncovered_assessment_sources(
                 candidates,
                 assessments,
                 len(self.sources),
             )
             if not uncovered_sources:
                 break
-            backfill = select_primary_backfill_candidates(
-                self._usable_candidates,
+            backfill = select_source_backfill_candidates(
+                candidate_pool,
                 candidates,
                 assessments,
                 source_count=len(self.sources),
@@ -607,11 +617,15 @@ class VideoSelector:
                 labels = ", ".join(
                     self.sources[index].label for index in uncovered_sources
                 )
-                raise RuntimeError(f"入力動画に非遷移候補がありません: {labels}")
+                raise RuntimeError(
+                    f"{stage_label}評価で入力動画に非遷移候補がありません: {labels}"
+                )
             backfill_round += 1
+            if not primary_stage:
+                self._extract_context_frames(backfill)
             backfill_assessments = self._assess_candidates(
-                model=self.request.primary_model,
-                stage=f"primary-backfill-{backfill_round:04d}",
+                model=model,
+                stage=f"{stage}-backfill-{backfill_round:04d}",
                 candidates=backfill,
             )
             candidates.extend(backfill)
@@ -624,11 +638,12 @@ class VideoSelector:
             )
             assessments.update(backfill_assessments)
             write_json_atomic(
-                self.work_dir / "primary-candidates.json",
+                candidates_path,
                 [candidate_to_json(candidate) for candidate in candidates],
             )
             logger.info(
-                "一次評価候補を入力元から補充しました: round=%d, %d件",
+                "%s評価候補を入力元から補充しました: round=%d, %d件",
+                stage_label,
                 backfill_round,
                 len(backfill),
             )
@@ -1500,7 +1515,7 @@ def select_primary_candidates(
     )
 
 
-def select_primary_backfill_candidates(
+def select_source_backfill_candidates(
     all_candidates: Sequence[FrameCandidate],
     assessed_candidates: Sequence[FrameCandidate],
     assessments: dict[str, FrameAssessment],
@@ -1514,7 +1529,7 @@ def select_primary_backfill_candidates(
     if source_count > output_count:
         return []
 
-    uncovered_sources = _uncovered_primary_sources(
+    uncovered_sources = _uncovered_assessment_sources(
         assessed_candidates,
         assessments,
         source_count,
@@ -1564,7 +1579,7 @@ def select_primary_backfill_candidates(
     )
 
 
-def _uncovered_primary_sources(
+def _uncovered_assessment_sources(
     candidates: Sequence[FrameCandidate],
     assessments: dict[str, FrameAssessment],
     source_count: int,

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -51,7 +51,7 @@ from .video_frame_extractor import VideoFrameExtractor
 
 logger = logging.getLogger(__name__)
 
-ALGORITHM_VERSION = "multi-video-selection-v1"
+ALGORITHM_VERSION = "multi-video-selection-v2"
 PROMPT_VERSION = "blog-image-selection-v3"
 DEFAULT_MAX_SAMPLE_INTERVAL_SECONDS = 10.0
 MINIMUM_ENDPOINT_MARGIN_SECONDS = 0.05
@@ -105,6 +105,7 @@ class VideoSelector:
         self.total_duration_seconds = 0.0
         self.model_metadata: dict[str, dict[str, Any]] = {}
         self._live_validated_models: set[str] = set()
+        self._usable_candidates: tuple[FrameCandidate, ...] = ()
         self.manifest_digest = ""
 
     def run(self) -> Path:
@@ -123,10 +124,8 @@ class VideoSelector:
 
         candidates = self._extract_candidates()
         primary_candidates = self._preselect_candidates(candidates)
-        primary_assessments = self._assess_candidates(
-            model=self.request.primary_model,
-            stage="primary",
-            candidates=primary_candidates,
+        primary_candidates, primary_assessments = (
+            self._assess_primary_candidates_with_backfill(primary_candidates)
         )
         primary_eligible = [
             candidate
@@ -558,6 +557,7 @@ class VideoSelector:
         else:
             executor.shutdown()
         usable = [candidate for candidate in measured if candidate is not None]
+        self._usable_candidates = tuple(usable)
         if len(usable) < self.request.output_count:
             raise RuntimeError(
                 f"有効候補{len(usable)}件が選択枚数"
@@ -575,6 +575,64 @@ class VideoSelector:
         )
         logger.info("一次評価候補を絞りました: %d/%d件", len(result), len(usable))
         return result
+
+    def _assess_primary_candidates_with_backfill(
+        self,
+        initial_candidates: Sequence[FrameCandidate],
+    ) -> tuple[list[FrameCandidate], dict[str, FrameAssessment]]:
+        """一次候補を評価し、未代表の入力元から候補を追加評価する."""
+        candidates = list(initial_candidates)
+        assessments = self._assess_candidates(
+            model=self.request.primary_model,
+            stage="primary",
+            candidates=candidates,
+        )
+        backfill_round = 0
+        while len(self.sources) <= self.request.output_count:
+            uncovered_sources = _uncovered_primary_sources(
+                candidates,
+                assessments,
+                len(self.sources),
+            )
+            if not uncovered_sources:
+                break
+            backfill = select_primary_backfill_candidates(
+                self._usable_candidates,
+                candidates,
+                assessments,
+                source_count=len(self.sources),
+                output_count=self.request.output_count,
+            )
+            if not backfill:
+                labels = ", ".join(
+                    self.sources[index].label for index in uncovered_sources
+                )
+                raise RuntimeError(f"入力動画に非遷移候補がありません: {labels}")
+            backfill_round += 1
+            backfill_assessments = self._assess_candidates(
+                model=self.request.primary_model,
+                stage=f"primary-backfill-{backfill_round:04d}",
+                candidates=backfill,
+            )
+            candidates.extend(backfill)
+            candidates.sort(
+                key=lambda item: (
+                    item.video_index,
+                    item.timestamp_seconds,
+                    item.frame_id,
+                )
+            )
+            assessments.update(backfill_assessments)
+            write_json_atomic(
+                self.work_dir / "primary-candidates.json",
+                [candidate_to_json(candidate) for candidate in candidates],
+            )
+            logger.info(
+                "一次評価候補を入力元から補充しました: round=%d, %d件",
+                backfill_round,
+                len(backfill),
+            )
+        return candidates, assessments
 
     def _extract_context_frames(
         self,
@@ -644,12 +702,13 @@ class VideoSelector:
         cache_key = self._assessment_cache_key(model, stage, candidates)
         state_path = self.work_dir / f"assessments-{stage}.json"
         state = load_assessment_state(state_path, cache_key)
-        batch_size = PRIMARY_BATCH_SIZE if stage == "primary" else SECONDARY_BATCH_SIZE
+        primary_stage = _is_primary_stage(stage)
+        batch_size = PRIMARY_BATCH_SIZE if primary_stage else SECONDARY_BATCH_SIZE
         batches = [
             candidates[index : index + batch_size]
             for index in range(0, len(candidates), batch_size)
         ]
-        context_dir = self.work_dir / "context-frames" if stage == "secondary" else None
+        context_dir = None if primary_stage else self.work_dir / "context-frames"
         for batch_index, batch in enumerate(batches, start=1):
             batch_ids = {candidate.frame_id for candidate in batch}
             if batch_ids.issubset(state):
@@ -740,17 +799,19 @@ class VideoSelector:
                                     context_frame_path(context_dir, candidate, "after")
                                 ),
                             }
-                            if stage == "secondary"
+                            if not _is_primary_stage(stage)
                             else {}
                         ),
                     }
                     for candidate in candidates
                 ],
                 "batch_size": (
-                    PRIMARY_BATCH_SIZE if stage == "primary" else SECONDARY_BATCH_SIZE
+                    PRIMARY_BATCH_SIZE
+                    if _is_primary_stage(stage)
+                    else SECONDARY_BATCH_SIZE
                 ),
                 "context_offset_seconds": (
-                    0 if stage == "primary" else CONTEXT_OFFSET_SECONDS
+                    0 if _is_primary_stage(stage) else CONTEXT_OFFSET_SECONDS
                 ),
                 "model_options": MODEL_OPTIONS,
             }
@@ -767,7 +828,7 @@ class VideoSelector:
             f"{candidate.frame_id}={self._source_for(candidate).label}"
             for candidate in candidates
         )
-        if stage == "primary":
+        if _is_primary_stage(stage):
             stage_note = "動画全体を時間分散と機械的品質で絞った一次候補です。"
             context_note = ""
         else:
@@ -1303,6 +1364,11 @@ def candidate_to_json(candidate: FrameCandidate) -> dict[str, Any]:
     return payload
 
 
+def _is_primary_stage(stage: str) -> bool:
+    """一次評価と、その追補評価のstage名を判定する."""
+    return stage == "primary" or stage.startswith("primary-backfill-")
+
+
 def select_primary_candidates(
     candidates: Sequence[FrameCandidate],
     metadata_items: Sequence[VideoMetadata],
@@ -1431,6 +1497,88 @@ def select_primary_candidates(
     return sorted(
         selected[:target],
         key=lambda item: (item.video_index, item.timestamp_seconds, item.frame_id),
+    )
+
+
+def select_primary_backfill_candidates(
+    all_candidates: Sequence[FrameCandidate],
+    assessed_candidates: Sequence[FrameCandidate],
+    assessments: dict[str, FrameAssessment],
+    *,
+    source_count: int,
+    output_count: int,
+) -> list[FrameCandidate]:
+    """非遷移候補がない入力元から未評価候補を少数ずつ補充する."""
+    if source_count <= 0 or output_count <= 0:
+        raise ValueError("入力動画数と選択枚数は正の整数で指定してください")
+    if source_count > output_count:
+        return []
+
+    uncovered_sources = _uncovered_primary_sources(
+        assessed_candidates,
+        assessments,
+        source_count,
+    )
+    assessed_ids = {candidate.frame_id for candidate in assessed_candidates}
+    assessed_by_source: dict[int, list[FrameCandidate]] = {
+        video_index: [] for video_index in uncovered_sources
+    }
+    available_by_source: dict[int, list[FrameCandidate]] = {
+        video_index: [] for video_index in uncovered_sources
+    }
+    for candidate in assessed_candidates:
+        if candidate.video_index in assessed_by_source:
+            assessed_by_source[candidate.video_index].append(candidate)
+    for candidate in all_candidates:
+        if (
+            candidate.video_index in available_by_source
+            and candidate.frame_id not in assessed_ids
+        ):
+            available_by_source[candidate.video_index].append(candidate)
+    for candidates in available_by_source.values():
+        candidates.sort(key=_primary_candidate_order)
+
+    selected_by_source: dict[int, list[FrameCandidate]] = {
+        video_index: [] for video_index in uncovered_sources
+    }
+    for _ in range(SECONDARY_CANDIDATE_MULTIPLIER):
+        for video_index in uncovered_sources:
+            source_candidates = available_by_source[video_index]
+            chosen = _next_source_representative(
+                source_candidates,
+                (
+                    *assessed_by_source[video_index],
+                    *selected_by_source[video_index],
+                ),
+            )
+            if chosen is not None:
+                selected_by_source[video_index].append(chosen)
+    selected = [
+        candidate
+        for video_index in uncovered_sources
+        for candidate in selected_by_source[video_index]
+    ]
+    return sorted(
+        selected,
+        key=lambda item: (item.video_index, item.timestamp_seconds, item.frame_id),
+    )
+
+
+def _uncovered_primary_sources(
+    candidates: Sequence[FrameCandidate],
+    assessments: dict[str, FrameAssessment],
+    source_count: int,
+) -> tuple[int, ...]:
+    """一次評価で非遷移候補をまだ得ていない入力元を返す."""
+    covered_sources = {
+        candidate.video_index
+        for candidate in candidates
+        if not assessments[candidate.frame_id].is_transition
+    }
+    return tuple(
+        video_index
+        for video_index in range(source_count)
+        if video_index not in covered_sources
     )
 
 

--- a/src/utils/contact_sheet.py
+++ b/src/utils/contact_sheet.py
@@ -57,11 +57,12 @@ def build_contact_sheet(
         x = index % columns * cell_width
         y = index // columns * (image_height + label_height)
         suffix = "  [before | selected | after]" if contextual else ""
+        source = f"  {candidate.source_label}" if candidate.source_label else ""
         draw.text(
             (x + 10, y + 8),
             (
                 f"{candidate.frame_id}  "
-                f"{_format_timestamp(candidate.timestamp_seconds)}{suffix}"
+                f"{_format_timestamp(candidate.timestamp_seconds)}{source}{suffix}"
             ),
             fill="white",
         )

--- a/tests/models/test_video_selection_request.py
+++ b/tests/models/test_video_selection_request.py
@@ -1,0 +1,32 @@
+"""動画選定リクエストの互換性を検証する."""
+
+from dataclasses import replace
+
+from src.models.video_selection_request import VideoSelectionRequest
+
+
+def test_replace_can_update_legacy_input_video() -> None:
+    """旧input_video fieldを使うreplaceが単一入力を更新できること."""
+    request = VideoSelectionRequest(
+        input_video="old.mp4",
+        output_dir="output",
+        output_count=30,
+        game_title=None,
+        game_context="",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host=None,
+        ollama_timeout=300.0,
+        allow_cpu=False,
+        ffmpeg_workers=4,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+
+    updated = replace(
+        request,
+        input_video="new.mp4",  # type: ignore[call-arg]  # 旧fieldの実行時互換
+    )
+
+    assert updated.input_video == "new.mp4"
+    assert updated.input_videos == ("new.mp4",)

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -339,6 +339,109 @@ def test_pipeline_selects_from_multiple_videos_and_reports_each_source(
     assert unavailable_assessor.assess_calls == 0
 
 
+def test_pipeline_backfills_source_when_reserved_primary_candidates_fail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """入力元の予約候補が全遷移なら未評価候補を追加評価すること."""
+    failed_primary_ids: set[str] = set()
+
+    def select_initial_candidates(
+        candidates: Sequence[FrameCandidate],
+        _metadata: Sequence[VideoMetadata],
+        _output_count: int,
+    ) -> list[FrameCandidate]:
+        by_source = {
+            video_index: [
+                candidate
+                for candidate in candidates
+                if candidate.video_index == video_index
+            ]
+            for video_index in range(2)
+        }
+        failed_primary_ids.update(candidate.frame_id for candidate in by_source[0][:3])
+        return [*by_source[0][:3], *by_source[1][:6]]
+
+    class ReservedCandidateFailingAssessor(FakeAssessor):
+        """最初の入力元で予約された一次候補だけを遷移と判定するfake."""
+
+        def assess(
+            self,
+            *,
+            model: str,
+            model_digest: str,
+            prompt: str,
+            candidates: Sequence[FrameCandidate],
+            contact_sheet: Path,
+        ) -> list[FrameAssessment]:
+            assessments = super().assess(
+                model=model,
+                model_digest=model_digest,
+                prompt=prompt,
+                candidates=candidates,
+                contact_sheet=contact_sheet,
+            )
+            return [
+                replace(
+                    assessment,
+                    is_transition=assessment.frame_id in failed_primary_ids,
+                )
+                for assessment in assessments
+            ]
+
+    monkeypatch.setattr(
+        "src.services.video_selector.select_primary_candidates",
+        select_initial_candidates,
+    )
+    videos = (
+        tmp_path / "Sample Game Part1.mp4",
+        tmp_path / "Sample Game Part2.mp4",
+    )
+    for video in videos:
+        video.write_bytes(bytes(range(256)) * 16)
+    output_dir = tmp_path / "selected"
+    request = VideoSelectionRequest(
+        input_videos=tuple(str(video) for video in videos),
+        output_dir=str(output_dir),
+        output_count=2,
+        game_title=None,
+        game_context="",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+
+    extractor = FakeFrameExtractor()
+    SingleVideoSelector(
+        request,
+        frame_extractor=extractor,
+        assessor=ReservedCandidateFailingAssessor(),
+    ).run()
+
+    work_dir = output_dir / ".game-screen-pick"
+    report = json.loads((output_dir / "report.json").read_text(encoding="utf-8"))
+    assert (work_dir / "assessments-primary-backfill-0001.json").is_file()
+    assert {item["video_index"] for item in report["selected"]} == {1, 2}
+    assert not failed_primary_ids & {item["frame_id"] for item in report["selected"]}
+
+    (work_dir / "completion.json").unlink()
+    (output_dir / "selected-01.jpg").unlink()
+    unavailable_assessor = UnavailableAssessor()
+    SingleVideoSelector(
+        request,
+        frame_extractor=extractor,
+        assessor=unavailable_assessor,
+    ).run()
+
+    assert unavailable_assessor.metadata_calls == 0
+    assert unavailable_assessor.assess_calls == 0
+
+
 def test_pipeline_rejects_resume_when_any_input_video_changes(tmp_path: Path) -> None:
     """2本目だけの内容変更も全体SHA-256で検出すること."""
     videos = (

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -442,6 +442,116 @@ def test_pipeline_backfills_source_when_reserved_primary_candidates_fail(
     assert unavailable_assessor.assess_calls == 0
 
 
+def test_pipeline_backfills_source_when_secondary_representative_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """二次評価の唯一の代表が遷移なら同じ入力元から追補すること."""
+    failed_secondary_ids: set[str] = set()
+
+    def select_single_source_representative(
+        candidates: Sequence[FrameCandidate],
+        _assessments: dict[str, FrameAssessment],
+        count: int,
+    ) -> list[FrameCandidate]:
+        by_source = {
+            video_index: [
+                candidate
+                for candidate in candidates
+                if candidate.video_index == video_index
+            ]
+            for video_index in range(2)
+        }
+        return [by_source[0][0], *by_source[1][: count - 1]]
+
+    class SecondaryRepresentativeFailingAssessor(FakeAssessor):
+        """最初の入力元で最初の二次候補だけを遷移と判定するfake."""
+
+        def assess(
+            self,
+            *,
+            model: str,
+            model_digest: str,
+            prompt: str,
+            candidates: Sequence[FrameCandidate],
+            contact_sheet: Path,
+        ) -> list[FrameAssessment]:
+            assessments = super().assess(
+                model=model,
+                model_digest=model_digest,
+                prompt=prompt,
+                candidates=candidates,
+                contact_sheet=contact_sheet,
+            )
+            if "厳しい再評価" in prompt and not failed_secondary_ids:
+                failed_secondary_ids.add(
+                    next(
+                        candidate.frame_id
+                        for candidate in candidates
+                        if candidate.video_index == 0
+                    )
+                )
+            return [
+                replace(
+                    assessment,
+                    is_transition=assessment.frame_id in failed_secondary_ids,
+                )
+                for assessment in assessments
+            ]
+
+    monkeypatch.setattr(
+        "src.services.video_selector.select_diverse_candidates",
+        select_single_source_representative,
+    )
+    videos = (
+        tmp_path / "Sample Game Part1.mp4",
+        tmp_path / "Sample Game Part2.mp4",
+    )
+    for video in videos:
+        video.write_bytes(bytes(range(256)) * 16)
+    output_dir = tmp_path / "selected"
+    request = VideoSelectionRequest(
+        input_videos=tuple(str(video) for video in videos),
+        output_dir=str(output_dir),
+        output_count=2,
+        game_title=None,
+        game_context="",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+    extractor = FakeFrameExtractor()
+
+    SingleVideoSelector(
+        request,
+        frame_extractor=extractor,
+        assessor=SecondaryRepresentativeFailingAssessor(),
+    ).run()
+
+    work_dir = output_dir / ".game-screen-pick"
+    report = json.loads((output_dir / "report.json").read_text(encoding="utf-8"))
+    assert (work_dir / "assessments-secondary-backfill-0001.json").is_file()
+    assert {item["video_index"] for item in report["selected"]} == {1, 2}
+    assert not failed_secondary_ids & {item["frame_id"] for item in report["selected"]}
+
+    (work_dir / "completion.json").unlink()
+    (output_dir / "selected-01.jpg").unlink()
+    unavailable_assessor = UnavailableAssessor()
+    SingleVideoSelector(
+        request,
+        frame_extractor=extractor,
+        assessor=unavailable_assessor,
+    ).run()
+
+    assert unavailable_assessor.metadata_calls == 0
+    assert unavailable_assessor.assess_calls == 0
+
+
 def test_pipeline_rejects_resume_when_any_input_video_changes(tmp_path: Path) -> None:
     """2本目だけの内容変更も全体SHA-256で検出すること."""
     videos = (

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -628,6 +628,108 @@ def test_pipeline_backfills_when_secondary_survivors_cannot_fill_output(
     assert {item["video_index"] for item in report["selected"]} == {1, 2}
 
 
+def test_pipeline_assesses_new_primary_candidate_for_secondary_backfill(
+    tmp_path: Path,
+) -> None:
+    """二次追補poolが尽きた入力元は未評価候補を一次評価から補充すること."""
+    kept_primary_source = False
+    failed_primary_ids: set[str] = set()
+    failed_secondary_ids: set[str] = set()
+
+    class ExhaustedSecondaryPoolAssessor(FakeAssessor):
+        """片方の一次生存候補を1件にし、その二次評価を遷移にするfake."""
+
+        def assess(
+            self,
+            *,
+            model: str,
+            model_digest: str,
+            prompt: str,
+            candidates: Sequence[FrameCandidate],
+            contact_sheet: Path,
+        ) -> list[FrameAssessment]:
+            nonlocal kept_primary_source
+            assessments = super().assess(
+                model=model,
+                model_digest=model_digest,
+                prompt=prompt,
+                candidates=candidates,
+                contact_sheet=contact_sheet,
+            )
+            if contact_sheet.parent.name == "primary":
+                for candidate in candidates:
+                    if candidate.video_index != 0:
+                        continue
+                    if kept_primary_source:
+                        failed_primary_ids.add(candidate.frame_id)
+                    else:
+                        kept_primary_source = True
+            if contact_sheet.parent.name == "secondary":
+                failed_secondary_ids.update(
+                    candidate.frame_id
+                    for candidate in candidates
+                    if candidate.video_index == 0
+                )
+            return [
+                replace(
+                    assessment,
+                    is_transition=(
+                        assessment.frame_id in failed_primary_ids
+                        or assessment.frame_id in failed_secondary_ids
+                    ),
+                )
+                for assessment in assessments
+            ]
+
+    videos = (
+        tmp_path / "Sample Game Part1.mp4",
+        tmp_path / "Sample Game Part2.mp4",
+    )
+    for video in videos:
+        video.write_bytes(bytes(range(256)) * 16)
+    output_dir = tmp_path / "selected"
+    request = VideoSelectionRequest(
+        input_videos=tuple(str(video) for video in videos),
+        output_dir=str(output_dir),
+        output_count=2,
+        game_title=None,
+        game_context="",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+
+    extractor = FakeFrameExtractor()
+    SingleVideoSelector(
+        request,
+        frame_extractor=extractor,
+        assessor=ExhaustedSecondaryPoolAssessor(),
+    ).run()
+
+    work_dir = output_dir / ".game-screen-pick"
+    report = json.loads((output_dir / "report.json").read_text(encoding="utf-8"))
+    assert (work_dir / "assessments-primary-secondary-backfill-0001.json").is_file()
+    assert (work_dir / "assessments-secondary-backfill-0001.json").is_file()
+    assert {item["video_index"] for item in report["selected"]} == {1, 2}
+
+    (work_dir / "completion.json").unlink()
+    (output_dir / "selected-01.jpg").unlink()
+    unavailable_assessor = UnavailableAssessor()
+    SingleVideoSelector(
+        request,
+        frame_extractor=extractor,
+        assessor=unavailable_assessor,
+    ).run()
+
+    assert unavailable_assessor.metadata_calls == 0
+    assert unavailable_assessor.assess_calls == 0
+
+
 def test_pipeline_rejects_resume_when_any_input_video_changes(tmp_path: Path) -> None:
     """2本目だけの内容変更も全体SHA-256で検出すること."""
     videos = (

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -1,4 +1,4 @@
-"""単一動画production pipelineの小さな結合テスト."""
+"""1本以上の動画を扱うproduction pipelineの小さな結合テスト."""
 
 import json
 import os
@@ -21,8 +21,8 @@ from src.services.ollama_frame_assessor import (
     OllamaFrameAssessor,
     OllamaModelValidationError,
 )
-from src.services.single_video_selector import SingleVideoSelector
 from src.services.video_frame_extractor import VideoFrameExtractor
+from src.services.video_selector import VideoSelector as SingleVideoSelector
 from src.utils.video_selection_files import file_sha256
 
 
@@ -274,6 +274,183 @@ def test_pipeline_outputs_artifacts_and_reuses_completed_run(tmp_path: Path) -> 
     assert unavailable_assessor.metadata_calls == 0
     assert extractor.extract_calls == extraction_after_first_run
     assert [file_sha256(path) for path in selected_paths] == first_hashes
+
+
+def test_pipeline_selects_from_multiple_videos_and_reports_each_source(
+    tmp_path: Path,
+) -> None:
+    """複数入力を一つのrunとして選定し各入力元をreportへ残すこと."""
+    videos = (
+        tmp_path / "Sample Game Part1.mp4",
+        tmp_path / "Sample Game Part2.mp4",
+    )
+    for video in videos:
+        video.write_bytes(bytes(range(256)) * 16)
+    output_dir = tmp_path / "selected"
+    request = VideoSelectionRequest(
+        input_videos=tuple(str(video) for video in videos),
+        output_dir=str(output_dir),
+        output_count=2,
+        game_title=None,
+        game_context="",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+
+    extractor = FakeFrameExtractor()
+    assessor = FakeAssessor()
+    contact_sheet = SingleVideoSelector(
+        request,
+        frame_extractor=extractor,
+        assessor=assessor,
+    ).run()
+
+    report = json.loads((output_dir / "report.json").read_text(encoding="utf-8"))
+    assert [item["path"] for item in report["videos"]] == [
+        str(video.resolve()) for video in videos
+    ]
+    assert {item["video_index"] for item in report["selected"]} == {1, 2}
+    manifest = json.loads(
+        (output_dir / ".game-screen-pick" / "run-manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert [item["path"] for item in manifest["inputs"]] == [
+        str(video.resolve()) for video in videos
+    ]
+    extraction_count = extractor.extract_calls
+    unavailable_assessor = UnavailableAssessor()
+
+    resumed_sheet = SingleVideoSelector(
+        request,
+        frame_extractor=extractor,
+        assessor=unavailable_assessor,
+    ).run()
+
+    assert resumed_sheet == contact_sheet
+    assert extractor.extract_calls == extraction_count
+    assert unavailable_assessor.metadata_calls == 0
+    assert unavailable_assessor.assess_calls == 0
+
+
+def test_pipeline_rejects_resume_when_any_input_video_changes(tmp_path: Path) -> None:
+    """2本目だけの内容変更も全体SHA-256で検出すること."""
+    videos = (
+        tmp_path / "Sample Game Part1.mp4",
+        tmp_path / "Sample Game Part2.mp4",
+    )
+    for video in videos:
+        video.write_bytes(bytes(range(256)) * 16)
+    request = VideoSelectionRequest(
+        input_videos=tuple(str(video) for video in videos),
+        output_dir=str(tmp_path / "selected"),
+        output_count=2,
+        game_title=None,
+        game_context="",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+    SingleVideoSelector(
+        request,
+        frame_extractor=FakeFrameExtractor(),
+        assessor=FakeAssessor(),
+    ).run()
+    changed_video = videos[1]
+    original_stat = changed_video.stat()
+    with changed_video.open("r+b") as file:
+        file.seek(1024)
+        file.write(b"changed")
+    os.utime(
+        changed_video,
+        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+    )
+    unavailable_assessor = UnavailableAssessor()
+
+    with pytest.raises(RuntimeError, match="実行条件が今回と異なります"):
+        SingleVideoSelector(
+            request,
+            frame_extractor=FakeFrameExtractor(),
+            assessor=unavailable_assessor,
+        ).run()
+
+    assert unavailable_assessor.metadata_calls == 0
+
+
+def test_pipeline_rejects_duplicate_input_video_before_ollama(tmp_path: Path) -> None:
+    """同じ入力pathの重複は外部接続より前に拒否すること."""
+    video = tmp_path / "Sample Game.mp4"
+    video.write_bytes(b"video")
+    request = VideoSelectionRequest(
+        input_videos=(str(video), str(video)),
+        output_dir=str(tmp_path / "selected"),
+        output_count=2,
+        game_title=None,
+        game_context="",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+    unavailable_assessor = UnavailableAssessor()
+
+    with pytest.raises(ValueError, match="重複"):
+        SingleVideoSelector(
+            request,
+            frame_extractor=FakeFrameExtractor(),
+            assessor=unavailable_assessor,
+        ).run()
+
+    assert unavailable_assessor.metadata_calls == 0
+
+
+def test_pipeline_requires_title_when_input_names_infer_different_games(
+    tmp_path: Path,
+) -> None:
+    """入力名から同じgame titleを得られない場合は明示指定を求めること."""
+    videos = (tmp_path / "Game A Part1.mp4", tmp_path / "Game B Part1.mp4")
+    for video in videos:
+        video.write_bytes(b"video")
+    request = VideoSelectionRequest(
+        input_videos=tuple(str(video) for video in videos),
+        output_dir=str(tmp_path / "selected"),
+        output_count=2,
+        game_title=None,
+        game_context="",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+    unavailable_assessor = UnavailableAssessor()
+
+    with pytest.raises(ValueError, match="--game-title"):
+        SingleVideoSelector(
+            request,
+            frame_extractor=FakeFrameExtractor(),
+            assessor=unavailable_assessor,
+        ).run()
+
+    assert unavailable_assessor.metadata_calls == 0
 
 
 def test_pipeline_rejects_resume_when_unsampled_video_bytes_change(
@@ -576,7 +753,7 @@ def test_candidate_extraction_cancels_queued_jobs_on_interrupt(
             super().shutdown(wait=wait, cancel_futures=cancel_futures)
 
     monkeypatch.setattr(
-        "src.services.single_video_selector.ThreadPoolExecutor",
+        "src.services.video_selector.ThreadPoolExecutor",
         RecordingExecutor,
     )
     video = tmp_path / "Sample Game.mp4"
@@ -629,7 +806,7 @@ def test_context_extraction_cancels_queued_jobs_on_interrupt(
             super().shutdown(wait=wait, cancel_futures=cancel_futures)
 
     monkeypatch.setattr(
-        "src.services.single_video_selector.ThreadPoolExecutor",
+        "src.services.video_selector.ThreadPoolExecutor",
         RecordingExecutor,
     )
     video = tmp_path / "Sample Game.mp4"
@@ -687,11 +864,11 @@ def test_mechanical_preselection_cancels_queued_jobs_on_interrupt(
         raise KeyboardInterrupt
 
     monkeypatch.setattr(
-        "src.services.single_video_selector.ThreadPoolExecutor",
+        "src.services.video_selector.ThreadPoolExecutor",
         RecordingExecutor,
     )
     monkeypatch.setattr(
-        "src.services.single_video_selector.measure_candidate",
+        "src.services.video_selector.measure_candidate",
         interrupt,
     )
     video = tmp_path / "Sample Game.mp4"
@@ -729,7 +906,7 @@ def test_pipeline_does_not_retry_model_validation_failure(
     tmp_path: Path,
 ) -> None:
     """GPUやdigestの決定的な検証失敗をinference再試行しないこと."""
-    monkeypatch.setattr("src.services.single_video_selector.time.sleep", lambda _: None)
+    monkeypatch.setattr("src.services.video_selector.time.sleep", lambda _: None)
     video = tmp_path / "Sample Game.mp4"
     video.write_bytes(bytes(range(256)) * 16)
     request = VideoSelectionRequest(

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -552,6 +552,82 @@ def test_pipeline_backfills_source_when_secondary_representative_fails(
     assert unavailable_assessor.assess_calls == 0
 
 
+def test_pipeline_backfills_when_secondary_survivors_cannot_fill_output(
+    tmp_path: Path,
+) -> None:
+    """二次評価後の生存候補総数が出力枚数未満なら候補を追補すること."""
+    failed_secondary_ids: set[str] = set()
+    kept_secondary_sources: set[int] = set()
+
+    class SecondaryCountFailingAssessor(FakeAssessor):
+        """最初の二次評価で各入力元の1件以外を遷移にするfake."""
+
+        def assess(
+            self,
+            *,
+            model: str,
+            model_digest: str,
+            prompt: str,
+            candidates: Sequence[FrameCandidate],
+            contact_sheet: Path,
+        ) -> list[FrameAssessment]:
+            assessments = super().assess(
+                model=model,
+                model_digest=model_digest,
+                prompt=prompt,
+                candidates=candidates,
+                contact_sheet=contact_sheet,
+            )
+            if contact_sheet.parent.name == "secondary":
+                for candidate in candidates:
+                    if candidate.video_index in kept_secondary_sources:
+                        failed_secondary_ids.add(candidate.frame_id)
+                    else:
+                        kept_secondary_sources.add(candidate.video_index)
+            return [
+                replace(
+                    assessment,
+                    is_transition=assessment.frame_id in failed_secondary_ids,
+                )
+                for assessment in assessments
+            ]
+
+    videos = (
+        tmp_path / "Sample Game Part1.mp4",
+        tmp_path / "Sample Game Part2.mp4",
+    )
+    for video in videos:
+        video.write_bytes(bytes(range(256)) * 16)
+    output_dir = tmp_path / "selected"
+    request = VideoSelectionRequest(
+        input_videos=tuple(str(video) for video in videos),
+        output_dir=str(output_dir),
+        output_count=3,
+        game_title=None,
+        game_context="",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+
+    SingleVideoSelector(
+        request,
+        frame_extractor=FakeFrameExtractor(),
+        assessor=SecondaryCountFailingAssessor(),
+    ).run()
+
+    work_dir = output_dir / ".game-screen-pick"
+    report = json.loads((output_dir / "report.json").read_text(encoding="utf-8"))
+    assert (work_dir / "assessments-secondary-backfill-0001.json").is_file()
+    assert len(report["selected"]) == 3
+    assert {item["video_index"] for item in report["selected"]} == {1, 2}
+
+
 def test_pipeline_rejects_resume_when_any_input_video_changes(tmp_path: Path) -> None:
     """2本目だけの内容変更も全体SHA-256で検出すること."""
     videos = (

--- a/tests/services/test_video_selector.py
+++ b/tests/services/test_video_selector.py
@@ -13,8 +13,8 @@ from src.services.video_selector import (
     make_timestamps,
     measure_candidate,
     select_final_frames,
-    select_primary_backfill_candidates,
     select_primary_candidates,
+    select_source_backfill_candidates,
 )
 
 
@@ -247,7 +247,7 @@ def test_primary_backfill_uses_next_candidate_after_reservations_fail() -> None:
         for candidate in assessed
     }
 
-    backfill = select_primary_backfill_candidates(
+    backfill = select_source_backfill_candidates(
         [*source_candidates, other_candidate],
         assessed,
         assessments,

--- a/tests/services/test_video_selector.py
+++ b/tests/services/test_video_selector.py
@@ -5,13 +5,15 @@ from pathlib import Path
 import pytest
 from PIL import Image, ImageDraw
 
-from src.models.video_selection import FrameAssessment, FrameCandidate
+from src.models.video_selection import FrameAssessment, FrameCandidate, VideoMetadata
 from src.services.video_selector import (
+    allocate_automatic_sample_counts,
     difference_hash_distance,
     infer_game_title,
     make_timestamps,
     measure_candidate,
     select_final_frames,
+    select_primary_candidates,
 )
 
 
@@ -134,6 +136,81 @@ def test_make_timestamps_keeps_exact_minimum_interval_after_rounding() -> None:
     timestamps = make_timestamps(0.45, 2, None)
 
     assert timestamps == (0.1, 0.35)
+
+
+def test_automatic_sample_budget_is_allocated_across_all_videos() -> None:
+    """自動sample数を各動画で増幅せず全入力の時間へ配分すること."""
+    metadata = [VideoMetadata(3600.0, 320, 180, "fake", "30/1")] * 4
+
+    counts = allocate_automatic_sample_counts(metadata, output_count=30)
+
+    assert counts == (361, 361, 361, 361)
+    assert sum(counts) <= 4_000
+    assert all(
+        len(
+            make_timestamps(
+                item.duration_seconds,
+                1,
+                None,
+                automatic_sample_count=count,
+            )
+        )
+        == count
+        for item, count in zip(metadata, counts, strict=True)
+    )
+
+
+def test_automatic_sample_budget_caps_long_combined_inputs() -> None:
+    """既定間隔の合計が上限を超えても自動modeは4,000件へ配分すること."""
+    metadata = [VideoMetadata(3600.0, 320, 180, "fake", "30/1")] * 12
+
+    counts = allocate_automatic_sample_counts(metadata, output_count=30)
+
+    assert sum(counts) == 4_000
+    assert all(count > 0 for count in counts)
+
+
+def test_primary_shortlist_stays_bounded_with_more_sources_than_slots() -> None:
+    """入力本数が多くても一次候補を出力枚数の12倍以内へ保つこと."""
+    metadata = [VideoMetadata(4.0, 320, 180, "fake", "30/1")] * 100
+    candidates = [
+        FrameCandidate(
+            frame_id=f"f{index:05d}",
+            timestamp_seconds=1.0,
+            path="",
+            quality_score=200.0 - index,
+            difference_hash=index,
+            video_index=index,
+        )
+        for index in range(100)
+    ]
+
+    selected = select_primary_candidates(candidates, metadata, output_count=1)
+
+    assert len(selected) == 12
+    assert len({candidate.video_index for candidate in selected}) == 12
+
+
+def test_primary_shortlist_keeps_fallbacks_for_each_representable_source() -> None:
+    """全入力を出力可能なら各入力から一次評価候補を複数残すこと."""
+    metadata = [VideoMetadata(8.0, 320, 180, "fake", "30/1")] * 2
+    candidates = [
+        FrameCandidate(
+            frame_id=f"v{video_index}-f{candidate_index}",
+            timestamp_seconds=float(candidate_index),
+            path="",
+            quality_score=100.0 - candidate_index,
+            difference_hash=(video_index + 1) << (candidate_index * 8),
+            video_index=video_index,
+        )
+        for video_index in range(2)
+        for candidate_index in range(1, 4)
+    ]
+
+    selected = select_primary_candidates(candidates, metadata, output_count=2)
+
+    assert len([item for item in selected if item.video_index == 0]) >= 2
+    assert len([item for item in selected if item.video_index == 1]) >= 2
 
 
 def test_measure_candidate_rejects_black_and_scores_visible_frame(

--- a/tests/services/test_video_selector.py
+++ b/tests/services/test_video_selector.py
@@ -13,6 +13,7 @@ from src.services.video_selector import (
     make_timestamps,
     measure_candidate,
     select_final_frames,
+    select_primary_backfill_candidates,
     select_primary_candidates,
 )
 
@@ -211,6 +212,50 @@ def test_primary_shortlist_keeps_fallbacks_for_each_representable_source() -> No
 
     assert len([item for item in selected if item.video_index == 0]) >= 2
     assert len([item for item in selected if item.video_index == 1]) >= 2
+
+
+def test_primary_backfill_uses_next_candidate_after_reservations_fail() -> None:
+    """予約候補が全滅した入力元から未評価の次候補を補充すること."""
+    source_candidates = [
+        FrameCandidate(
+            frame_id=f"v1-f{index}",
+            timestamp_seconds=float(index),
+            path="",
+            quality_score=100.0 - index,
+            difference_hash=1 << (index * 8),
+            video_index=0,
+        )
+        for index in range(1, 5)
+    ]
+    other_candidate = FrameCandidate(
+        frame_id="v2-f1",
+        timestamp_seconds=1.0,
+        path="",
+        quality_score=90.0,
+        difference_hash=2,
+        video_index=1,
+    )
+    assessed = [*source_candidates[:3], other_candidate]
+    assessments = {
+        candidate.frame_id: FrameAssessment(
+            candidate.frame_id,
+            80.0,
+            candidate.video_index == 0,
+            "探索",
+            "test",
+        )
+        for candidate in assessed
+    }
+
+    backfill = select_primary_backfill_candidates(
+        [*source_candidates, other_candidate],
+        assessed,
+        assessments,
+        source_count=2,
+        output_count=2,
+    )
+
+    assert [candidate.frame_id for candidate in backfill] == ["v1-f4"]
 
 
 def test_measure_candidate_rejects_black_and_scores_visible_frame(

--- a/tests/services/test_video_selector.py
+++ b/tests/services/test_video_selector.py
@@ -6,7 +6,7 @@ import pytest
 from PIL import Image, ImageDraw
 
 from src.models.video_selection import FrameAssessment, FrameCandidate
-from src.services.single_video_selector import (
+from src.services.video_selector import (
     difference_hash_distance,
     infer_game_title,
     make_timestamps,

--- a/tests/services/test_video_selector.py
+++ b/tests/services/test_video_selector.py
@@ -15,6 +15,7 @@ from src.services.video_selector import (
     select_final_frames,
     select_primary_candidates,
     select_source_backfill_candidates,
+    source_time_scales,
 )
 
 
@@ -256,6 +257,65 @@ def test_primary_backfill_uses_next_candidate_after_reservations_fail() -> None:
     )
 
     assert [candidate.frame_id for candidate in backfill] == ["v1-f4"]
+
+
+def test_source_backfill_continues_when_survivor_count_is_short() -> None:
+    """全入力に生存候補があっても出力枚数不足なら未評価候補を補充すること."""
+    assessed = [
+        FrameCandidate("v1-live", 1.0, "", video_index=0),
+        FrameCandidate("v2-live", 1.0, "", video_index=1),
+    ]
+    remaining = [
+        FrameCandidate(
+            f"v{video_index + 1}-next-{index}",
+            float(index + 2),
+            "",
+            quality_score=90.0 - index,
+            difference_hash=1 << (video_index * 24 + index * 8),
+            video_index=video_index,
+        )
+        for video_index in range(2)
+        for index in range(3)
+    ]
+    assessments = {
+        candidate.frame_id: FrameAssessment(
+            candidate.frame_id,
+            80.0,
+            False,
+            "探索",
+            "test",
+        )
+        for candidate in assessed
+    }
+
+    backfill = select_source_backfill_candidates(
+        [*assessed, *remaining],
+        assessed,
+        assessments,
+        source_count=2,
+        output_count=3,
+    )
+
+    assert len(backfill) == 3
+    assert {candidate.video_index for candidate in backfill} == {0, 1}
+
+
+def test_source_time_scales_use_each_video_span_and_expected_share() -> None:
+    """動画ごとの相対spanをその入力へ期待する選定枚数で割ること."""
+    candidates = [
+        FrameCandidate(
+            frame_id=f"v{video_index}-{position}",
+            timestamp_seconds=video_index * 10_000.0 + position * 3600.0,
+            path="",
+            video_index=video_index,
+        )
+        for video_index in range(10)
+        for position in range(2)
+    ]
+
+    scales = source_time_scales(candidates, count=30)
+
+    assert scales == dict.fromkeys(range(10), 1200.0)
 
 
 def test_measure_candidate_rejects_black_and_scores_visible_frame(

--- a/tests/services/test_video_selector.py
+++ b/tests/services/test_video_selector.py
@@ -115,6 +115,7 @@ def test_make_timestamps_stays_before_actual_last_vfr_frame() -> None:
         last_frame_timestamp_seconds=6.5,
     )
 
+    assert timestamps[0] == 0.5
     assert timestamps[-1] <= 6.5
 
 
@@ -170,6 +171,46 @@ def test_automatic_sample_budget_caps_long_combined_inputs() -> None:
 
     assert sum(counts) == 4_000
     assert all(count > 0 for count in counts)
+
+
+def test_automatic_sample_budget_matches_early_last_frame_capacity() -> None:
+    """最終frameが早い場合も配分数と生成timestamp数が一致すること."""
+    metadata = [
+        VideoMetadata(
+            100.0,
+            320,
+            180,
+            "fake",
+            "30/1",
+            last_frame_timestamp_seconds=1.0,
+        )
+    ] * 2
+
+    counts = allocate_automatic_sample_counts(metadata, output_count=8)
+
+    assert counts == (4, 4)
+    assert all(
+        len(
+            make_timestamps(
+                item.duration_seconds,
+                8,
+                None,
+                minimum_end_margin_seconds=1 / 30,
+                last_frame_timestamp_seconds=item.last_frame_timestamp_seconds,
+                automatic_sample_count=count,
+            )
+        )
+        == count
+        for item, count in zip(metadata, counts, strict=True)
+    )
+
+
+def test_legacy_single_video_selector_import_path_is_available() -> None:
+    """旧moduleから従来のclass名をimportできること."""
+    from src.services.single_video_selector import SingleVideoSelector
+    from src.services.video_selector import VideoSelector
+
+    assert SingleVideoSelector is VideoSelector
 
 
 def test_primary_shortlist_stays_bounded_with_more_sources_than_slots() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,6 +8,30 @@ from src.main import run
 from src.models.video_selection_request import VideoSelectionRequest
 
 
+def test_video_selection_request_preserves_legacy_positional_constructor() -> None:
+    """旧単一動画requestの13引数位置指定を同じ順序で受け付けること."""
+    request = VideoSelectionRequest(
+        "input.mp4",
+        "output",
+        12,
+        "ゲーム名",
+        "探索を含む",
+        "primary",
+        "secondary",
+        "127.0.0.1:11434",
+        120.0,
+        True,
+        4,
+        2.5,
+        True,
+    )
+
+    assert request.input_videos == ("input.mp4",)
+    assert request.output_dir == "output"
+    assert request.output_count == 12
+    assert request.debug is True
+
+
 def test_cli_translates_multiple_inputs_to_video_selection_request(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,6 +27,7 @@ def test_video_selection_request_preserves_legacy_positional_constructor() -> No
     )
 
     assert request.input_videos == ("input.mp4",)
+    assert request.input_video == "input.mp4"
     assert request.output_dir == "output"
     assert request.output_count == 12
     assert request.debug is True
@@ -94,6 +95,7 @@ def test_cli_translates_multiple_inputs_to_video_selection_request(
             debug=True,
         )
     ]
+    assert captured_requests[0].input_video is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,14 +8,16 @@ from src.main import run
 from src.models.video_selection_request import VideoSelectionRequest
 
 
-def test_cli_translates_options_to_video_selection_request(
+def test_cli_translates_multiple_inputs_to_video_selection_request(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """CLIオプションが単一動画requestへ変換されること."""
-    input_video = tmp_path / "game.mp4"
+    input_video = tmp_path / "game-part-1.mp4"
+    second_input_video = tmp_path / "game-part-2.mp4"
     output_dir = tmp_path / "selected"
     input_video.write_bytes(b"video")
+    second_input_video.write_bytes(b"video")
     captured_requests: list[VideoSelectionRequest] = []
 
     def capture_request(request: VideoSelectionRequest) -> None:
@@ -46,13 +48,14 @@ def test_cli_translates_options_to_video_selection_request(
             "2.5",
             "--debug",
             str(input_video),
+            str(second_input_video),
             str(output_dir),
         ]
     )
 
     assert captured_requests == [
         VideoSelectionRequest(
-            input_video=str(input_video),
+            input_videos=(str(input_video), str(second_input_video)),
             output_dir=str(output_dir),
             output_count=12,
             game_title="ゲーム名",

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.6.1"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

- CLIを1本以上の入力動画に対応し、従来の単一動画呼び出しも維持
- 入力動画ごとの候補抽出と再開manifestを全動画横断の選定へ統合
- reportとcontact sheetへ入力動画と動画内時刻を記録
- 自動sampling budgetを全入力で最大4,000件へ配分
- 一次候補を出力枚数の12倍以内に保ち、代表可能な各入力にはfallback候補を確保
- 一次・二次評価で候補が全遷移または総数不足なら未評価候補を追補し、追補評価も再開可能に保存
- 二次追補poolが尽きた場合は未評価候補を一次評価からオンデマンドで補充
- 時間分散尺度を動画ごとの相対spanと期待選定枚数から算出
- 最終frameが早い動画でもsample配分数を生成可能なtimestamp数と一致
- 旧単一動画requestの13引数位置指定constructor、input_video読取・dataclasses.replace、single_video_selector import pathを維持
- 複数動画の再開・入力変更・重複入力・タイトル推測・候補配分を回帰テストで検証
- project versionを1.7.0へ更新

## 検証

- uv run task check
  - Ruff lint / format: 成功
  - mypy: 成功
  - pytest: 227 passed
- uv lock --check: version更新前後とも成功
- git diff --check: 成功

## 互換性と注意点

- 既存の 入力動画 出力フォルダ 形式はそのまま利用可能
- 複数動画では最後のpathを出力フォルダ、それ以前を入力動画として扱う
- 再開manifestは全入力動画の順序とSHA-256を含むため、入力の変更や並べ替え時は新しい出力フォルダが必要
- 自動modeの候補数は全入力合計4,000件以内に配分
- 明示したsample intervalで全入力合計4,000件を超える場合はintervalの拡大が必要

Closes #272
