### PR TITLE
feat: 候補フレームキャッシュ確認の進捗を表示する

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.14.2"
+version = "1.15.0"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -200,6 +200,8 @@ class VideoSource:
 class VideoSelector:
     """フレーム抽出、Ollama評価、選定、成果物生成を順に実行する."""
 
+    CANDIDATE_CACHE_CHECK_PROGRESS_INTERVAL = 500
+
     def __init__(
         self,
         request: VideoSelectionRequest,
@@ -1438,6 +1440,10 @@ class VideoSelector:
             ]
         ] = []
         self._candidate_manifest_digests.clear()
+        total_candidates = sum(len(source.timestamps) for source in self.sources)
+        checked_count = 0
+        cache_hits = 0
+        logger.info("候補フレームcacheを確認しています: %d件", total_candidates)
         for source in self.sources:
             source_dir = (
                 source.cache_dir
@@ -1468,16 +1474,32 @@ class VideoSelector:
             pending_ids: set[str] = set()
             for candidate in source_candidates:
                 record = cached_records.get(candidate.frame_id)
-                if record is None or not self._matches_candidate_file(
-                    Path(candidate.path),
-                    record["file_size"],
-                ):
+                cache_hit = record is not None and self._matches_candidate_file(
+                    Path(candidate.path), record["file_size"]
+                )
+                if cache_hit:
+                    cache_hits += 1
+                else:
                     pending.append(candidate)
                     pending_ids.add(candidate.frame_id)
+                checked_count += 1
+                if checked_count % self.CANDIDATE_CACHE_CHECK_PROGRESS_INTERVAL == 0:
+                    logger.info(
+                        "候補フレームcache確認中: %d/%d件 (hit=%d件, miss=%d件)",
+                        checked_count,
+                        total_candidates,
+                        cache_hits,
+                        checked_count - cache_hits,
+                    )
             candidates.extend(source_candidates)
             source_states.append(
                 (source, source_candidates, cached_records, pending_ids)
             )
+        logger.info(
+            "候補フレームcache: hit=%d件, miss=%d件",
+            cache_hits,
+            checked_count - cache_hits,
+        )
         frame_ids = [candidate.frame_id for candidate in candidates]
         if len(set(frame_ids)) != len(frame_ids):
             raise RuntimeError("Input Video間でframe IDが衝突しました")

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -4120,6 +4120,56 @@ def test_pipeline_does_not_decode_manifest_backed_candidate_cache(
     assert extractor.extract_calls == 0
 
 
+def test_pipeline_logs_candidate_cache_check_progress_and_summary(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """候補cache確認中の件数とhit/miss集計を再開時にも出力すること."""
+    video = tmp_path / "Sample Game.mp4"
+    video.write_bytes(bytes(range(256)) * 16)
+    request = VideoSelectionRequest(
+        input_video=str(video),
+        output_dir=str(tmp_path / "selected"),
+        output_count=2,
+        game_title=None,
+        game_context="テスト用のGame Context",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+    selector = SingleVideoSelector(
+        request,
+        frame_extractor=FakeFrameExtractor(),
+        assessor=FakeAssessor(),
+    )
+    monkeypatch.setattr(
+        SingleVideoSelector,
+        "CANDIDATE_CACHE_CHECK_PROGRESS_INTERVAL",
+        2,
+    )
+    caplog.set_level(logging.INFO)
+    selector._prepare_run()
+
+    selector._extract_candidates()
+
+    first_messages = [record.getMessage() for record in caplog.records]
+    assert "候補フレームcache確認中: 2/13件 (hit=0件, miss=2件)" in first_messages
+    assert "候補フレームcache: hit=0件, miss=13件" in first_messages
+
+    caplog.clear()
+    selector._extract_candidates()
+
+    resumed_messages = [record.getMessage() for record in caplog.records]
+    assert "候補フレームcache確認中: 2/13件 (hit=2件, miss=0件)" in resumed_messages
+    assert "候補フレームcache: hit=13件, miss=0件" in resumed_messages
+
+
 @pytest.mark.parametrize("invalid_cache_image", ["too-wide", "not-jpeg"])
 def test_pipeline_reextracts_cached_image_outside_extraction_contract(
     tmp_path: Path,

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.14.2"
+version = "1.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要
- 候補フレームcache確認の開始時に総件数を表示
- 500件ごとに確認済み件数と累積hit/missを表示
- 初回runとcache再開runのログを結合テストで検証
- プロジェクトバージョンを1.15.0へ更新

## 確認
- UV_CACHE_DIR=/private/tmp/game-screen-pick-iss309-uv-cache uv run task check（375 passed）
- UV_CACHE_DIR=/private/tmp/game-screen-pick-iss309-uv-cache uv lock

Closes #309