### PR TITLE
feat: 選択枚数を必須化して上限を999枚に拡張

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ Ollamaのvision modelで画面遷移中のframeや近い重複を避けながら
 uv sync
 ```
 
-Game Titleと、動画を置いたInput Video Directory、空のOutput Folderを指定して
-実行します。
+選択枚数、Game Title、動画を置いたInput Video Directory、空のOutput Folderを
+指定して実行します。
 
 ```bash
 uv run game-screen-pick \
+  -n 30 \
   --game-title "ドラクエ11" \
   ./recordings \
   ./recordings-selected
@@ -33,6 +34,7 @@ Web検索でGame Contextを生成する代わりに、直接指定すること�
 
 ```bash
 uv run game-screen-pick \
+  -n 30 \
   --game-context "ジャンル: RPG。探索と会話を進める。代表的な画面はフィールド、会話、戦闘。景観と人物が明瞭な画像を重視する。" \
   ./recordings \
   ./recordings-selected

--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -12,7 +12,7 @@ uv run game-screen-pick [オプション] <入力動画ディレクトリ> <出�
 ### オプション
 
 - `-c`, `--config`: TOML設定ファイル（既定: `config.toml`）
-- `-n`, `--num`: 選択枚数（1から600、既定: 30）
+- `-n`, `--num`: 選択枚数（必須、1から999）
 - `--game-title`: Web検索からGame Contextを生成するためのゲーム表記
 - `--game-context`: 画像評価に直接使用するGame Context
 
@@ -108,6 +108,7 @@ editionを一意に判別できない場合、情報が不足する場合、情�
 
 ```bash
 OPENAI_API_KEY=... uv run game-screen-pick \
+  -n 30 \
   --game-title "ドラクエ11" \
   ./recordings \
   ./recordings-selected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.13.3"
+version = "1.14.0"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/src/main.py
+++ b/src/main.py
@@ -141,7 +141,7 @@ def validate_positive_float(value: float | str | None) -> float | None:
 
 
 def validate_output_count(value: int | str | None) -> int | None:
-    """選択枚数をcontact sheetがJPEGに収まる範囲へ制限する."""
+    """選択枚数を対応範囲へ制限する."""
     output_count = validate_positive_int(value)
     if output_count is not None and output_count > MAXIMUM_OUTPUT_COUNT:
         raise click.BadParameter(
@@ -323,8 +323,7 @@ def validate_game_context_input(
     "-n",
     "--num",
     "output_count",
-    default=30,
-    show_default=True,
+    required=True,
     type=int,
     callback=lambda _ctx, _param, value: validate_output_count(value),
     help=f"選択枚数（1から{MAXIMUM_OUTPUT_COUNT}）",

--- a/src/models/video_selection_request.py
+++ b/src/models/video_selection_request.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-MAXIMUM_OUTPUT_COUNT = 600
+MAXIMUM_OUTPUT_COUNT = 999
 MINIMUM_SAMPLE_INTERVAL_SECONDS = 0.25
 _MISSING = object()
 

--- a/src/utils/contact_sheet.py
+++ b/src/utils/contact_sheet.py
@@ -12,6 +12,8 @@ from PIL import Image, ImageDraw
 from ..models.video_selection import FrameCandidate
 from .video_selection_files import create_exclusive_temporary_file
 
+_MAXIMUM_JPEG_DIMENSION = 65_000
+
 
 def context_frame_path(
     context_dir: Path,
@@ -49,6 +51,18 @@ def build_contact_sheet(
         columns = 3
 
     rows = math.ceil(len(candidates) / columns)
+    width = cell_width * columns
+    height = (image_height + label_height) * rows
+    scale = min(
+        1.0,
+        _MAXIMUM_JPEG_DIMENSION / width,
+        _MAXIMUM_JPEG_DIMENSION / height,
+    )
+    if scale < 1.0:
+        cell_width = max(1, math.floor(cell_width * scale))
+        image_height = max(1, math.floor(image_height * scale))
+        label_height = max(1, math.floor(label_height * scale))
+
     sheet = Image.new(
         "RGB",
         (cell_width * columns, (image_height + label_height) * rows),

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -17,6 +17,7 @@ from PIL import Image, ImageDraw
 from src.models.video_selection import (
     FrameAssessment,
     FrameCandidate,
+    SelectedFrame,
     VideoMetadata,
 )
 from src.models.video_selection_request import VideoSelectionRequest
@@ -417,6 +418,81 @@ def test_pipeline_outputs_artifacts_and_reuses_completed_run(tmp_path: Path) -> 
     assert "game_context_generation" not in manifest
     assert all("ゲーム『" not in prompt for prompt in assessor.prompts)
     assert all("テスト用のGame Context" in prompt for prompt in assessor.prompts)
+
+
+def test_pipeline_writes_all_final_artifacts_for_999_selected_images(
+    tmp_path: Path,
+) -> None:
+    """999枚の個別画像、report、読み取り可能な一覧sheetを出力すること."""
+
+    class LongVideoExtractor(FakeFrameExtractor):
+        """999枚分のSample Positionを持てる動画情報を返すfake."""
+
+        def probe(self, video: Path) -> VideoMetadata:
+            assert video.is_file()
+            self.probe_calls += 1
+            return VideoMetadata(1000.0, 320, 180, "fake", "30/1")
+
+    video = tmp_path / "Sample Game.mp4"
+    video.write_bytes(bytes(range(256)) * 16)
+    output_dir = tmp_path / "selected"
+    request = VideoSelectionRequest(
+        input_video=str(video),
+        output_dir=str(output_dir),
+        output_count=999,
+        game_title=None,
+        game_context="テスト用のGame Context",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+    extractor = LongVideoExtractor()
+    selector = SingleVideoSelector(
+        request,
+        frame_extractor=extractor,
+        assessor=FakeAssessor(),
+    )
+    selector._prepare_run()
+    candidate_path = tmp_path / "candidate.jpg"
+    extractor.extract_frame(
+        video,
+        0.0,
+        candidate_path,
+        max_width=960,
+    )
+    measured = measure_candidate(FrameCandidate("f00001", 0.0, str(candidate_path)))
+    assert measured is not None
+    selected = []
+    for index in range(1, 1000):
+        frame_id = f"f{index:05d}"
+        candidate = replace(measured, frame_id=frame_id)
+        assessment = FrameAssessment(
+            frame_id=frame_id,
+            blog_score=80.0,
+            is_transition=False,
+            scene="探索",
+            reason="test",
+        )
+        selected.append(SelectedFrame(candidate, 80.0, assessment, assessment))
+
+    selector._write_selected_artifacts(selected)
+
+    selected_paths = sorted(output_dir.glob("selected-[0-9][0-9][0-9].jpg"))
+    assert len(selected_paths) == 999
+    assert selected_paths[0].name == "selected-001.jpg"
+    assert selected_paths[-1].name == "selected-999.jpg"
+    report = json.loads((output_dir / "report.json").read_text(encoding="utf-8"))
+    assert report["output_count"] == 999
+    assert len(report["selected"]) == 999
+    with Image.open(output_dir / "selected-contact-sheet.jpg") as sheet:
+        assert sheet.format == "JPEG"
+        assert max(sheet.size) <= 65_000
+        sheet.verify()
 
 
 @pytest.mark.parametrize("cache_relative_output", [".", "output"])
@@ -2001,16 +2077,16 @@ def test_pipeline_uses_resolved_ollama_model_name(tmp_path: Path) -> None:
     assert set(assessor.assessed_models) == {"llava:latest"}
 
 
-def test_pipeline_rejects_output_count_above_contact_sheet_limit(
+def test_pipeline_rejects_output_count_above_maximum(
     tmp_path: Path,
 ) -> None:
-    """JPEG一覧を生成できない枚数を高価な処理前に拒否すること."""
+    """上限を超える選択枚数を高価な処理前に拒否すること."""
     video = tmp_path / "Sample Game.mp4"
     video.write_bytes(bytes(range(256)) * 16)
     request = VideoSelectionRequest(
         input_video=str(video),
         output_dir=str(tmp_path / "selected"),
-        output_count=601,
+        output_count=1000,
         game_title=None,
         game_context="テスト用のGame Context",
         primary_model="primary",
@@ -2023,7 +2099,7 @@ def test_pipeline_rejects_output_count_above_contact_sheet_limit(
         debug=False,
     )
 
-    with pytest.raises(ValueError, match="600以下"):
+    with pytest.raises(ValueError, match="999以下"):
         SingleVideoSelector(
             request,
             frame_extractor=FakeFrameExtractor(),
@@ -3138,7 +3214,7 @@ def test_pipeline_allocates_explicit_sample_minimum_across_long_input_videos(
     request = VideoSelectionRequest(
         input_videos=tuple(str(video) for video in videos),
         output_dir=str(tmp_path / "selected"),
-        output_count=600,
+        output_count=999,
         game_title=None,
         game_context="テスト用のGame Context",
         primary_model="primary",
@@ -3158,7 +3234,7 @@ def test_pipeline_allocates_explicit_sample_minimum_across_long_input_videos(
 
     selector._prepare_run()
 
-    assert sum(len(source.timestamps) for source in selector.sources) == 600
+    assert sum(len(source.timestamps) for source in selector.sources) == 999
 
 
 def test_pipeline_plans_more_than_legacy_combined_candidate_limit(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -118,7 +118,7 @@ def test_cli_logs_project_version_and_all_effective_settings(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """起動直後にproject情報とdefaultを含む全設定を確認できること."""
+    """起動直後にproject情報と明示した選択枚数を含む全設定を確認できること."""
     input_dir = tmp_path / "recordings"
     input_dir.mkdir()
     (input_dir / "Sample Game Part1.mp4").write_bytes(b"video")
@@ -128,7 +128,16 @@ def test_cli_logs_project_version_and_all_effective_settings(
     monkeypatch.setattr("src.main.run_video_application", lambda _request: None)
     caplog.set_level(logging.INFO)
 
-    run(["--game-context", "探索を含む", str(input_dir), str(output_dir)])
+    run(
+        [
+            "-n",
+            "30",
+            "--game-context",
+            "探索を含む",
+            str(input_dir),
+            str(output_dir),
+        ]
+    )
 
     messages = [record.getMessage() for record in caplog.records]
     assert "game-screen-pick 1.8.0-test の画像選定処理を開始します。" in messages
@@ -158,7 +167,7 @@ def test_cli_logs_project_version_and_all_effective_settings(
     [
         (["-n", "0"], "正の整数"),
         (["-n", "-1"], "正の整数"),
-        (["-n", "601"], "600以下"),
+        (["-n", "1000"], "999以下"),
     ],
 )
 def test_cli_rejects_invalid_numeric_options(
@@ -183,6 +192,55 @@ def test_cli_rejects_invalid_numeric_options(
     assert error_pattern in capsys.readouterr().err
 
 
+def test_cli_requires_output_count_before_application(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """選択枚数を省略するとapplication開始前のusage errorになること."""
+    input_dir = tmp_path / "recordings"
+    input_dir.mkdir()
+    (input_dir / "game.mp4").write_bytes(b"video")
+    monkeypatch.setattr(
+        "src.main.run_video_application",
+        lambda _request: pytest.fail("applicationは呼ばれないこと"),
+    )
+
+    result = CliRunner().invoke(
+        execute,
+        ["--game-context", "探索を含む", str(input_dir), str(tmp_path / "selected")],
+    )
+
+    assert result.exit_code == 2
+    assert "Missing option '-n' / '--num'" in result.output
+
+
+@pytest.mark.parametrize("output_count", [1, 999])
+def test_cli_accepts_boundary_output_counts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    output_count: int,
+) -> None:
+    """選択枚数の下限と上限をapplicationへ渡すこと."""
+    input_dir = tmp_path / "recordings"
+    input_dir.mkdir()
+    (input_dir / "game.mp4").write_bytes(b"video")
+    captured_requests: list[VideoSelectionRequest] = []
+    monkeypatch.setattr("src.main.run_video_application", captured_requests.append)
+
+    run(
+        [
+            "-n",
+            str(output_count),
+            "--game-context",
+            "探索を含む",
+            str(input_dir),
+            str(tmp_path / "selected"),
+        ]
+    )
+
+    assert captured_requests[0].output_count == output_count
+
+
 def test_cli_rejects_a_file_as_input(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -197,7 +255,7 @@ def test_cli_rejects_a_file_as_input(
     )
 
     with pytest.raises(SystemExit):
-        run([str(input_video), str(tmp_path / "selected")])
+        run(["-n", "1", str(input_video), str(tmp_path / "selected")])
 
     assert "入力動画ディレクトリが見つかりません" in capsys.readouterr().err
 
@@ -220,7 +278,7 @@ def test_cli_rejects_directory_without_supported_videos(
     )
 
     with pytest.raises(SystemExit):
-        run([str(input_dir), str(tmp_path / "selected")])
+        run(["-n", "1", str(input_dir), str(tmp_path / "selected")])
 
     assert "処理対象の動画が見つかりません" in capsys.readouterr().err
 
@@ -234,6 +292,8 @@ def test_cli_help_describes_directory_input() -> None:
     assert "INPUT_VIDEO..." not in result.output
     assert "-c, --config FILE" in result.output
     assert "-n, --num INTEGER" in result.output
+    assert "選択枚数（1から999）" in result.output
+    assert "[required]" in result.output
     assert "--game-title TEXT" in result.output
     assert "--game-context TEXT" in result.output
     for removed_option in (
@@ -277,7 +337,7 @@ def test_cli_rejects_game_title_and_game_context_without_exactly_one_input(
     )
 
     with pytest.raises(SystemExit):
-        run([*context_args, str(input_dir), str(tmp_path / "selected")])
+        run(["-n", "1", *context_args, str(input_dir), str(tmp_path / "selected")])
 
     assert "--game-titleと--game-contextのどちらか一方" in capsys.readouterr().err
 
@@ -450,6 +510,6 @@ def test_cli_rejects_invalid_config_before_application(
     )
 
     with pytest.raises(SystemExit):
-        run(["-c", str(config_path), "missing-input", "output"])
+        run(["-n", "1", "-c", str(config_path), "missing-input", "output"])
 
     assert error_pattern in capsys.readouterr().err

--- a/tests/utils/test_contact_sheet.py
+++ b/tests/utils/test_contact_sheet.py
@@ -33,6 +33,30 @@ def test_build_contact_sheet_outputs_readable_selected_image(
         assert sheet.size == (1440, 604)
 
 
+def test_build_contact_sheet_outputs_readable_jpeg_for_999_images(
+    tmp_path: Path,
+) -> None:
+    """999枚の選定画像をJPEGの寸法上限内の一枚へまとめること."""
+    image_path = tmp_path / "candidate.jpg"
+    Image.new("RGB", (16, 9), "white").save(image_path)
+    candidates = [
+        FrameCandidate(
+            frame_id=f"{index:03d}",
+            timestamp_seconds=float(index),
+            path=str(image_path),
+        )
+        for index in range(1, 1000)
+    ]
+    output_path = tmp_path / "selected-contact-sheet.jpg"
+
+    build_contact_sheet(candidates, output_path)
+
+    with Image.open(output_path) as sheet:
+        assert sheet.format == "JPEG"
+        assert max(sheet.size) <= 65_000
+        sheet.verify()
+
+
 def test_build_context_sheet_uses_before_and_after_frames(tmp_path: Path) -> None:
     """二次評価sheetが直前・対象・直後の三枚を含むこと."""
     candidate_path = tmp_path / "candidate.jpg"

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.13.3"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

- -n/--num を必須化し、1から999の範囲を高価な処理前に検証します
- 大量枚数ではコンタクトシートのセルを同比率で縮小し、999枚でもJPEG寸法上限内に収めます
- CLIヘルプ、README、技術リファレンスを新しい必須指定と上限へ更新します
- project versionを1.14.0へ更新します

## 検証

- uv run task check（371 tests passed）
- uv lock --check（version更新前後）
- 999枚の個別画像、report.json、読み取り可能なselected-contact-sheet.jpgを結合テストで確認

Closes #307