### PR TITLE
docs: 起動方法の例を簡素化

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,21 @@ Ollamaのvision modelで画面遷移中のframeや近い重複を避けながら
 uv sync
 ```
 
-Game Contextと、動画を置いたInput Video Directory、空のOutput Folderを指定して
+ゲームタイトルと、動画を置いたInput Video Directory、空のOutput Folderを指定して
 実行します。標準では30枚を選びます。
 
 ```bash
 uv run game-screen-pick \
-  --game-context "ジャンル: RPG。探索と会話を進める。代表的な画面はフィールド、会話、戦闘。景観と人物が明瞭な画像を重視する。" \
+  --game-title "ドラクエ11" \
   ./recordings \
   ./recordings-selected
 ```
 
-Game Contextを直接書く代わりに、`--game-title`からWeb検索で生成することもできます。
+Web検索でGame Contextを生成する代わりに、直接指定することもできます。
 
 ```bash
-OLLAMA_API_KEY=... uv run game-screen-pick \
-  --game-title "ドラクエ11" \
+uv run game-screen-pick \
+  --game-context "ジャンル: RPG。探索と会話を進める。代表的な画面はフィールド、会話、戦闘。景観と人物が明瞭な画像を重視する。" \
   ./recordings \
   ./recordings-selected
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ uv sync
 ```
 
 ゲームタイトルと、動画を置いたInput Video Directory、空のOutput Folderを指定して
-実行します。標準では30枚を選びます。
+実行します。`--game-title`を使う場合は、事前に環境変数`OLLAMA_API_KEY`を
+設定してください。標準では30枚を選びます。
 
 ```bash
 uv run game-screen-pick \

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Ollamaのvision modelで画面遷移中のframeや近い重複を避けながら
 uv sync
 ```
 
-ゲームタイトルと、動画を置いたInput Video Directory、空のOutput Folderを指定して
-実行します。`--game-title`を使う場合は、事前に環境変数`OLLAMA_API_KEY`を
-設定してください。標準では30枚を選びます。
+Game Titleと、動画を置いたInput Video Directory、空のOutput Folderを指定して
+実行します。既定のOllama providerで`--game-title`を使う場合は、事前に
+環境変数`OLLAMA_API_KEY`を設定してください。標準では30枚を選びます。
 
 ```bash
 uv run game-screen-pick \

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ uv sync
 ```
 
 Game Titleと、動画を置いたInput Video Directory、空のOutput Folderを指定して
-実行します。既定のOllama providerで`--game-title`を使う場合は、事前に
-環境変数`OLLAMA_API_KEY`を設定してください。標準では30枚を選びます。
+実行します。
 
 ```bash
 uv run game-screen-pick \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.13.2"
+version = "1.13.3"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.13.2"
+version = "1.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

- 起動方法の主な例を `--game-title` に変更し、正規の `Game Title` 用語へ統一
- `OLLAMA_API_KEY=...` をコマンド例から削除
- `--game-context` の直接指定例を代替手順として掲載
- プロジェクトバージョンを 1.13.3 に更新

## 確認

- `uv lock --check`
- `uv run task check`（Ruff、format、mypy、pytest 366件）