### PR TITLE
chore: repo-templateを最新版へ更新する

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,4 +1,4 @@
-_commit: 1af963b
+_commit: 3fc0cdb
 _src_path: git@github.com:mizucopo/repo-template.git
 author_email: mizu.copo@gmail.com
 author_name: みず

--- a/.github/scripts/authorize-release-latest.sh
+++ b/.github/scripts/authorize-release-latest.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+latest_ref="refs/heads/automation/release-latest"
+latest_tracking_ref="refs/remotes/origin/automation/release-latest"
+
+load_latest() {
+  latest_commit=""
+  latest_source_sha=""
+  latest_release_tag=""
+
+  set +e
+  marker_line="$(git ls-remote --exit-code --refs origin "$latest_ref")"
+  marker_status=$?
+  set -e
+  case "$marker_status" in
+    0)
+      latest_commit="${marker_line%%[[:space:]]*}"
+      git fetch --force origin "$latest_ref:$latest_tracking_ref"
+      marker_body="$(git show -s --format=%B "$latest_tracking_ref")"
+      latest_source_sha="$(printf '%s\n' "$marker_body" | sed -n 's/^source-sha: //p')"
+      latest_release_tag="$(printf '%s\n' "$marker_body" | sed -n 's/^release-tag: //p')"
+      if [[ ! "$latest_source_sha" =~ ^[0-9a-f]{40}$ ]] \
+        || [[ ! "$latest_release_tag" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]*$ ]]; then
+        echo "The latest release marker is invalid." >&2
+        exit 1
+      fi
+      ;;
+    2) ;;
+    *)
+      echo "Could not inspect the latest release marker." >&2
+      exit 1
+      ;;
+  esac
+}
+
+operation="${1:-read}"
+case "$operation" in
+  record)
+    : "${RELEASE_TAG:?RELEASE_TAG is required}"
+    if [[ ! "$RELEASE_TAG" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]*$ ]]; then
+      echo "The release tag is invalid." >&2
+      exit 1
+    fi
+
+    attempt=0
+    while true; do
+      attempt=$((attempt + 1))
+      load_latest
+
+      if [ "$latest_source_sha" = "$GITHUB_SHA" ]; then
+        if [ "$latest_release_tag" != "$RELEASE_TAG" ]; then
+          echo "The current commit already has a different latest release tag." >&2
+          exit 1
+        fi
+        exit 0
+      fi
+
+      if [ -n "$latest_source_sha" ]; then
+        if git merge-base --is-ancestor "$GITHUB_SHA" "$latest_source_sha"; then
+          exit 0
+        fi
+        if ! git merge-base --is-ancestor "$latest_source_sha" "$GITHUB_SHA"; then
+          echo "The latest release marker is not on the current release history." >&2
+          exit 1
+        fi
+      fi
+
+      next_latest_commit="$(
+        printf 'Release latest marker\n\nsource-sha: %s\nrelease-tag: %s\n' \
+          "$GITHUB_SHA" "$RELEASE_TAG" \
+          | git -c user.name=github-actions -c user.email=github-actions@github.com \
+            commit-tree "$(git rev-parse 'HEAD^{tree}')" -p "$GITHUB_SHA"
+      )"
+      if git push \
+        --force-with-lease="$latest_ref:$latest_commit" \
+        origin "${next_latest_commit}:$latest_ref"; then
+        exit 0
+      fi
+
+      expected_latest_commit="$latest_commit"
+      load_latest
+      if [ "$latest_commit" = "$expected_latest_commit" ]; then
+        echo "Could not update the latest release marker; the remote marker did not change." >&2
+        exit 1
+      fi
+
+      backoff_seconds=$((attempt < 5 ? attempt : 5))
+      sleep "$backoff_seconds"
+    done
+    ;;
+  read)
+    load_latest
+    if [ -z "$latest_source_sha" ]; then
+      echo "The latest release marker does not exist." >&2
+      exit 1
+    fi
+    {
+      echo "source_sha=$latest_source_sha"
+      echo "release_tag=$latest_release_tag"
+    } >> "$GITHUB_OUTPUT"
+    ;;
+  *)
+    echo "Usage: $0 {record|read}" >&2
+    exit 2
+    ;;
+esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,3 +193,30 @@ jobs:
 
           - [Source Code](${{ github.server_url }}/${{ github.repository }}/tree/$TAG)
           "
+
+      - name: Record latest release
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.version }}
+        run: bash .github/scripts/authorize-release-latest.sh record
+
+  promote-latest:
+    needs: release
+    concurrency:
+      group: release-latest
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Read latest release
+        id: latest-state
+        run: bash .github/scripts/authorize-release-latest.sh read
+
+      - name: Mark GitHub Release as latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.latest-state.outputs.release_tag }}
+        run: gh release edit "$TAG" --latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.13.0"
+version = "1.13.1"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.13.0"
+version = "1.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

- `repo-template/main` の `3fc0cdb` を Copier で取り込む
- Release の完成状態を専用 ref に記録し、最新の完成済み Release だけを GitHub の Latest へ昇格する
- project version と root lock entry を `1.13.1` へ更新する

Closes #302

## 確認

- `uv run task check`（pytest 366件を含む）
- `uv lock --check`（version 更新前後）
- `bash -n .github/scripts/authorize-release-latest.sh`
- `git diff --check`

## 留意点

- Release workflow の変更は `repo-template` の生成物をそのまま採用している
- 対象 template commit の template quality checks と CodeQL は成功済み
