### PR TITLE
perf: 機械評価キャッシュの再開を軽量化する

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -95,6 +95,8 @@ _Avoid_: phase cache root, unconditional overwrite target, append-only destinati
 Input Video Directory直下の`cache-game-screen-pick/`へ保存する、再生成可能な処理状態。
 Input Videoとphaseごとに独立したversionとsemantic input keyを持つ。phase versionまたは
 結果へ影響する条件が変わった場合は、そのphaseと依存する後続だけを再実行する。
+候補抽出manifestと機械評価payloadのdigestを照合し、正常な再開では候補JPEG本文を
+全件再読込せずregular fileとsizeだけを軽量に確認する。
 folder全体を削除でき、`CACHE_INFO.txt`が削除とidentityの契約を説明する。
 _Avoid_: user artifact, hidden Output Folder state, unversioned cache
 

--- a/docs/adr/0008-cache-video-selection-phases-by-input-video.md
+++ b/docs/adr/0008-cache-video-selection-phases-by-input-video.md
@@ -24,13 +24,24 @@ digests for the evaluation unit. Invalid, corrupt, schema-mismatched, or legacy
 entries are cache misses.
 Probe metadata is reusable only when its complete payload matches the recorded
 digest and its stream endpoint and minimum-interval sample-count arithmetic
-remain finite. A candidate JPEG without a mechanical
-analysis digest record, or whose SHA-256 no longer matches that record, is
-re-extracted before the analysis is reused or rerun. Mechanical cache reuse also
-recomputes rejection classification, quality score, and dHash from every
-validated candidate JPEG. Transition-context extraction similarly persists each
-before/after JPEG digest and re-extracts only a requested frame whose bytes no
-longer match.
+remain finite. Candidate extraction atomically records an ordered manifest of
+frame IDs, timestamps, JPEG sizes, and creation-time SHA-256 values, protected by
+a complete payload digest. A normal resume validates that manifest and uses
+regular-file type and size checks instead of reopening and hashing every JPEG.
+A missing or corrupt manifest invalidates the extraction phase, while a missing,
+symlinked, non-regular, empty, or differently sized JPEG is re-extracted. The
+accepted performance trade-off is that a candidate JPEG replacement preserving
+the recorded size is not detected by the bulk resume check; deleting the cache
+forces regeneration in that case.
+
+Mechanical analysis records the candidate-manifest payload digest and protects
+its complete candidate, rejection, quality-score, and dHash mapping with a
+second payload digest. When both digests and the structural contract match, the
+stored mechanical results are restored directly instead of decoding and
+remeasuring every candidate JPEG. A manifest change or mechanical payload
+mismatch reruns mechanical analysis. Transition-context extraction similarly
+persists each before/after JPEG digest and re-extracts only a requested frame
+whose bytes no longer match.
 An assessment checkpoint is reusable only when it contains the complete prefix
 of batches that the current evaluation unit could have saved; a hole or a
 regrouped partial batch invalidates the whole phase checkpoint. Its cache key

--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -162,6 +162,12 @@ SHA-256、mtime、絶対pathは同一性判定へ使いません。そのため�
 cacheはprobe、候補抽出・機械評価、一次評価、二次評価などのphaseとInput Video単位で
 管理します。各phaseは独立したversionと条件keyを持ち、version、model digest、prompt、
 Game Context、選定設定などが変わると、そのphaseと依存する後続だけを再実行します。
+候補抽出phaseはframe ID、時刻、JPEG size、生成時SHA-256をpayload digest付きmanifestへ
+保存します。正常な再開ではmanifestの完全性と各JPEGのregular file・sizeだけを確認し、
+全候補JPEGの再読込や機械評価を繰り返しません。manifestの欠損・破損、JPEGの欠損・
+symlink・size不一致、機械評価payloadのdigest不一致はcache missとして再生成します。
+この軽量確認では同じsizeを保った候補JPEGの置換は検出しないため、確実に再生成したい
+場合はcache folderを削除してください。
 動的生成したGame Contextも生成条件とともに保存し、同じGame Title、provider、modelの
 再実行ではWeb検索やcontext生成を繰り返しません。Ollama providerでは正規化した
 Ollama hostも生成条件に含め、別endpointの同名modelを混同しません。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.14.1"
+version = "1.14.2"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -1775,6 +1775,7 @@ class VideoSelector:
             if candidate.frame_id not in rejected_id_set
         ]
         recorded_ids: list[str] = []
+        recorded_id_set: set[str] = set()
         restored: list[FrameCandidate] = []
         for raw in data["candidates"]:
             if not isinstance(raw, dict):
@@ -1783,10 +1784,11 @@ class VideoSelector:
             if (
                 not isinstance(frame_id, str)
                 or frame_id not in expected_by_id
-                or frame_id in recorded_ids
+                or frame_id in recorded_id_set
             ):
                 return None
             recorded_ids.append(frame_id)
+            recorded_id_set.add(frame_id)
             expected = expected_by_id[frame_id]
             quality = raw.get("quality_score")
             difference_hash = raw.get("difference_hash")

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -7,6 +7,7 @@ import logging
 import math
 import os
 import shutil
+import stat
 import time
 from collections import Counter
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
@@ -86,8 +87,8 @@ MAXIMUM_OUTPUT_DHASH_DISTANCE = 10
 MINIMUM_DISTINCT_DHASH_DISTANCE = 5
 RUN_MANIFEST_SCHEMA_VERSION = 1
 VIDEO_PROBE_PHASE_VERSION = 2
-CANDIDATE_EXTRACTION_PHASE_VERSION = 1
-MECHANICAL_ANALYSIS_PHASE_VERSION = 3
+CANDIDATE_EXTRACTION_PHASE_VERSION = 2
+MECHANICAL_ANALYSIS_PHASE_VERSION = 4
 PRIMARY_ASSESSMENT_PHASE_VERSION = 3
 SECONDARY_CONTEXT_PHASE_VERSION = 2
 SECONDARY_ASSESSMENT_PHASE_VERSION = 2
@@ -227,6 +228,7 @@ class VideoSelector:
         self.model_metadata: dict[str, dict[str, Any]] = {}
         self._live_validated_model_stages: set[str] = set()
         self._usable_candidates: tuple[FrameCandidate, ...] = ()
+        self._candidate_manifest_digests: dict[int, str] = {}
         self.manifest_digest = ""
         self._replace_registered_output = False
 
@@ -1427,6 +1429,15 @@ class VideoSelector:
         """全入力動画の等間隔位置から縮小候補フレームを抽出する."""
         candidates: list[FrameCandidate] = []
         pending: list[FrameCandidate] = []
+        source_states: list[
+            tuple[
+                VideoSource,
+                list[FrameCandidate],
+                dict[str, dict[str, Any]],
+                set[str],
+            ]
+        ] = []
+        self._candidate_manifest_digests.clear()
         for source in self.sources:
             source_dir = (
                 source.cache_dir
@@ -1447,20 +1458,26 @@ class VideoSelector:
                         source_label=source.label,
                     )
                 )
-            recorded_digests = self._recorded_candidate_digests(
+            manifest = self._load_candidate_manifest(
                 source,
                 source_candidates,
             )
+            cached_records = manifest[0] if manifest is not None else {}
+            if manifest is not None:
+                self._candidate_manifest_digests[source.index] = manifest[1]
+            pending_ids: set[str] = set()
             for candidate in source_candidates:
-                path = Path(candidate.path)
-                recorded_digest = recorded_digests.get(candidate.frame_id)
-                is_valid = _is_valid_cached_image(path)
-                digest_changed = recorded_digest is None or (
-                    is_valid and file_sha256(path) != recorded_digest
-                )
-                if not is_valid or digest_changed:
+                record = cached_records.get(candidate.frame_id)
+                if record is None or not self._matches_candidate_file(
+                    Path(candidate.path),
+                    record["file_size"],
+                ):
                     pending.append(candidate)
+                    pending_ids.add(candidate.frame_id)
             candidates.extend(source_candidates)
+            source_states.append(
+                (source, source_candidates, cached_records, pending_ids)
+            )
         frame_ids = [candidate.frame_id for candidate in candidates]
         if len(set(frame_ids)) != len(frame_ids):
             raise RuntimeError("Input Video間でframe IDが衝突しました")
@@ -1480,33 +1497,113 @@ class VideoSelector:
             wait_on_error=True,
             on_complete=log_progress,
         )
+        for source, source_candidates, cached_records, pending_ids in source_states:
+            if pending_ids:
+                self._save_candidate_manifest(
+                    source,
+                    source_candidates,
+                    cached_records,
+                    pending_ids,
+                )
         return candidates
 
-    def _recorded_candidate_digests(
+    @staticmethod
+    def _matches_candidate_file(path: Path, expected_size: int) -> bool:
+        """manifestと一致するregular fileか本文を読まずに返す."""
+        try:
+            status = path.lstat()
+        except OSError:
+            return False
+        return stat.S_ISREG(status.st_mode) and status.st_size == expected_size
+
+    def _candidate_manifest_path(self, source: VideoSource) -> Path:
+        """候補抽出phase manifestのpathを返す."""
+        path = (
+            source.cache_dir
+            / "candidate-extraction"
+            / source.candidate_cache_key
+            / "manifest.json"
+        )
+        prepare_cache_directory(self.cache_root, path.parent)
+        return path
+
+    def _load_candidate_manifest(
         self,
         source: VideoSource,
         expected_candidates: Sequence[FrameCandidate],
-    ) -> dict[str, str]:
-        """機械評価cacheが記録した候補JPEG digestを返す."""
-        data = self._read_mechanical_phase_data(source)
+    ) -> tuple[dict[str, dict[str, Any]], str] | None:
+        """完全な候補抽出manifestとそのpayload digestを返す."""
+        data = read_phase_data(
+            self._candidate_manifest_path(source),
+            phase="candidate-extraction",
+            phase_version=CANDIDATE_EXTRACTION_PHASE_VERSION,
+            expected_key=source.candidate_cache_key,
+        )
         if data is None or not isinstance(data.get("source_frames"), list):
-            return {}
+            return None
         source_frames = data["source_frames"]
-        if len(source_frames) != len(expected_candidates):
-            return {}
-        digests: dict[str, str] = {}
+        manifest_payload = {"source_frames": source_frames}
+        payload_digest = data.get("payload_digest")
+        if (
+            len(source_frames) != len(expected_candidates)
+            or not _is_sha256(payload_digest)
+            or payload_digest != json_digest(manifest_payload)
+        ):
+            return None
+        records: dict[str, dict[str, Any]] = {}
         for raw, expected in zip(source_frames, expected_candidates, strict=True):
             if not isinstance(raw, dict):
-                return {}
+                return None
+            file_size = raw.get("file_size")
             image_sha256 = raw.get("image_sha256")
             if (
                 raw.get("frame_id") != expected.frame_id
+                or raw.get("timestamp_seconds") != expected.timestamp_seconds
+                or not isinstance(file_size, int)
+                or isinstance(file_size, bool)
+                or file_size <= 0
                 or not isinstance(image_sha256, str)
                 or not _is_sha256(image_sha256)
             ):
-                return {}
-            digests[expected.frame_id] = image_sha256
-        return digests
+                return None
+            records[expected.frame_id] = raw
+        return records, payload_digest
+
+    def _save_candidate_manifest(
+        self,
+        source: VideoSource,
+        source_candidates: Sequence[FrameCandidate],
+        cached_records: dict[str, dict[str, Any]],
+        extracted_ids: set[str],
+    ) -> None:
+        """抽出済みJPEGのportableな完全性情報をatomic保存する."""
+        source_frames: list[dict[str, Any]] = []
+        for candidate in source_candidates:
+            cached = cached_records.get(candidate.frame_id)
+            if candidate.frame_id not in extracted_ids and cached is not None:
+                source_frames.append(cached)
+                continue
+            path = Path(candidate.path)
+            if not _is_valid_cached_image(path):
+                raise RuntimeError(f"候補フレームを正常に抽出できませんでした: {path}")
+            source_frames.append(
+                {
+                    "frame_id": candidate.frame_id,
+                    "timestamp_seconds": candidate.timestamp_seconds,
+                    "file_size": path.stat().st_size,
+                    "image_sha256": file_sha256(path),
+                }
+            )
+        manifest_payload = {"source_frames": source_frames}
+        payload_digest = json_digest(manifest_payload)
+        write_phase_data(
+            self._candidate_manifest_path(source),
+            phase="candidate-extraction",
+            phase_version=CANDIDATE_EXTRACTION_PHASE_VERSION,
+            cache_key=source.candidate_cache_key,
+            data={**manifest_payload, "payload_digest": payload_digest},
+        )
+        self._candidate_manifest_digests[source.index] = payload_digest
 
     def _extract_candidate(self, candidate: FrameCandidate) -> None:
         """候補フレームを一枚抽出する."""
@@ -1640,34 +1737,45 @@ class VideoSelector:
         data = self._read_mechanical_phase_data(source)
         if (
             data is None
-            or not isinstance(data.get("source_frames"), list)
             or not isinstance(data.get("candidates"), list)
             or not isinstance(data.get("rejected_frame_ids"), list)
         ):
             return None
-        if len(data["source_frames"]) != len(expected_candidates):
-            return None
-        for raw, expected_candidate in zip(
-            data["source_frames"],
-            expected_candidates,
-            strict=True,
+        mechanical_payload = {
+            "source_frames_digest": data.get("source_frames_digest"),
+            "candidates": data["candidates"],
+            "rejected_frame_ids": data["rejected_frame_ids"],
+        }
+        if (
+            not _is_sha256(data.get("payload_digest"))
+            or data["payload_digest"] != json_digest(mechanical_payload)
+            or data.get("source_frames_digest")
+            != self._candidate_manifest_digests.get(source.index)
         ):
-            if not isinstance(raw, dict):
-                return None
-            image_sha256 = raw.get("image_sha256")
-            if (
-                raw.get("frame_id") != expected_candidate.frame_id
-                or not isinstance(image_sha256, str)
-                or len(image_sha256) != 64
-                or not _is_valid_cached_image(Path(expected_candidate.path))
-                or file_sha256(Path(expected_candidate.path)) != image_sha256
-            ):
-                return None
+            return None
         expected_by_id = {
             candidate.frame_id: candidate for candidate in expected_candidates
         }
-        raw_by_id: dict[str, dict[str, Any]] = {}
+        rejected_ids = data["rejected_frame_ids"]
+        if any(
+            not isinstance(frame_id, str) or frame_id not in expected_by_id
+            for frame_id in rejected_ids
+        ) or len(set(rejected_ids)) != len(rejected_ids):
+            return None
+        rejected_id_set = set(rejected_ids)
+        if rejected_ids != [
+            candidate.frame_id
+            for candidate in expected_candidates
+            if candidate.frame_id in rejected_id_set
+        ]:
+            return None
+        expected_usable_ids = [
+            candidate.frame_id
+            for candidate in expected_candidates
+            if candidate.frame_id not in rejected_id_set
+        ]
         recorded_ids: list[str] = []
+        restored: list[FrameCandidate] = []
         for raw in data["candidates"]:
             if not isinstance(raw, dict):
                 return None
@@ -1675,25 +1783,11 @@ class VideoSelector:
             if (
                 not isinstance(frame_id, str)
                 or frame_id not in expected_by_id
-                or frame_id in raw_by_id
+                or frame_id in recorded_ids
             ):
                 return None
-            raw_by_id[frame_id] = raw
             recorded_ids.append(frame_id)
-
-        restored: list[FrameCandidate] = []
-        expected_rejected_ids: list[str] = []
-        for expected in expected_candidates:
-            try:
-                measured = measure_candidate(expected)
-            except (OSError, ValueError, Image.DecompressionBombError):
-                return None
-            if measured is None:
-                expected_rejected_ids.append(expected.frame_id)
-                continue
-            raw = raw_by_id.get(expected.frame_id)
-            if raw is None:
-                return None
+            expected = expected_by_id[frame_id]
             quality = raw.get("quality_score")
             difference_hash = raw.get("difference_hash")
             if (
@@ -1710,16 +1804,14 @@ class VideoSelector:
                 parsed_hash = int(difference_hash, 16)
             except ValueError:
                 return None
-            if (
-                float(quality) != measured.quality_score
-                or parsed_hash != measured.difference_hash
-            ):
-                return None
-            restored.append(measured)
-        if (
-            recorded_ids != [candidate.frame_id for candidate in restored]
-            or data["rejected_frame_ids"] != expected_rejected_ids
-        ):
+            restored.append(
+                replace(
+                    expected,
+                    quality_score=float(quality),
+                    difference_hash=parsed_hash,
+                )
+            )
+        if recorded_ids != expected_usable_ids:
             return None
         return restored
 
@@ -1734,33 +1826,34 @@ class VideoSelector:
         path = source.cache_dir / "mechanical-analysis" / f"{cache_key}.json"
         prepare_cache_directory(self.cache_root, path.parent)
         usable_ids = {candidate.frame_id for candidate in candidates}
+        source_frames_digest = self._candidate_manifest_digests.get(source.index)
+        if source_frames_digest is None:
+            raise RuntimeError("候補抽出manifestが確定していません")
+        mechanical_payload = {
+            "source_frames_digest": source_frames_digest,
+            "candidates": [
+                {
+                    "frame_id": candidate.frame_id,
+                    "timestamp_seconds": candidate.timestamp_seconds,
+                    "quality_score": candidate.quality_score,
+                    "difference_hash": f"{candidate.difference_hash:016x}",
+                }
+                for candidate in candidates
+            ],
+            "rejected_frame_ids": [
+                candidate.frame_id
+                for candidate in source_candidates
+                if candidate.frame_id not in usable_ids
+            ],
+        }
         write_phase_data(
             path,
             phase="mechanical-analysis",
             phase_version=MECHANICAL_ANALYSIS_PHASE_VERSION,
             cache_key=cache_key,
             data={
-                "source_frames": [
-                    {
-                        "frame_id": candidate.frame_id,
-                        "image_sha256": file_sha256(Path(candidate.path)),
-                    }
-                    for candidate in source_candidates
-                ],
-                "candidates": [
-                    {
-                        "frame_id": candidate.frame_id,
-                        "timestamp_seconds": candidate.timestamp_seconds,
-                        "quality_score": candidate.quality_score,
-                        "difference_hash": f"{candidate.difference_hash:016x}",
-                    }
-                    for candidate in candidates
-                ],
-                "rejected_frame_ids": [
-                    candidate.frame_id
-                    for candidate in source_candidates
-                    if candidate.frame_id not in usable_ids
-                ],
+                **mechanical_payload,
+                "payload_digest": json_digest(mechanical_payload),
             },
         )
 

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -3425,8 +3425,10 @@ def test_probe_cache_rejects_corrupt_payload(
     assert selector.sources[0].metadata.duration_seconds == 4.0
 
 
-def test_mechanical_cache_reextracts_changed_candidate_image(tmp_path: Path) -> None:
-    """記録済みdigestと異なる候補JPEGを動画から再抽出すること."""
+def test_mechanical_cache_reextracts_changed_size_candidate_image(
+    tmp_path: Path,
+) -> None:
+    """manifestとsizeが異なる候補JPEGを動画から再抽出すること."""
     video = tmp_path / "Sample Game.mp4"
     video.write_bytes(bytes(range(256)) * 16)
     request = VideoSelectionRequest(
@@ -3458,7 +3460,7 @@ def test_mechanical_cache_reextracts_changed_candidate_image(tmp_path: Path) -> 
         first_selector.sources[0],
         first_candidates,
     )
-    shutil.copyfile(first_candidates[1].path, first_candidates[0].path)
+    Path(first_candidates[0].path).write_bytes(b"broken candidate cache")
     extractor = TrackingFrameExtractor()
     second_selector = SingleVideoSelector(
         request,
@@ -3480,8 +3482,8 @@ def test_mechanical_cache_reextracts_changed_candidate_image(tmp_path: Path) -> 
     assert second_key == first_key
 
 
-def test_candidate_cache_reextracts_without_recorded_digests(tmp_path: Path) -> None:
-    """機械評価記録のない候補JPEGを抽出cache hitにしないこと."""
+def test_candidate_cache_reextracts_without_manifest(tmp_path: Path) -> None:
+    """manifestのない候補JPEGを抽出cache hitにしないこと."""
     video = tmp_path / "Sample Game.mp4"
     video.write_bytes(bytes(range(256)) * 16)
     request = VideoSelectionRequest(
@@ -3505,8 +3507,13 @@ def test_candidate_cache_reextracts_without_recorded_digests(tmp_path: Path) -> 
         assessor=FakeAssessor(),
     )
     first_selector._prepare_run()
-    first_candidates = first_selector._extract_candidates()
-    shutil.copyfile(first_candidates[1].path, first_candidates[0].path)
+    first_selector._extract_candidates()
+    manifest_path = next(
+        (_cache_root(tmp_path) / "videos").glob(
+            "*/candidate-extraction/*/manifest.json"
+        )
+    )
+    manifest_path.unlink()
     extractor = TrackingFrameExtractor()
     second_selector = SingleVideoSelector(
         request,
@@ -3519,6 +3526,112 @@ def test_candidate_cache_reextracts_without_recorded_digests(tmp_path: Path) -> 
 
     assert len(extractor.candidate_videos) == len(second_candidates)
     assert set(extractor.candidate_videos) == {video.name}
+
+
+def test_candidate_cache_reextracts_corrupt_manifest(tmp_path: Path) -> None:
+    """payload digestと一致しない候補manifestをcache missにすること."""
+    video = tmp_path / "Sample Game.mp4"
+    video.write_bytes(bytes(range(256)) * 16)
+    request = VideoSelectionRequest(
+        input_video=str(video),
+        output_dir=str(tmp_path / "selected"),
+        output_count=2,
+        game_title=None,
+        game_context="テスト用のGame Context",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+    first_selector = SingleVideoSelector(
+        request,
+        frame_extractor=FakeFrameExtractor(),
+        assessor=FakeAssessor(),
+    )
+    first_selector._prepare_run()
+    first_selector._extract_candidates()
+    manifest_path = next(
+        (_cache_root(tmp_path) / "videos").glob(
+            "*/candidate-extraction/*/manifest.json"
+        )
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["data"]["source_frames"][0]["file_size"] += 1
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    extractor = TrackingFrameExtractor()
+    second_selector = SingleVideoSelector(
+        request,
+        frame_extractor=extractor,
+        assessor=FakeAssessor(),
+    )
+    second_selector._prepare_run()
+
+    candidates = second_selector._extract_candidates()
+
+    assert len(extractor.candidate_videos) == len(candidates)
+
+
+def test_resume_reuses_mechanical_cache_without_reading_candidate_jpegs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """正常な再開では候補JPEGの検証と機械評価を繰り返さないこと."""
+    video = tmp_path / "Sample Game.mp4"
+    video.write_bytes(bytes(range(256)) * 16)
+    request = VideoSelectionRequest(
+        input_video=str(video),
+        output_dir=str(tmp_path / "selected"),
+        output_count=2,
+        game_title=None,
+        game_context="テスト用のGame Context",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+    first_selector = SingleVideoSelector(
+        request,
+        frame_extractor=FakeFrameExtractor(),
+        assessor=FakeAssessor(),
+    )
+    first_selector._prepare_run()
+    candidates = first_selector._extract_candidates()
+    expected = first_selector._preselect_candidates(candidates)
+
+    def fail_candidate_read(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("候補JPEGを再読込しました")
+
+    monkeypatch.setattr(
+        "src.services.video_selector._is_valid_cached_image",
+        fail_candidate_read,
+    )
+    monkeypatch.setattr(
+        "src.services.video_selector.file_sha256",
+        fail_candidate_read,
+    )
+    monkeypatch.setattr(
+        "src.services.video_selector.measure_candidate",
+        fail_candidate_read,
+    )
+    second_selector = SingleVideoSelector(
+        request,
+        frame_extractor=FakeFrameExtractor(),
+        assessor=FakeAssessor(),
+    )
+    second_selector._prepare_run()
+
+    restored_candidates = second_selector._extract_candidates()
+    restored = second_selector._preselect_candidates(restored_candidates)
+
+    assert restored == expected
 
 
 def test_primary_cache_key_tracks_batch_composition(tmp_path: Path) -> None:
@@ -3671,9 +3784,9 @@ def test_mechanical_cache_rejects_candidate_membership_corruption(
         moved_id = payload["data"]["candidates"].pop(0)["frame_id"]
         rejected_ids = {*payload["data"]["rejected_frame_ids"], moved_id}
         payload["data"]["rejected_frame_ids"] = [
-            frame["frame_id"]
-            for frame in payload["data"]["source_frames"]
-            if frame["frame_id"] in rejected_ids
+            candidate.frame_id
+            for candidate in candidates
+            if candidate.frame_id in rejected_ids
         ]
     mechanical_path.write_text(json.dumps(payload), encoding="utf-8")
     second_selector = SingleVideoSelector(
@@ -3968,11 +4081,11 @@ def test_pipeline_reextracts_symlinked_cached_image(
     assert file_sha256(external) == external_hash
 
 
-def test_pipeline_reextracts_cached_image_over_decompression_bomb_limit(
+def test_pipeline_does_not_decode_manifest_backed_candidate_cache(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Pillowの展開上限を超えるcache画像をabortせずcache missにすること."""
+    """正常な候補manifest hitではPillowによるJPEG再検証を省くこと."""
     video = tmp_path / "Sample Game.mp4"
     video.write_bytes(bytes(range(256)) * 16)
     request = VideoSelectionRequest(
@@ -4003,7 +4116,8 @@ def test_pipeline_reextracts_cached_image_over_decompression_bomb_limit(
 
     selector._extract_candidates()
 
-    assert extractor.extract_calls == len(candidates)
+    assert candidates
+    assert extractor.extract_calls == 0
 
 
 @pytest.mark.parametrize("invalid_cache_image", ["too-wide", "not-jpeg"])

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.14.1"
+version = "1.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

- 候補抽出phaseへpayload digest付きmanifestを追加し、正常な再開では候補JPEG本文を全件再読込せずregular fileとsizeだけを確認
- 機械評価cacheへ候補manifest digestと完全payload digestを保存し、正常hit時はquality scoreとdHashを直接復元
- manifest欠損・破損、候補JPEGの欠損・symlink・size不一致、機械評価payload不整合をcache missとして再生成
- phase cache契約と技術仕様を更新し、versionを1.14.2へ更新

## 検証

- UV_CACHE_DIR=/private/tmp/game-screen-pick-uv-cache uv run task check
  - Ruff、format、mypy成功
  - 374 tests passed
- UV_CACHE_DIR=/private/tmp/game-screen-pick-uv-cache uv lock --check（version更新前後とも成功）

## 注意点

- phase version更新により、更新後の初回runでは候補抽出・機械評価cacheを再生成します
- 軽量確認では同じfile sizeを保った候補JPEG置換は検出しません。確実な再生成にはcache-game-screen-pick folderを削除します

Closes #310