### PR TITLE
chore: Copierテンプレートを更新

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,4 +1,4 @@
-_commit: b338731
+_commit: 1af963b
 _src_path: git@github.com:mizucopo/repo-template.git
 author_email: mizu.copo@gmail.com
 author_name: みず

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -8,9 +8,14 @@ name in agent instructions.
 
 - Create implementation issues and review-follow-up issues as GitHub Issues.
 - Read the full issue body, comments, and labels before acting on an issue.
-- Include enough context for an agent to act: source URL, affected files or
-  lines when available, problem statement, and expected resolution or open
-  question.
+- Keep issues concise and centered on the purpose, desired outcome, and problem
+  or open question. Add acceptance criteria only when they clarify what done
+  means.
+- Avoid prescribing implementation details unless they are requirements or
+  constraints. Decide the approach when implementation begins so it reflects
+  the current code, tools, and constraints.
+- Include source URLs or other evidence when needed to explain the purpose or
+  constraints.
 - Use GitHub's native issue dependencies for blocking relationships when they
   are available. Otherwise, record blockers in the issue body.
 - Treat pull requests as implementation and review surfaces, not as substitutes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.7.0"
+version = "1.7.1"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.7.0"
+version = "1.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

- `repo-template` の最新 `main`（`1af963b`）を適用
- Issue の記載方針を、目的・期待結果・問題または質問を中心とする簡潔な内容へ更新
- `.copier-answers.yml` の既存回答値を維持し、適用済み revision のみ更新

## 確認

- `uv run task check`
  - Ruff / format / mypy: 成功
  - pytest: 227 passed

## リスク・移行

- 実行時コードの変更や移行作業はありません。