### PR TITLE
feat: CLIの実行条件と処理状態をログ出力する

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.8.0"
+version = "1.9.0"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/src/main.py
+++ b/src/main.py
@@ -75,9 +75,7 @@ def _log_cli_start(
     output_dir: str,
 ) -> None:
     """project情報と実際に適用するCLI optionを起動直後に出力する."""
-    logger.info(
-        "%s %s の画像選定処理を開始します。", PROJECT_NAME, _project_version()
-    )
+    logger.info("%s %s の画像選定処理を開始します。", PROJECT_NAME, _project_version())
     options: dict[str, object] = {
         "--num": output_count,
         "--game-title": (

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,10 @@
 """game-screen-pick のCLIエントリポイント."""
 
+import json
 import logging
+import os
 import sys
+from importlib import metadata
 from pathlib import Path
 
 import click
@@ -16,6 +19,7 @@ from .utils.elapsed_log_formatter import ElapsedLogFormatter
 
 DEFAULT_PRIMARY_MODEL = "qwen3.8:27b"
 DEFAULT_SECONDARY_MODEL = "muse-glimmer:30b"
+PROJECT_NAME = "game-screen-pick"
 SUPPORTED_VIDEO_EXTENSIONS = frozenset(
     {
         ".avi",
@@ -37,6 +41,70 @@ SUPPORTED_VIDEO_EXTENSIONS = frozenset(
 console_handler = logging.StreamHandler(sys.stdout)
 console_handler.setFormatter(ElapsedLogFormatter())
 logging.basicConfig(level=logging.INFO, handlers=[console_handler], force=True)
+logger = logging.getLogger(__name__)
+
+
+def _project_version() -> str:
+    """install済みpackage metadataから実行versionを返す."""
+    return metadata.version(PROJECT_NAME)
+
+
+def _display_ollama_host(ollama_host: str | None) -> str:
+    """Ollama hostの実効入力値と自動決定元を表示用に返す."""
+    if ollama_host:
+        return ollama_host
+    if "OLLAMA_HOST" in os.environ:
+        return f"{os.environ['OLLAMA_HOST']}（自動決定: OLLAMA_HOST）"
+    return "127.0.0.1:11434（自動決定: 既定値）"
+
+
+def _log_cli_start(
+    *,
+    output_count: int,
+    game_title: str | None,
+    game_context: str,
+    primary_model: str,
+    secondary_model: str,
+    ollama_host: str | None,
+    ollama_timeout: float,
+    allow_cpu: bool,
+    ffmpeg_workers: int,
+    sample_interval_seconds: float | None,
+    debug: bool,
+    input_video_dir: str,
+    output_dir: str,
+) -> None:
+    """project情報と実際に適用するCLI optionを起動直後に出力する."""
+    logger.info(
+        "%s %s の画像選定処理を開始します。", PROJECT_NAME, _project_version()
+    )
+    options: dict[str, object] = {
+        "--num": output_count,
+        "--game-title": (
+            game_title.strip()
+            if game_title and game_title.strip()
+            else "<自動決定: 動画ファイル名>"
+        ),
+        "--game-context": game_context.strip(),
+        "--primary-model": primary_model,
+        "--secondary-model": secondary_model,
+        "--ollama-host": _display_ollama_host(ollama_host),
+        "--ollama-timeout": ollama_timeout,
+        "--allow-cpu": allow_cpu,
+        "--ffmpeg-workers": ffmpeg_workers,
+        "--sample-interval-seconds": (
+            sample_interval_seconds
+            if sample_interval_seconds is not None
+            else "<自動決定: 動画時間と選択枚数>"
+        ),
+        "--debug": debug,
+        "INPUT_VIDEO_DIR": input_video_dir,
+        "OUTPUT_DIR": output_dir,
+    }
+    logger.info(
+        "起動オプション: %s",
+        json.dumps(options, ensure_ascii=False, sort_keys=True),
+    )
 
 
 def validate_positive_int(value: int | str | None) -> int | None:
@@ -209,6 +277,21 @@ def execute(
     output_dir: str,
 ) -> None:
     """入力ディレクトリのゲーム動画全体からブログ掲載用画像を選定する."""
+    _log_cli_start(
+        output_count=output_count,
+        game_title=game_title,
+        game_context=game_context,
+        primary_model=primary_model,
+        secondary_model=secondary_model,
+        ollama_host=ollama_host,
+        ollama_timeout=ollama_timeout,
+        allow_cpu=allow_cpu,
+        ffmpeg_workers=ffmpeg_workers,
+        sample_interval_seconds=sample_interval_seconds,
+        debug=debug,
+        input_video_dir=input_video_dir,
+        output_dir=output_dir,
+    )
     input_videos = discover_input_videos(input_video_dir)
     run_video_application(
         VideoSelectionRequest(

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import math
 import os
@@ -33,6 +34,7 @@ from ..utils.contact_sheet import (
     build_contact_sheet,
     context_frame_path,
 )
+from ..utils.periodic_status_logger import periodic_status_log
 from ..utils.video_selection_files import (
     RUN_LOCK_FILENAME,
     file_sha256,
@@ -64,6 +66,7 @@ SECONDARY_BATCH_SIZE = 6
 CONTEXT_OFFSET_SECONDS = 0.35
 MAXIMUM_OUTPUT_DHASH_DISTANCE = 10
 MINIMUM_DISTINCT_DHASH_DISTANCE = 5
+STATUS_LOG_INTERVAL_SECONDS = 30.0
 
 
 @dataclass(frozen=True)
@@ -110,9 +113,14 @@ class VideoSelector:
 
     def run(self) -> Path:
         """選定を実行し、人間確認用コンタクトシートのパスを返す."""
-        self._prepare_paths()
-        with output_directory_lock(self.work_dir):
-            return self._run_locked()
+        with periodic_status_log(
+            logger,
+            "画像選定処理は動作中です",
+            interval_seconds=STATUS_LOG_INTERVAL_SECONDS,
+        ):
+            self._prepare_paths()
+            with output_directory_lock(self.work_dir):
+                return self._run_locked()
 
     def _run_locked(self) -> Path:
         """outputの排他lockを保持した状態でpipelineを実行する."""
@@ -263,6 +271,7 @@ class VideoSelector:
         self.total_duration_seconds = sum(
             source.metadata.duration_seconds for source in self.sources
         )
+        self._log_resolved_automatic_options()
         has_existing_manifest = self._restore_existing_manifest()
         if has_existing_manifest and (self.work_dir / "completion.json").is_file():
             return
@@ -285,6 +294,38 @@ class VideoSelector:
         self.manifest_digest = json_digest(manifest)
         manifest["manifest_digest"] = self.manifest_digest
         self._prepare_output_dir(manifest)
+
+    def _log_resolved_automatic_options(self) -> None:
+        """metadataから確定した自動決定optionの実効値を出力する."""
+        resolved: dict[str, object] = {}
+        if not self.request.game_title or not self.request.game_title.strip():
+            resolved["--game-title"] = self.game_title
+        if self.request.sample_interval_seconds is None:
+            sampling: list[dict[str, object]] = []
+            for source in self.sources:
+                intervals = [
+                    right - left
+                    for left, right in zip(
+                        source.timestamps[:-1],
+                        source.timestamps[1:],
+                        strict=True,
+                    )
+                ]
+                sampling.append(
+                    {
+                        "source": source.label,
+                        "candidate_count": len(source.timestamps),
+                        "effective_interval_seconds": (
+                            round(max(intervals), 6) if intervals else None
+                        ),
+                    }
+                )
+            resolved["--sample-interval-seconds"] = sampling
+        if resolved:
+            logger.info(
+                "自動決定オプション: %s",
+                json.dumps(resolved, ensure_ascii=False, sort_keys=True),
+            )
 
     def _resolve_game_title(self) -> str:
         """明示タイトル、または全入力から一致して推測したタイトルを返す."""

--- a/src/utils/periodic_status_logger.py
+++ b/src/utils/periodic_status_logger.py
@@ -1,0 +1,67 @@
+"""長時間処理中の生存状態を定期的にログ出力する."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from threading import Event, Thread
+from typing import Protocol
+
+
+class _WaitableStopEvent(Protocol):
+    """定期ログの停止待ちに必要なevent interface."""
+
+    def wait(self, timeout: float) -> bool:
+        """timeout内に停止通知を受けたか返す."""
+        ...
+
+
+def _log_until_stopped(
+    logger: logging.Logger,
+    message: str,
+    stop_event: _WaitableStopEvent,
+    *,
+    started_at: float,
+    interval_seconds: float,
+    clock: Callable[[], float],
+) -> None:
+    """停止通知を受けるまで一定間隔で動作状態を出力する."""
+    while not stop_event.wait(interval_seconds):
+        logger.info(
+            "%s（開始から%.0f秒経過）",
+            message,
+            max(0.0, clock() - started_at),
+        )
+
+
+@contextmanager
+def periodic_status_log(
+    logger: logging.Logger,
+    message: str,
+    *,
+    interval_seconds: float,
+) -> Iterator[None]:
+    """context内の処理が続く間、別threadから生存状態をログ出力する."""
+    if interval_seconds <= 0:
+        raise ValueError("定期状態ログの間隔は正の数で指定してください")
+    stop_event = Event()
+    started_at = time.monotonic()
+    thread = Thread(
+        target=_log_until_stopped,
+        args=(logger, message, stop_event),
+        kwargs={
+            "started_at": started_at,
+            "interval_seconds": interval_seconds,
+            "clock": time.monotonic,
+        },
+        name="game-screen-pick-status-logger",
+        daemon=True,
+    )
+    thread.start()
+    try:
+        yield
+    finally:
+        stop_event.set()
+        thread.join()

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -1,6 +1,7 @@
 """1本以上の動画を扱うproduction pipelineの小さな結合テスト."""
 
 import json
+import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
@@ -274,6 +275,53 @@ def test_pipeline_outputs_artifacts_and_reuses_completed_run(tmp_path: Path) -> 
     assert unavailable_assessor.metadata_calls == 0
     assert extractor.extract_calls == extraction_after_first_run
     assert [file_sha256(path) for path in selected_paths] == first_hashes
+
+
+def test_pipeline_logs_resolved_automatic_options(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """metadata確定後に自動決定したtitleとsampling条件を出力すること."""
+    video = tmp_path / "Sample Game Part3.mp4"
+    video.write_bytes(bytes(range(256)) * 16)
+    request = VideoSelectionRequest(
+        input_video=str(video),
+        output_dir=str(tmp_path / "selected"),
+        output_count=2,
+        game_title=None,
+        game_context="",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+    caplog.set_level(logging.INFO)
+
+    SingleVideoSelector(
+        request,
+        frame_extractor=FakeFrameExtractor(),
+        assessor=FakeAssessor(),
+    ).run()
+
+    messages = [record.getMessage() for record in caplog.records]
+    resolved_message = next(
+        message for message in messages if message.startswith("自動決定オプション: ")
+    )
+    resolved = json.loads(resolved_message.removeprefix("自動決定オプション: "))
+    assert resolved == {
+        "--game-title": "Sample Game",
+        "--sample-interval-seconds": [
+            {
+                "candidate_count": 13,
+                "effective_interval_seconds": 0.25,
+                "source": "v01 Sample Game Part3.mp4",
+            }
+        ],
+    }
 
 
 def test_pipeline_selects_from_multiple_videos_and_reports_each_source(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -139,9 +139,7 @@ def test_cli_logs_project_version_and_all_effective_options(
         "--game-context": "",
         "--game-title": "<自動決定: 動画ファイル名>",
         "--num": 30,
-        "--ollama-host": (
-            "http://ollama.example:11434（自動決定: OLLAMA_HOST）"
-        ),
+        "--ollama-host": ("http://ollama.example:11434（自動決定: OLLAMA_HOST）"),
         "--ollama-timeout": 900.0,
         "--primary-model": "qwen3.8:27b",
         "--sample-interval-seconds": "<自動決定: 動画時間と選択枚数>",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,7 @@
 """動画ディレクトリCLI adapterの単体テスト."""
 
+import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -105,6 +107,48 @@ def test_cli_translates_sorted_directory_videos_to_video_selection_request(
         )
     ]
     assert captured_requests[0].input_video is None
+
+
+def test_cli_logs_project_version_and_all_effective_options(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """起動直後にproject情報とdefaultを含む全optionを確認できること."""
+    input_dir = tmp_path / "recordings"
+    input_dir.mkdir()
+    (input_dir / "Sample Game Part1.mp4").write_bytes(b"video")
+    output_dir = tmp_path / "selected"
+    monkeypatch.setenv("OLLAMA_HOST", "http://ollama.example:11434")
+    monkeypatch.setattr("src.main._project_version", lambda: "1.8.0-test")
+    monkeypatch.setattr("src.main.run_video_application", lambda _request: None)
+    caplog.set_level(logging.INFO)
+
+    run([str(input_dir), str(output_dir)])
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert "game-screen-pick 1.8.0-test の画像選定処理を開始します。" in messages
+    options_message = next(
+        message for message in messages if message.startswith("起動オプション: ")
+    )
+    options = json.loads(options_message.removeprefix("起動オプション: "))
+    assert options == {
+        "--allow-cpu": False,
+        "--debug": False,
+        "--ffmpeg-workers": 2,
+        "--game-context": "",
+        "--game-title": "<自動決定: 動画ファイル名>",
+        "--num": 30,
+        "--ollama-host": (
+            "http://ollama.example:11434（自動決定: OLLAMA_HOST）"
+        ),
+        "--ollama-timeout": 900.0,
+        "--primary-model": "qwen3.8:27b",
+        "--sample-interval-seconds": "<自動決定: 動画時間と選択枚数>",
+        "--secondary-model": "muse-glimmer:30b",
+        "INPUT_VIDEO_DIR": str(input_dir),
+        "OUTPUT_DIR": str(output_dir),
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_periodic_status_logger.py
+++ b/tests/utils/test_periodic_status_logger.py
@@ -1,0 +1,39 @@
+"""periodic_status_loggerの単体テスト."""
+
+import logging
+from collections.abc import Iterator
+from unittest.mock import MagicMock, call
+
+from src.utils.periodic_status_logger import _log_until_stopped
+
+
+class FakeStopEvent:
+    """指定したwait結果を順に返すevent fake."""
+
+    def __init__(self, results: Iterator[bool]) -> None:
+        self._results = results
+
+    def wait(self, _timeout: float) -> bool:
+        """次の停止状態を返す."""
+        return next(self._results)
+
+
+def test_log_until_stopped_reports_elapsed_time_periodically() -> None:
+    """停止通知まで動作中の状態と経過秒を継続して出力すること."""
+    logger = MagicMock(spec=logging.Logger)
+    stop_event = FakeStopEvent(iter((False, False, True)))
+    clock_values = iter((130.0, 160.0))
+
+    _log_until_stopped(
+        logger,
+        "画像選定処理は動作中です",
+        stop_event,
+        started_at=100.0,
+        interval_seconds=30.0,
+        clock=lambda: next(clock_values),
+    )
+
+    assert logger.info.call_args_list == [
+        call("%s（開始から%.0f秒経過）", "画像選定処理は動作中です", 30.0),
+        call("%s（開始から%.0f秒経過）", "画像選定処理は動作中です", 60.0),
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

- CLI起動直後にgame-screen-pickの実行versionと、defaultを含む全option・位置引数をJSON形式でログ出力します。
- 自動決定したgame titleと、動画ごとの候補数・実効sample intervalをmetadata確定後にログ出力します。
- 長時間処理中は30秒間隔で生存状態と開始からの経過秒をログ出力します。
- project versionを1.9.0へ更新します。

## 検証

- UV_CACHE_DIR=/private/tmp/game-screen-pick-uv-cache uv run task check
  - Ruff lint / format
  - mypy
  - pytest: 232 passed

選定結果と再開manifestの契約は変更していません。

Closes #283