### PR TITLE
fix: CLIの実行ログを処理内容が分かる形式に整える

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.9.0"
+version = "1.9.1"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/src/main.py
+++ b/src/main.py
@@ -99,10 +99,9 @@ def _log_cli_start(
         "INPUT_VIDEO_DIR": input_video_dir,
         "OUTPUT_DIR": output_dir,
     }
-    logger.info(
-        "起動オプション: %s",
-        json.dumps(options, ensure_ascii=False, sort_keys=True),
-    )
+    logger.info("起動オプション:")
+    for option, value in options.items():
+        logger.info("  %s: %s", option, json.dumps(value, ensure_ascii=False))
 
 
 def validate_positive_int(value: int | str | None) -> int | None:

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import math
 import os
@@ -34,7 +33,6 @@ from ..utils.contact_sheet import (
     build_contact_sheet,
     context_frame_path,
 )
-from ..utils.periodic_status_logger import periodic_status_log
 from ..utils.video_selection_files import (
     RUN_LOCK_FILENAME,
     file_sha256,
@@ -66,7 +64,6 @@ SECONDARY_BATCH_SIZE = 6
 CONTEXT_OFFSET_SECONDS = 0.35
 MAXIMUM_OUTPUT_DHASH_DISTANCE = 10
 MINIMUM_DISTINCT_DHASH_DISTANCE = 5
-STATUS_LOG_INTERVAL_SECONDS = 30.0
 
 
 @dataclass(frozen=True)
@@ -113,14 +110,10 @@ class VideoSelector:
 
     def run(self) -> Path:
         """選定を実行し、人間確認用コンタクトシートのパスを返す."""
-        with periodic_status_log(
-            logger,
-            "画像選定処理は動作中です",
-            interval_seconds=STATUS_LOG_INTERVAL_SECONDS,
-        ):
-            self._prepare_paths()
-            with output_directory_lock(self.work_dir):
-                return self._run_locked()
+        self._prepare_paths()
+        logger.info("出力フォルダの実行状態を確認しています: %s", self.output_dir)
+        with output_directory_lock(self.work_dir):
+            return self._run_locked()
 
     def _run_locked(self) -> Path:
         """outputの排他lockを保持した状態でpipelineを実行する."""
@@ -213,7 +206,13 @@ class VideoSelector:
         self._prepare_paths()
         self.game_title = self._resolve_game_title()
         probed_sources: list[tuple[Path, VideoMetadata, float]] = []
-        for video in self.videos:
+        for index, video in enumerate(self.videos, start=1):
+            logger.info(
+                "入力動画の情報を確認しています: %d/%d件 %s",
+                index,
+                len(self.videos),
+                video.name,
+            )
             metadata = self.frame_extractor.probe(video)
             end_margin_seconds = max(
                 MINIMUM_ENDPOINT_MARGIN_SECONDS,
@@ -271,7 +270,6 @@ class VideoSelector:
         self.total_duration_seconds = sum(
             source.metadata.duration_seconds for source in self.sources
         )
-        self._log_resolved_automatic_options()
         has_existing_manifest = self._restore_existing_manifest()
         if has_existing_manifest and (self.work_dir / "completion.json").is_file():
             return
@@ -286,46 +284,20 @@ class VideoSelector:
         )
         if has_existing_manifest:
             return
-        self.model_metadata = self.assessor.fetch_model_metadata(
-            {self.request.primary_model, self.request.secondary_model}
+        requested_models = {
+            self.request.primary_model,
+            self.request.secondary_model,
+        }
+        logger.info(
+            "Ollamaモデル情報を確認しています: %s",
+            ", ".join(sorted(requested_models)),
         )
+        self.model_metadata = self.assessor.fetch_model_metadata(requested_models)
         self._live_validated_models.update(self.model_metadata)
         manifest = self._build_manifest()
         self.manifest_digest = json_digest(manifest)
         manifest["manifest_digest"] = self.manifest_digest
         self._prepare_output_dir(manifest)
-
-    def _log_resolved_automatic_options(self) -> None:
-        """metadataから確定した自動決定optionの実効値を出力する."""
-        resolved: dict[str, object] = {}
-        if not self.request.game_title or not self.request.game_title.strip():
-            resolved["--game-title"] = self.game_title
-        if self.request.sample_interval_seconds is None:
-            sampling: list[dict[str, object]] = []
-            for source in self.sources:
-                intervals = [
-                    right - left
-                    for left, right in zip(
-                        source.timestamps[:-1],
-                        source.timestamps[1:],
-                        strict=True,
-                    )
-                ]
-                sampling.append(
-                    {
-                        "source": source.label,
-                        "candidate_count": len(source.timestamps),
-                        "effective_interval_seconds": (
-                            round(max(intervals), 6) if intervals else None
-                        ),
-                    }
-                )
-            resolved["--sample-interval-seconds"] = sampling
-        if resolved:
-            logger.info(
-                "自動決定オプション: %s",
-                json.dumps(resolved, ensure_ascii=False, sort_keys=True),
-            )
 
     def _resolve_game_title(self) -> str:
         """明示タイトル、または全入力から一致して推測したタイトルを返す."""
@@ -414,6 +386,7 @@ class VideoSelector:
             return
         if self.assessor is None:
             raise RuntimeError("Ollama assessorが初期化されていません")
+        logger.info("Ollamaモデル情報を再確認しています: %s", model)
         live_metadata = self.assessor.fetch_model_metadata({model})
         if live_metadata.get(model) != self.model_metadata.get(model):
             raise OllamaModelValidationError(
@@ -455,6 +428,12 @@ class VideoSelector:
 
     def _input_manifest(self, source: VideoSource) -> dict[str, Any]:
         """入力動画一つ分の再開条件を返す."""
+        logger.info(
+            "入力動画の同一性を確認しています: %d/%d件 %s",
+            source.index + 1,
+            len(self.sources),
+            source.path.name,
+        )
         stat = source.path.stat()
         metadata = source.metadata
         return {
@@ -501,6 +480,7 @@ class VideoSelector:
         artifacts = payload.get("artifacts")
         if not isinstance(artifacts, list):
             raise RuntimeError("完了記録のartifactsが不正です")
+        logger.info("完了済み成果物を検証しています: %d件", len(artifacts))
         output_root = self.output_dir.resolve()
         for item in artifacts:
             if not isinstance(item, dict) or not isinstance(item.get("path"), str):
@@ -888,6 +868,12 @@ class VideoSelector:
             for attempt in range(1, 4):
                 started = time.monotonic()
                 try:
+                    logger.info(
+                        "%s評価を開始します: %d/%d batch",
+                        stage,
+                        batch_index,
+                        len(batches),
+                    )
                     assessments = self.assessor.assess(
                         model=str(self.model_metadata[model]["resolved_name"]),
                         model_digest=str(self.model_metadata[model]["digest"]),
@@ -1045,6 +1031,7 @@ contact sheet内の対象ID: {ids}
         selected: Sequence[SelectedFrame],
     ) -> list[Path]:
         """full resolution画像、report、一覧sheetを出力する."""
+        logger.info("最終画像とレポートを出力します: %d件", len(selected))
         width = max(2, len(str(self.request.output_count)))
         report_items: list[dict[str, Any]] = []
         contact_candidates: list[FrameCandidate] = []

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import math
 import os
@@ -66,6 +67,11 @@ MAXIMUM_OUTPUT_DHASH_DISTANCE = 10
 MINIMUM_DISTINCT_DHASH_DISTANCE = 5
 
 
+def _log_value(value: object) -> str:
+    """動的な値を1物理行へ安全に収まる表示へ変換する."""
+    return json.dumps(str(value), ensure_ascii=False)
+
+
 @dataclass(frozen=True)
 class VideoSource:
     """一つの入力動画と、その動画に固有の抽出条件."""
@@ -111,7 +117,10 @@ class VideoSelector:
     def run(self) -> Path:
         """選定を実行し、人間確認用コンタクトシートのパスを返す."""
         self._prepare_paths()
-        logger.info("出力フォルダの実行状態を確認しています: %s", self.output_dir)
+        logger.info(
+            "出力フォルダの実行状態を確認しています: %s",
+            _log_value(self.output_dir),
+        )
         with output_directory_lock(self.work_dir):
             return self._run_locked()
 
@@ -120,7 +129,7 @@ class VideoSelector:
         self._prepare_run()
         if self._verify_completion():
             contact_sheet = self.output_dir / "selected-contact-sheet.jpg"
-            logger.info("完了済み成果物を検証しました: %s", contact_sheet)
+            logger.info("完了済み成果物を検証しました: %s", _log_value(contact_sheet))
             return contact_sheet
 
         candidates = self._extract_candidates()
@@ -166,7 +175,7 @@ class VideoSelector:
         artifacts = self._write_selected_artifacts(selected)
         self._write_completion(artifacts)
         contact_sheet = self.output_dir / "selected-contact-sheet.jpg"
-        logger.info("画像選定が完了しました: %s", contact_sheet)
+        logger.info("画像選定が完了しました: %s", _log_value(contact_sheet))
         return contact_sheet
 
     def _prepare_paths(self) -> None:
@@ -211,7 +220,7 @@ class VideoSelector:
                 "入力動画の情報を確認しています: %d/%d件 %s",
                 index,
                 len(self.videos),
-                video.name,
+                _log_value(video.name),
             )
             metadata = self.frame_extractor.probe(video)
             end_margin_seconds = max(
@@ -290,7 +299,7 @@ class VideoSelector:
         }
         logger.info(
             "Ollamaモデル情報を確認しています: %s",
-            ", ".join(sorted(requested_models)),
+            _log_value(", ".join(sorted(requested_models))),
         )
         self.model_metadata = self.assessor.fetch_model_metadata(requested_models)
         self._live_validated_models.update(self.model_metadata)
@@ -386,7 +395,7 @@ class VideoSelector:
             return
         if self.assessor is None:
             raise RuntimeError("Ollama assessorが初期化されていません")
-        logger.info("Ollamaモデル情報を再確認しています: %s", model)
+        logger.info("Ollamaモデル情報を再確認しています: %s", _log_value(model))
         live_metadata = self.assessor.fetch_model_metadata({model})
         if live_metadata.get(model) != self.model_metadata.get(model):
             raise OllamaModelValidationError(
@@ -432,7 +441,7 @@ class VideoSelector:
             "入力動画の同一性を確認しています: %d/%d件 %s",
             source.index + 1,
             len(self.sources),
-            source.path.name,
+            _log_value(source.path.name),
         )
         stat = source.path.stat()
         metadata = source.metadata

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -282,16 +282,16 @@ def test_pipeline_logs_concrete_processing_without_generic_status(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """具体的な処理だけを出力し汎用状態と自動決定詳細を出さないこと."""
-    video = tmp_path / "Sample Game Part3.mp4"
+    video = tmp_path / "Sample Game\nPart3.mp4"
     video.write_bytes(bytes(range(256)) * 16)
     request = VideoSelectionRequest(
         input_video=str(video),
         output_dir=str(tmp_path / "selected"),
         output_count=2,
-        game_title=None,
+        game_title="Sample Game",
         game_context="",
-        primary_model="primary",
-        secondary_model="secondary",
+        primary_model="primary\nmodel",
+        secondary_model="secondary\x1bmodel",
         ollama_host="fake",
         ollama_timeout=1.0,
         allow_cpu=True,
@@ -308,10 +308,20 @@ def test_pipeline_logs_concrete_processing_without_generic_status(
     ).run()
 
     messages = [record.getMessage() for record in caplog.records]
-    assert "入力動画の情報を確認しています: 1/1件 Sample Game Part3.mp4" in messages
-    assert "入力動画の同一性を確認しています: 1/1件 Sample Game Part3.mp4" in messages
-    assert "Ollamaモデル情報を確認しています: primary, secondary" in messages
+    assert '入力動画の情報を確認しています: 1/1件 "Sample Game\\nPart3.mp4"' in messages
+    assert (
+        '入力動画の同一性を確認しています: 1/1件 "Sample Game\\nPart3.mp4"' in messages
+    )
+    assert (
+        'Ollamaモデル情報を確認しています: "primary\\nmodel, '
+        'secondary\\u001bmodel"' in messages
+    )
     assert "候補フレームを抽出します: 13/13件" in messages
+    assert all(
+        control not in message
+        for message in messages
+        for control in ("\n", "\r", "\x1b")
+    )
     assert all("画像選定処理は動作中です" not in message for message in messages)
     assert all(not message.startswith("自動決定オプション:") for message in messages)
 

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -277,11 +277,11 @@ def test_pipeline_outputs_artifacts_and_reuses_completed_run(tmp_path: Path) -> 
     assert [file_sha256(path) for path in selected_paths] == first_hashes
 
 
-def test_pipeline_logs_resolved_automatic_options(
+def test_pipeline_logs_concrete_processing_without_generic_status(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """metadata確定後に自動決定したtitleとsampling条件を出力すること."""
+    """具体的な処理だけを出力し汎用状態と自動決定詳細を出さないこと."""
     video = tmp_path / "Sample Game Part3.mp4"
     video.write_bytes(bytes(range(256)) * 16)
     request = VideoSelectionRequest(
@@ -308,20 +308,17 @@ def test_pipeline_logs_resolved_automatic_options(
     ).run()
 
     messages = [record.getMessage() for record in caplog.records]
-    resolved_message = next(
-        message for message in messages if message.startswith("自動決定オプション: ")
+    assert (
+        "入力動画の情報を確認しています: 1/1件 Sample Game Part3.mp4" in messages
     )
-    resolved = json.loads(resolved_message.removeprefix("自動決定オプション: "))
-    assert resolved == {
-        "--game-title": "Sample Game",
-        "--sample-interval-seconds": [
-            {
-                "candidate_count": 13,
-                "effective_interval_seconds": 0.25,
-                "source": "v01 Sample Game Part3.mp4",
-            }
-        ],
-    }
+    assert (
+        "入力動画の同一性を確認しています: 1/1件 Sample Game Part3.mp4"
+        in messages
+    )
+    assert "Ollamaモデル情報を確認しています: primary, secondary" in messages
+    assert "候補フレームを抽出します: 13/13件" in messages
+    assert all("画像選定処理は動作中です" not in message for message in messages)
+    assert all(not message.startswith("自動決定オプション:") for message in messages)
 
 
 def test_pipeline_selects_from_multiple_videos_and_reports_each_source(

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -308,13 +308,8 @@ def test_pipeline_logs_concrete_processing_without_generic_status(
     ).run()
 
     messages = [record.getMessage() for record in caplog.records]
-    assert (
-        "入力動画の情報を確認しています: 1/1件 Sample Game Part3.mp4" in messages
-    )
-    assert (
-        "入力動画の同一性を確認しています: 1/1件 Sample Game Part3.mp4"
-        in messages
-    )
+    assert "入力動画の情報を確認しています: 1/1件 Sample Game Part3.mp4" in messages
+    assert "入力動画の同一性を確認しています: 1/1件 Sample Game Part3.mp4" in messages
     assert "Ollamaモデル情報を確認しています: primary, secondary" in messages
     assert "候補フレームを抽出します: 13/13件" in messages
     assert all("画像選定処理は動作中です" not in message for message in messages)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -128,25 +128,22 @@ def test_cli_logs_project_version_and_all_effective_options(
 
     messages = [record.getMessage() for record in caplog.records]
     assert "game-screen-pick 1.8.0-test の画像選定処理を開始します。" in messages
-    options_message = next(
-        message for message in messages if message.startswith("起動オプション: ")
-    )
-    options = json.loads(options_message.removeprefix("起動オプション: "))
-    assert options == {
-        "--allow-cpu": False,
-        "--debug": False,
-        "--ffmpeg-workers": 2,
-        "--game-context": "",
-        "--game-title": "<自動決定: 動画ファイル名>",
-        "--num": 30,
-        "--ollama-host": ("http://ollama.example:11434（自動決定: OLLAMA_HOST）"),
-        "--ollama-timeout": 900.0,
-        "--primary-model": "qwen3.8:27b",
-        "--sample-interval-seconds": "<自動決定: 動画時間と選択枚数>",
-        "--secondary-model": "muse-glimmer:30b",
-        "INPUT_VIDEO_DIR": str(input_dir),
-        "OUTPUT_DIR": str(output_dir),
-    }
+    assert "起動オプション:" in messages
+    assert [message for message in messages if message.startswith("  ")] == [
+        "  --num: 30",
+        '  --game-title: "<自動決定: 動画ファイル名>"',
+        '  --game-context: ""',
+        '  --primary-model: "qwen3.8:27b"',
+        '  --secondary-model: "muse-glimmer:30b"',
+        '  --ollama-host: "http://ollama.example:11434（自動決定: OLLAMA_HOST）"',
+        "  --ollama-timeout: 900.0",
+        "  --allow-cpu: false",
+        "  --ffmpeg-workers: 2",
+        '  --sample-interval-seconds: "<自動決定: 動画時間と選択枚数>"',
+        "  --debug: false",
+        f"  INPUT_VIDEO_DIR: {json.dumps(str(input_dir), ensure_ascii=False)}",
+        f"  OUTPUT_DIR: {json.dumps(str(output_dir), ensure_ascii=False)}",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.9.0"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

- 起動オプションを1項目ずつ別のログ行へ出力するように変更
- 汎用的な動作中ログと自動決定オプションの詳細ログを停止
- 入力動画、Ollamaモデル、評価batch、成果物出力など具体的な処理内容をログへ追加
- ファイル名やモデル名などの動的な値をエスケープし、改行・端末制御文字でログ行が分断されないように修正
- プロジェクトバージョンを1.9.1へ更新

## 検証

- `UV_CACHE_DIR=/private/tmp/game-screen-pick-uv-cache uv run task check`
  - Ruff check / format check: 成功
  - mypy: 成功
  - pytest: 232 passed

Closes #285