### PR TITLE
fix: Ollama評価で短い表示IDを使用する

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,6 +48,12 @@ _Avoid_: beginning-only sampling, random timestamp, fixed candidate cap
 Sample Positionから一定量ずつ抽出・機械評価し、ブログ画像になる可能性があるframe。暗転、白飛び、ほぼ単色のframeは含まない。
 _Avoid_: selected output, every decoded frame, all pending jobs submitted at once
 
+**Frame Display ID**:
+一つのOllama評価batch内だけでFrame Candidateへ割り当てる`A01`形式の短い連番。
+contact sheet、prompt、応答検証だけに使い、評価結果は対応する安定Frame Candidate IDへ
+戻してからAssessment Cacheへ保存する。
+_Avoid_: persisted identity, long stable ID in Ollama prompt, accepting unknown or duplicate ID
+
 **Primary Candidate**:
 Frame Candidateを機械的品質と時間分散で絞った、一次Ollama評価の対象。
 _Avoid_: final output, title-specific category

--- a/docs/adr/0008-cache-video-selection-phases-by-input-video.md
+++ b/docs/adr/0008-cache-video-selection-phases-by-input-video.md
@@ -45,6 +45,12 @@ while preserving compatible earlier phases.
 Automatic Sample Positions and Frame Candidate IDs are derived independently
 for each Input Video. They do not depend on the video's position in the current
 input set, so adding another video does not rename or resample unchanged videos.
+Those stable IDs remain cache identities but are not shown to Ollama. Each
+assessment batch assigns short Frame Display IDs (`A01`, `A02`, ...), uses them
+consistently in the contact sheet, prompt, and response validation, and maps an
+exactly-once complete response back to stable IDs before checkpointing. A retry
+after an invalid response includes the validation error and expected display
+IDs instead of repeating the identical deterministic prompt.
 Issue #300 removes the fixed per-video and combined-run candidate limits without
 changing that identity contract. Candidate extraction and mechanical analysis
 keep only a worker-bounded window of unfinished jobs, while Ollama assessment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.14.0"
+version = "1.14.1"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/src/services/ollama_frame_assessor.py
+++ b/src/services/ollama_frame_assessor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json
 import math
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, Sequence
 from urllib.parse import urlsplit, urlunsplit
@@ -14,6 +15,14 @@ from ..models.video_selection import FrameAssessment, FrameCandidate
 
 MODEL_OPTIONS = {"temperature": 0, "seed": 271}
 MINIMUM_GPU_MEMORY_RATIO = 0.5
+
+
+def batch_display_frame_ids(candidate_count: int) -> tuple[str, ...]:
+    """Ollama batch内だけで使う短い連番表示IDを返す."""
+    if candidate_count < 0:
+        raise ValueError("candidate数は0以上で指定してください")
+    width = max(2, len(str(candidate_count)))
+    return tuple(f"A{index:0{width}d}" for index in range(1, candidate_count + 1))
 
 
 class OllamaModelValidationError(RuntimeError):
@@ -150,21 +159,24 @@ class OllamaFrameAssessor:
         assessments_by_id: dict[str, FrameAssessment] = {}
         for item in frames:
             assessment = self._assessment_from_item(item)
-            previous = assessments_by_id.get(assessment.frame_id)
-            if previous is not None and previous != assessment:
+            if assessment.frame_id in assessments_by_id:
                 raise ValueError(
-                    f"Ollama応答の重複frame評価が一致しません: {assessment.frame_id}"
+                    f"Ollama応答に重複表示IDがあります: {assessment.frame_id}"
                 )
             assessments_by_id[assessment.frame_id] = assessment
 
-        expected_ids = {candidate.frame_id for candidate in candidates}
+        display_ids = batch_display_frame_ids(len(candidates))
+        expected_ids = set(display_ids)
         actual_ids = set(assessments_by_id)
         if actual_ids != expected_ids:
             raise ValueError(
-                "Ollama応答のframe IDが一致しません: "
+                "Ollama応答の表示IDが一致しません: "
                 f"expected={sorted(expected_ids)}, actual={sorted(actual_ids)}"
             )
-        return [assessments_by_id[candidate.frame_id] for candidate in candidates]
+        return [
+            replace(assessments_by_id[display_id], frame_id=candidate.frame_id)
+            for display_id, candidate in zip(display_ids, candidates, strict=True)
+        ]
 
     def _verify_gpu_use(self, model: str, model_digest: str) -> None:
         """各batchでloaded modelのdigestとGPU配置を確認する."""

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -53,6 +53,7 @@ from .ollama_frame_assessor import (
     MODEL_OPTIONS,
     OllamaFrameAssessor,
     OllamaModelValidationError,
+    batch_display_frame_ids,
 )
 from .video_frame_extractor import VideoFrameExtractor
 from .video_phase_cache import (
@@ -72,7 +73,7 @@ GAME_CONTEXT_CHECKPOINT_SCHEMA_VERSION = 2
 logger = logging.getLogger(__name__)
 
 ALGORITHM_VERSION = "multi-video-selection-v7"
-PROMPT_VERSION = "blog-image-selection-v5"
+PROMPT_VERSION = "blog-image-selection-v6"
 DEFAULT_MAX_SAMPLE_INTERVAL_SECONDS = 10.0
 MINIMUM_ENDPOINT_MARGIN_SECONDS = 0.05
 INTERVAL_COUNT_TOLERANCE = 1e-9
@@ -2205,11 +2206,23 @@ class VideoSelector:
                     )
                 )
                 prepare_cache_directory(self.cache_root, sheet_path.parent)
-                build_contact_sheet(batch, sheet_path, context_dir=context_dir)
+                display_ids = batch_display_frame_ids(len(batch))
+                build_contact_sheet(
+                    batch,
+                    sheet_path,
+                    context_dir=context_dir,
+                    display_ids=display_ids,
+                )
+                base_prompt = self._model_prompt(stage, batch)
                 last_error: Exception | None = None
                 for attempt in range(1, 4):
                     started = time.monotonic()
                     try:
+                        prompt = (
+                            self._retry_prompt(base_prompt, batch, last_error)
+                            if isinstance(last_error, ValueError)
+                            else base_prompt
+                        )
                         assessments = self.assessor.assess(
                             model=str(
                                 self.model_metadata[
@@ -2221,7 +2234,7 @@ class VideoSelector:
                                     "primary" if primary_stage else "secondary"
                                 ]["digest"]
                             ),
-                            prompt=self._model_prompt(stage, batch),
+                            prompt=prompt,
                             candidates=batch,
                             contact_sheet=sheet_path,
                         )
@@ -2388,7 +2401,7 @@ class VideoSelector:
         source = self._source_for(candidates[0])
         if any(self._source_for(candidate) != source for candidate in candidates):
             raise ValueError("一つの評価batchへ複数Input Videoを混在できません")
-        ids = ", ".join(candidate.frame_id for candidate in candidates)
+        ids = ", ".join(batch_display_frame_ids(len(candidates)))
         if _is_primary_stage(stage):
             stage_note = "動画全体を時間分散と機械的品質で絞った一次候補です。"
             context_note = ""
@@ -2425,8 +2438,24 @@ contact sheet内の対象ID: {ids}
 画面も残してください。タイトル固有のルールは設けないでください。
 ゲームジャンルに存在しない場面を無理に仮定しないでください。
 全IDを1回ずつ含め、JSON以外は返さないでください。
-形式: {{"frames":[{{"id":"f00001","blog_score":80,"transition":false,
+形式: {{"frames":[{{"id":"A01","blog_score":80,"transition":false,
 "scene":"探索","reason":"人物とフィールドが明瞭"}}]}}"""
+
+    @staticmethod
+    def _retry_prompt(
+        base_prompt: str,
+        candidates: Sequence[FrameCandidate],
+        previous_error: ValueError,
+    ) -> str:
+        """不正応答後の再試行へ検証結果と期待表示IDを加える."""
+        expected_ids = ", ".join(batch_display_frame_ids(len(candidates)))
+        return f"""{base_prompt}
+
+前回の応答は次の検証に失敗しました:
+{previous_error}
+contact sheetを再確認し、欠落・未知・重複のないJSONへ修正してください。
+期待する表示ID: {expected_ids}
+各表示IDを必ず1回だけ返してください。"""
 
     def _write_gpu_evidence(self) -> None:
         """実行中に確認したGPU利用証跡を保存する."""

--- a/src/utils/contact_sheet.py
+++ b/src/utils/contact_sheet.py
@@ -29,6 +29,7 @@ def build_contact_sheet(
     output_path: Path,
     *,
     context_dir: Path | None = None,
+    display_ids: Sequence[str] | None = None,
 ) -> None:
     """候補一覧を一枚のJPEGへまとめる.
 
@@ -37,6 +38,13 @@ def build_contact_sheet(
     """
     if not candidates:
         raise ValueError("空の候補からコンタクトシートは作成できません")
+    labels = (
+        tuple(candidate.frame_id for candidate in candidates)
+        if display_ids is None
+        else tuple(display_ids)
+    )
+    if len(labels) != len(candidates) or any(not label for label in labels):
+        raise ValueError("表示IDは候補と同じ件数の空でない文字列にしてください")
 
     contextual = context_dir is not None
     if contextual:
@@ -77,7 +85,7 @@ def build_contact_sheet(
         draw.text(
             (x + 10, y + 8),
             (
-                f"{candidate.frame_id}  "
+                f"{labels[index]}  "
                 f"{_format_timestamp(candidate.timestamp_seconds)}{source}{suffix}"
             ),
             fill="white",

--- a/tests/services/test_ollama_frame_assessor.py
+++ b/tests/services/test_ollama_frame_assessor.py
@@ -67,7 +67,7 @@ class ChangingDigestAssessor(OllamaFrameAssessor):
                         {
                             "frames": [
                                 {
-                                    "id": "f00001",
+                                    "id": "A01",
                                     "blog_score": 80,
                                     "transition": False,
                                     "scene": "探索",
@@ -215,34 +215,35 @@ def test_assess_revalidates_loaded_model_digest_for_every_batch(
     assert assessor.ps_calls == 2
 
 
-def test_assess_accepts_identical_duplicates_in_candidate_order(
+def test_assess_maps_short_display_ids_to_internal_ids_in_candidate_order(
     tmp_path: Path,
 ) -> None:
-    """完全一致する重複を除き、入力candidate順で返すこと."""
-    first = frame_response("f00001", blog_score=81)
-    second = frame_response("f00002", blog_score=72)
+    """短い表示IDを長い内部IDへ戻し、入力candidate順で返すこと."""
+    first = frame_response("A01", blog_score=81)
+    second = frame_response("A02", blog_score=72)
+    candidate_ids = [
+        "f1193384472080815349902201",
+        "f1193384472080815349902202",
+    ]
 
     assessments = assess_frames(
         tmp_path,
-        [second, first, second.copy(), first.copy()],
-        ["f00001", "f00002"],
+        [second, first],
+        candidate_ids,
     )
 
-    assert [assessment.frame_id for assessment in assessments] == [
-        "f00001",
-        "f00002",
-    ]
+    assert [assessment.frame_id for assessment in assessments] == candidate_ids
     assert [assessment.blog_score for assessment in assessments] == [81.0, 72.0]
 
 
-def test_assess_rejects_conflicting_duplicate(tmp_path: Path) -> None:
-    """同じframe IDで内容が異なる重複を拒否すること."""
-    with pytest.raises(ValueError, match="f00001"):
+def test_assess_rejects_duplicate_display_id(tmp_path: Path) -> None:
+    """内容が同じでも重複する表示IDを拒否すること."""
+    with pytest.raises(ValueError, match="A01"):
         assess_frames(
             tmp_path,
             [
-                frame_response("f00001", blog_score=80),
-                frame_response("f00001", blog_score=81),
+                frame_response("A01", blog_score=80),
+                frame_response("A01", blog_score=80),
             ],
             ["f00001"],
         )
@@ -250,19 +251,19 @@ def test_assess_rejects_conflicting_duplicate(tmp_path: Path) -> None:
 
 def test_assess_rejects_missing_frame_id(tmp_path: Path) -> None:
     """要求したframe IDが欠落する応答を拒否すること."""
-    with pytest.raises(ValueError, match="frame IDが一致しません"):
+    with pytest.raises(ValueError, match="表示IDが一致しません"):
         assess_frames(
             tmp_path,
-            [frame_response("f00001")],
+            [frame_response("A01")],
             ["f00001", "f00002"],
         )
 
 
 def test_assess_rejects_unknown_frame_id(tmp_path: Path) -> None:
     """要求していないframe IDを含む応答を拒否すること."""
-    with pytest.raises(ValueError, match="frame IDが一致しません"):
+    with pytest.raises(ValueError, match="表示IDが一致しません"):
         assess_frames(
             tmp_path,
-            [frame_response("f00001"), frame_response("f99999")],
+            [frame_response("A01"), frame_response("A99")],
             ["f00001"],
         )

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -1076,6 +1076,12 @@ def test_pipeline_logs_assessment_completion_and_failure_without_batch_start(
     class RetryOnceAssessor(FakeAssessor):
         """最初の評価だけ一時失敗するfake."""
 
+        def __init__(self) -> None:
+            """試行promptを記録する."""
+            super().__init__()
+            self.attempted_prompts: list[str] = []
+            self.attempted_candidate_ids: list[tuple[str, ...]] = []
+
         def assess(
             self,
             *,
@@ -1086,9 +1092,16 @@ def test_pipeline_logs_assessment_completion_and_failure_without_batch_start(
             contact_sheet: Path,
         ) -> list[FrameAssessment]:
             """一度だけ失敗し、その後は固定評価を返す."""
+            self.attempted_prompts.append(prompt)
+            self.attempted_candidate_ids.append(
+                tuple(candidate.frame_id for candidate in candidates)
+            )
             if self.assess_calls == 0:
                 self.assess_calls += 1
-                raise ConnectionError("temporary failure")
+                raise ValueError(
+                    "Ollama応答の表示IDが一致しません: "
+                    "expected=['A01', 'A02'], actual=['A01', 'A99']"
+                )
             return super().assess(
                 model=model,
                 model_digest=model_digest,
@@ -1117,17 +1130,33 @@ def test_pipeline_logs_assessment_completion_and_failure_without_batch_start(
     )
     caplog.set_level(logging.INFO)
 
+    assessor = RetryOnceAssessor()
     SingleVideoSelector(
         request,
         frame_extractor=FakeFrameExtractor(),
-        assessor=RetryOnceAssessor(),
+        assessor=assessor,
     ).run()
 
     messages = [record.getMessage() for record in caplog.records]
     assert all("評価を開始します" not in message for message in messages)
     assert any(message.startswith("primary評価: ") for message in messages)
     assert any(message.startswith("secondary評価: ") for message in messages)
-    assert "primary評価batch 1の試行1が失敗しました: temporary failure" in messages
+    assert any(
+        message.startswith(
+            "primary評価batch 1の試行1が失敗しました: Ollama応答の表示IDが一致しません"
+        )
+        for message in messages
+    )
+    first_prompt, retry_prompt = assessor.attempted_prompts[:2]
+    assert "contact sheet内の対象ID: A01, A02" in first_prompt
+    assert all(
+        internal_id not in first_prompt
+        for internal_id in assessor.attempted_candidate_ids[0]
+    )
+    assert retry_prompt != first_prompt
+    assert "前回の応答は次の検証に失敗しました" in retry_prompt
+    assert "actual=['A01', 'A99']" in retry_prompt
+    assert "期待する表示ID: A01, A02" in retry_prompt
 
 
 def test_pipeline_selects_from_multiple_videos_and_reports_each_source(

--- a/tests/utils/test_contact_sheet.py
+++ b/tests/utils/test_contact_sheet.py
@@ -3,10 +3,51 @@
 import stat
 from pathlib import Path
 
+import pytest
 from PIL import Image
 
 from src.models.video_selection import FrameCandidate
 from src.utils.contact_sheet import build_contact_sheet, context_frame_path
+
+
+def test_build_contact_sheet_uses_short_display_ids_without_renaming_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Ollama用sheetには内部IDでなくbatch内表示IDを描くこと."""
+    drawn_labels: list[str] = []
+
+    class RecordingDraw:
+        """描画文字列だけを記録するfake."""
+
+        def text(
+            self,
+            _position: tuple[int, int],
+            value: str,
+            *,
+            fill: str,
+        ) -> None:
+            """labelを記録する."""
+            assert fill == "white"
+            drawn_labels.append(value)
+
+    monkeypatch.setattr(
+        "src.utils.contact_sheet.ImageDraw.Draw",
+        lambda _sheet: RecordingDraw(),
+    )
+    candidate_path = tmp_path / "candidate.jpg"
+    Image.new("RGB", (320, 180), "white").save(candidate_path)
+    internal_id = "f1193384472080815349902201"
+    candidate = FrameCandidate(internal_id, 10.0, str(candidate_path))
+
+    build_contact_sheet(
+        [candidate],
+        tmp_path / "contact-sheet.jpg",
+        display_ids=["A01"],
+    )
+
+    assert drawn_labels == ["A01  00:10"]
+    assert candidate.frame_id == internal_id
 
 
 def test_build_contact_sheet_outputs_readable_selected_image(

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.14.0"
+version = "1.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

- Ollama評価batch内では長い安定frame IDの代わりに `A01` 形式の短い表示IDを使用
- 応答を厳格に検証してから安定frame IDへ戻し、Assessment Cacheには従来のIDで保存
- 不正応答後の再試行promptへ直前の検証エラーと期待表示IDを追加
- Frame Display IDのドメイン契約とcache ADRを更新
- バージョンを `1.14.1` へ更新

## 検証

- `UV_CACHE_DIR=/private/tmp/game-screen-pick-issue313-uv-cache uv run task check`
  - Ruff / format / mypy 成功
  - 372 tests passed
- `UV_CACHE_DIR=/private/tmp/game-screen-pick-issue313-uv-cache uv lock --check`（版更新前後とも成功）

Closes #313