### PR TITLE
feat: Game Context生成のproviderとmodelを必須化

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,9 +35,10 @@ Game Titleから一つのGame Context Providerで生成する。画像評価の�
 _Avoid_: hard-coded title tuning, regenerated resume input, provider-specific detail level
 
 **Game Context Provider**:
-Game TitleからGame Contextを生成するために明示選択するWeb検索provider。
+Game TitleからGame Contextを生成するためにmodelと組み合わせて明示選択するWeb検索provider。
 `ollama`、`openai`、`gemini`、`xai`のいずれか一つだけを呼び出し、失敗時に別providerへ
-fallbackしない。Web検索結果は命令ではなく、検証対象の外部dataとして扱う。
+fallbackしない。providerとmodelに暗黙の既定値は持たない。Web検索結果は命令ではなく、
+検証対象の外部dataとして扱う。
 _Avoid_: automatic fallback, trusted search instructions, implicit paid API call
 
 **Sample Position**:

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 [run]
 game_context_provider = "ollama"
+game_context_model = "qwen3.8:27b"
 primary_model = "qwen3.8:27b"
 secondary_model = "muse-glimmer:30b"
 ollama_timeout = 900.0

--- a/docs/adr/0007-generate-game-context-before-video-selection.md
+++ b/docs/adr/0007-generate-game-context-before-video-selection.md
@@ -12,7 +12,8 @@ a local Ollama model, OpenAI Responses `web_search`, Gemini Google Search, or xA
 Responses `web_search`. Search content is treated as untrusted data, official
 sites and stores are preferred, and unresolved identity, insufficient evidence,
 or contradictory sources fail instead of producing guessed facts. Provider
-failure never falls back to another provider.
+and model must both be configured explicitly. Neither has an implicit default,
+and provider failure never falls back to another provider.
 
 The final Game Context is resolved before video probing and long-running frame
 processing. It is logged and stored in the Run Manifest and report. Dynamically

--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -33,7 +33,9 @@ OLLAMA_HOST=192.168.1.31:11434 \
 
 繰り返し使う値はTOML設定ファイルの`[run]`tableへ記述します。既定では実行時の
 current directoryにある`config.toml`を読み込み、別の設定を使う場合だけ`-c`または
-`--config`で指定します。全項目を記述する必要はありません。
+`--config`で指定します。`--game-title`を使う場合は`game_context_provider`と
+`game_context_model`の両方が必須です。`--game-context`で直接指定する場合は、両項目を
+省略できます。そのほかの項目はすべて記述する必要はありません。
 
 標準では`qwen3.8:27b`を一次評価、`muse-glimmer:30b`を二次評価に使います。
 `ollama_host`がない場合は`OLLAMA_HOST`、`127.0.0.1:11434`の順で解決します。
@@ -41,8 +43,8 @@ current directoryにある`config.toml`を読み込み、別の設定を使う�
 
 | key | 内容 | 組み込み既定値 |
 | --- | --- | --- |
-| `game_context_provider` | Game Context検索provider | `ollama` |
-| `game_context_model` | context生成model | provider既定 |
+| `game_context_provider` | Game Context検索provider | なし（`--game-title`指定時は必須） |
+| `game_context_model` | context生成model | なし（`--game-title`指定時は必須） |
 | `primary_model` | 一次評価用Ollama vision model | `qwen3.8:27b` |
 | `secondary_model` | 二次評価用Ollama vision model | `muse-glimmer:30b` |
 | `ollama_host` | Ollama host | 環境変数またはlocalhost |
@@ -87,12 +89,12 @@ editionを一意に判別できない場合、情報が不足する場合、情�
 ネタバレは含めません。検索結果は信頼できない外部dataとして扱い、検索先の命令には
 従いません。
 
-| provider | API key | 未指定時の生成model | 検索・生成方法 |
-| --- | --- | --- | --- |
-| `ollama` | `OLLAMA_API_KEY` | `primary_model`と同じmodel | Ollama Web Search APIの結果を`ollama_host`のOllama modelで生成 |
-| `openai` | `OPENAI_API_KEY` | `gpt-5.6` | OpenAI Responses APIの`web_search` |
-| `gemini` | `GEMINI_API_KEY` | `gemini-3.7-flash` | Gemini Interactions APIのGoogle Search |
-| `xai` | `XAI_API_KEY` | `grok-4.6` | xAI Responses APIの`web_search` |
+| provider | API key | 検索・生成方法 |
+| --- | --- | --- |
+| `ollama` | `OLLAMA_API_KEY` | Ollama Web Search APIの結果を`ollama_host`のOllama modelで生成 |
+| `openai` | `OPENAI_API_KEY` | OpenAI Responses APIの`web_search` |
+| `gemini` | `GEMINI_API_KEY` | Gemini Interactions APIのGoogle Search |
+| `xai` | `XAI_API_KEY` | xAI Responses APIの`web_search` |
 
 各APIの利用条件、無料枠、料金、rate limitはprovider側の設定に従い、利用料金が
 発生する場合があります。選択したproviderだけを呼び出し、認証失敗、通信失敗、
@@ -103,8 +105,42 @@ editionを一意に判別できない場合、情報が不足する場合、情�
 - Gemini: <https://ai.google.dev/gemini-api/docs/google-search>
 - xAI: <https://docs.x.ai/developers/tools/web-search>
 
-たとえばOpenAI providerを使う場合は、事前に`config.toml`の
-`game_context_provider`を`openai`へ変更します。
+利用するproviderとmodelの組を`config.toml`へ明示します。各providerの完全な`[run]`
+設定例は次のとおりです。
+
+Ollama:
+
+```toml
+[run]
+game_context_provider = "ollama"
+game_context_model = "qwen3.8:27b"
+```
+
+OpenAI:
+
+```toml
+[run]
+game_context_provider = "openai"
+game_context_model = "gpt-5.6"
+```
+
+Gemini:
+
+```toml
+[run]
+game_context_provider = "gemini"
+game_context_model = "gemini-3.7-flash"
+```
+
+xAI:
+
+```toml
+[run]
+game_context_provider = "xai"
+game_context_model = "grok-4.6"
+```
+
+たとえばOpenAIの設定を選んだ場合は、対応するAPI keyを設定して実行します。
 
 ```bash
 OPENAI_API_KEY=... uv run game-screen-pick \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.15.0"
+version = "1.16.0"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/src/main.py
+++ b/src/main.py
@@ -68,7 +68,7 @@ def _log_cli_start(
     output_count: int,
     game_title: str | None,
     game_context: str,
-    game_context_provider: str,
+    game_context_provider: str | None,
     game_context_model: str | None,
     primary_model: str,
     secondary_model: str,
@@ -90,8 +90,8 @@ def _log_cli_start(
             game_title.strip() if game_title and game_title.strip() else ""
         ),
         "--game-context": game_context.strip(),
-        "[run].game_context_provider": game_context_provider,
-        "[run].game_context_model": game_context_model or "<provider既定>",
+        "[run].game_context_provider": game_context_provider or "",
+        "[run].game_context_model": game_context_model or "",
         "[run].primary_model": primary_model,
         "[run].secondary_model": secondary_model,
         "[run].ollama_host": _display_ollama_host(ollama_host),
@@ -206,8 +206,10 @@ def resolve_video_run_config(
     }
     values.update(file_values)
 
-    provider = str(values["game_context_provider"])
-    if provider not in SUPPORTED_GAME_CONTEXT_PROVIDERS:
+    raw_provider = values["game_context_provider"]
+    assert raw_provider is None or isinstance(raw_provider, str)
+    provider = raw_provider.strip() if raw_provider is not None else None
+    if provider and provider not in SUPPORTED_GAME_CONTEXT_PROVIDERS:
         choices = ", ".join(SUPPORTED_GAME_CONTEXT_PROVIDERS)
         raise click.BadParameter(
             f"{choices}から指定してください（実際の値: {provider}）",
@@ -247,11 +249,14 @@ def resolve_video_run_config(
         resolved_sample_interval, float
     )
 
+    raw_game_context_model = values["game_context_model"]
+    assert raw_game_context_model is None or isinstance(raw_game_context_model, str)
+
     return VideoRunConfig(
         game_context_provider=provider,
         game_context_model=(
-            str(values["game_context_model"])
-            if values["game_context_model"] is not None
+            raw_game_context_model.strip()
+            if raw_game_context_model is not None
             else None
         ),
         primary_model=str(values["primary_model"]),
@@ -309,6 +314,27 @@ def validate_game_context_input(
         )
 
 
+def validate_game_context_generation_config(
+    *,
+    game_title: str | None,
+    game_context_provider: str | None,
+    game_context_model: str | None,
+) -> None:
+    """Game Title生成時だけproviderとmodelの明示指定を要求する."""
+    if not game_title or not game_title.strip():
+        return
+    if not game_context_provider or not game_context_provider.strip():
+        raise click.BadParameter(
+            "Game Contextを生成する場合は空でない文字列を指定してください",
+            param_hint="[run].game_context_provider",
+        )
+    if not game_context_model or not game_context_model.strip():
+        raise click.BadParameter(
+            "Game Contextを生成する場合は空でない文字列を指定してください",
+            param_hint="[run].game_context_model",
+        )
+
+
 @click.command()
 @click.option(
     "-c",
@@ -352,6 +378,11 @@ def execute(
     config = resolve_video_run_config(config_path=config_path)
     input_videos = discover_input_videos(input_video_dir)
     validate_game_context_input(game_title, game_context)
+    validate_game_context_generation_config(
+        game_title=game_title,
+        game_context_provider=config.game_context_provider,
+        game_context_model=config.game_context_model,
+    )
     _log_cli_start(
         config_path=config_path,
         output_count=output_count,

--- a/src/models/video_run_config.py
+++ b/src/models/video_run_config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 class VideoRunConfig:
     """設定ファイルから読み込む実効設定."""
 
-    game_context_provider: str = "ollama"
+    game_context_provider: str | None = None
     game_context_model: str | None = None
     primary_model: str = "qwen3.8:27b"
     secondary_model: str = "muse-glimmer:30b"

--- a/src/models/video_selection_request.py
+++ b/src/models/video_selection_request.py
@@ -24,7 +24,7 @@ class VideoSelectionRequest:
     sample_interval_seconds: float | None
     debug: bool
     input_videos: tuple[str, ...]
-    game_context_provider: str
+    game_context_provider: str | None
     game_context_model: str | None
 
     def __init__(
@@ -44,7 +44,7 @@ class VideoSelectionRequest:
         debug: bool | object = _MISSING,
         *,
         input_videos: tuple[str, ...] = (),
-        game_context_provider: str = "ollama",
+        game_context_provider: str | None = None,
         game_context_model: str | None = None,
     ) -> None:
         """旧位置指定と新しい複数入力keywordを同じrequestへ正規化する."""

--- a/src/services/game_context_generator.py
+++ b/src/services/game_context_generator.py
@@ -12,11 +12,6 @@ from urllib.request import Request, urlopen
 from .ollama_frame_assessor import OllamaFrameAssessor
 
 SUPPORTED_GAME_CONTEXT_PROVIDERS = ("ollama", "openai", "gemini", "xai")
-DEFAULT_GAME_CONTEXT_MODELS = {
-    "openai": "gpt-5.6",
-    "gemini": "gemini-3.7-flash",
-    "xai": "grok-4.6",
-}
 REQUIRED_CONTEXT_HEADINGS = (
     "ジャンル:",
     "基本的なゲーム進行と主なプレイ要素:",
@@ -68,23 +63,6 @@ class JsonRequester(Protocol):
         payload: dict[str, Any],
         timeout_seconds: float,
     ) -> dict[str, Any]: ...
-
-
-def resolve_game_context_model(
-    provider: str,
-    requested_model: str | None,
-    *,
-    ollama_default_model: str,
-) -> str:
-    """明示modelまたはprovider既定modelを返す."""
-    if requested_model and requested_model.strip():
-        return requested_model.strip()
-    if provider == "ollama":
-        return ollama_default_model
-    try:
-        return DEFAULT_GAME_CONTEXT_MODELS[provider]
-    except KeyError as error:
-        raise ValueError(f"未対応のgame context providerです: {provider}") from error
 
 
 class GameContextGenerator:

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -46,9 +46,9 @@ from ..utils.video_selection_files import (
     write_json_atomic,
 )
 from .game_context_generator import (
+    SUPPORTED_GAME_CONTEXT_PROVIDERS,
     GameContextGenerator,
     normalize_generated_context,
-    resolve_game_context_model,
 )
 from .ollama_frame_assessor import (
     MODEL_OPTIONS,
@@ -372,6 +372,7 @@ class VideoSelector:
                 f"sample intervalは{MINIMUM_SAMPLE_INTERVAL_SECONDS}秒以上で"
                 "指定してください"
             )
+        self._validate_game_context_request()
         if not self.ollama_endpoint:
             self.ollama_endpoint = OllamaFrameAssessor.normalize_host(
                 self.request.ollama_host
@@ -415,6 +416,41 @@ class VideoSelector:
             )
         if self.output_dir.exists() and not self.output_dir.is_dir():
             raise RuntimeError(f"出力先がフォルダではありません: {self.output_dir}")
+
+    def _validate_game_context_request(self) -> None:
+        """Game Context入力と動的生成設定を外部処理より前に検証する."""
+        has_title = bool(self.request.game_title and self.request.game_title.strip())
+        has_context = bool(self.request.game_context.strip())
+        if has_title and has_context:
+            raise ValueError(
+                "--game-titleと--game-contextのどちらか一方だけを指定してください"
+            )
+        if not has_title and not has_context:
+            raise ValueError(
+                "--game-titleと--game-contextのどちらか一方を指定してください"
+            )
+        if not has_title:
+            return
+
+        provider = self.request.game_context_provider
+        if not provider or not provider.strip():
+            raise ValueError(
+                "Game Contextを生成する場合は"
+                "[run].game_context_providerを空でない文字列で指定してください"
+            )
+        normalized_provider = provider.strip()
+        if normalized_provider not in SUPPORTED_GAME_CONTEXT_PROVIDERS:
+            choices = ", ".join(SUPPORTED_GAME_CONTEXT_PROVIDERS)
+            raise ValueError(
+                f"[run].game_context_providerは{choices}から指定してください"
+                f"（実際の値: {normalized_provider}）"
+            )
+        model = self.request.game_context_model
+        if not model or not model.strip():
+            raise ValueError(
+                "Game Contextを生成する場合は"
+                "[run].game_context_modelを空でない文字列で指定してください"
+            )
 
     def _prepare_run(self) -> None:
         """入力・モデル・manifestを検証して実行状態を確定する."""
@@ -767,11 +803,11 @@ class VideoSelector:
             return
 
         provider = self.request.game_context_provider
-        model = resolve_game_context_model(
-            provider,
-            self.request.game_context_model,
-            ollama_default_model=self.request.primary_model,
-        )
+        model = self.request.game_context_model
+        assert provider is not None
+        assert model is not None
+        provider = provider.strip()
+        model = model.strip()
         host = self.request.ollama_host or os.environ.get(
             "OLLAMA_HOST", "127.0.0.1:11434"
         )

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -784,15 +784,6 @@ class VideoSelector:
             else ""
         )
         requested_context = self.request.game_context.strip()
-        if game_title and requested_context:
-            raise ValueError(
-                "--game-titleと--game-contextのどちらか一方だけを指定してください"
-            )
-
-        if not game_title and not requested_context:
-            raise ValueError(
-                "--game-titleと--game-contextのどちらか一方を指定してください"
-            )
         if requested_context:
             self.game_context = requested_context
             self.game_context_generation = None

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -878,6 +878,8 @@ def test_context_generation_failure_stops_before_video_probe(tmp_path: Path) -> 
         output_count=2,
         game_title="Game",
         game_context="",
+        game_context_provider="ollama",
+        game_context_model="context-model",
         primary_model="primary",
         secondary_model="secondary",
         ollama_host="fake",
@@ -894,6 +896,54 @@ def test_context_generation_failure_stops_before_video_probe(tmp_path: Path) -> 
             frame_extractor=extractor,
             assessor=FakeAssessor(),
             context_generator=FailingContextGenerator(),
+        ).run()
+
+    assert extractor.probe_calls == 0
+
+
+@pytest.mark.parametrize(
+    ("provider", "model", "missing_key"),
+    [
+        (None, "context-model", "game_context_provider"),
+        ("  ", "context-model", "game_context_provider"),
+        ("openai", None, "game_context_model"),
+        ("openai", "  ", "game_context_model"),
+    ],
+)
+def test_pipeline_requires_explicit_context_provider_and_model_before_probe(
+    tmp_path: Path,
+    provider: str | None,
+    model: str | None,
+    missing_key: str,
+) -> None:
+    """programmatic title生成もproviderとmodelの未指定をprobe前に拒否すること."""
+    video = tmp_path / "recording.mp4"
+    video.write_bytes(b"video")
+    extractor = FakeFrameExtractor()
+    request = VideoSelectionRequest(
+        input_video=str(video),
+        output_dir=str(tmp_path / "selected"),
+        output_count=2,
+        game_title="Game",
+        game_context="",
+        game_context_provider=provider,
+        game_context_model=model,
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+
+    with pytest.raises(ValueError, match=rf"\[run\]\.{missing_key}"):
+        SingleVideoSelector(
+            request,
+            frame_extractor=extractor,
+            assessor=FakeAssessor(),
+            context_generator=ExplodingContextGenerator(),
         ).run()
 
     assert extractor.probe_calls == 0
@@ -2838,7 +2888,13 @@ def test_pipeline_rejects_unmanaged_output_before_game_context_generation(
 
     with pytest.raises(RuntimeError, match="出力フォルダが空ではなく"):
         SingleVideoSelector(
-            replace(request, game_title="Sample Game", game_context=""),
+            replace(
+                request,
+                game_title="Sample Game",
+                game_context="",
+                game_context_provider="openai",
+                game_context_model="context-model",
+            ),
             frame_extractor=FakeFrameExtractor(),
             assessor=FakeAssessor(),
             context_generator=generator,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -148,7 +148,7 @@ def test_cli_logs_project_version_and_all_effective_settings(
         '  --game-title: ""',
         '  --game-context: "探索を含む"',
         '  [run].game_context_provider: "ollama"',
-        '  [run].game_context_model: "<provider既定>"',
+        '  [run].game_context_model: "qwen3.8:27b"',
         '  [run].primary_model: "qwen3.8:27b"',
         '  [run].secondary_model: "muse-glimmer:30b"',
         '  [run].ollama_host: "http://ollama.example:11434（自動決定: OLLAMA_HOST）"',
@@ -340,6 +340,87 @@ def test_cli_rejects_game_title_and_game_context_without_exactly_one_input(
         run(["-n", "1", *context_args, str(input_dir), str(tmp_path / "selected")])
 
     assert "--game-titleと--game-contextのどちらか一方" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("config_text", "missing_key"),
+    [
+        ('[run]\ngame_context_model = "context-model"\n', "game_context_provider"),
+        (
+            '[run]\ngame_context_provider = ""\ngame_context_model = "context-model"\n',
+            "game_context_provider",
+        ),
+        ('[run]\ngame_context_provider = "openai"\n', "game_context_model"),
+        (
+            '[run]\ngame_context_provider = "openai"\ngame_context_model = "  "\n',
+            "game_context_model",
+        ),
+    ],
+)
+def test_cli_requires_explicit_context_provider_and_model_for_game_title(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    config_text: str,
+    missing_key: str,
+) -> None:
+    """titleから生成する場合はproviderとmodelの明示指定を必須にすること."""
+    input_dir = tmp_path / "recordings"
+    input_dir.mkdir()
+    (input_dir / "game.mp4").write_bytes(b"video")
+    config_path = tmp_path / "picker.toml"
+    config_path.write_text(config_text, encoding="utf-8")
+    monkeypatch.setattr(
+        "src.main.run_video_application",
+        lambda _request: pytest.fail("applicationは呼ばれないこと"),
+    )
+
+    with pytest.raises(SystemExit):
+        run(
+            [
+                "-n",
+                "1",
+                "--game-title",
+                "Game",
+                "-c",
+                str(config_path),
+                str(input_dir),
+                str(tmp_path / "selected"),
+            ]
+        )
+
+    assert f"[run].{missing_key}" in capsys.readouterr().err
+
+
+def test_cli_allows_direct_context_without_context_provider_or_model(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """直接指定では未設定のproviderとmodelを要求しないこと."""
+    input_dir = tmp_path / "recordings"
+    input_dir.mkdir()
+    input_video = input_dir / "game.mp4"
+    input_video.write_bytes(b"video")
+    config_path = tmp_path / "picker.toml"
+    config_path.write_text("[run]\n", encoding="utf-8")
+    captured_requests: list[VideoSelectionRequest] = []
+    monkeypatch.setattr("src.main.run_video_application", captured_requests.append)
+
+    run(
+        [
+            "-n",
+            "1",
+            "--game-context",
+            "直接指定",
+            "-c",
+            str(config_path),
+            str(input_dir),
+            str(tmp_path / "selected"),
+        ]
+    )
+
+    assert captured_requests[0].game_context_provider is None
+    assert captured_requests[0].game_context_model is None
 
 
 def test_cli_loads_all_run_options_from_config(

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.15.0"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

- Game Titleから生成する場合にgame_context_providerとgame_context_modelの明示指定を必須化
- Ollamaを含む全providerの暗黙model fallbackを削除し、直接Game Context指定は従来どおり許可
- 起動時の実効設定、4 providerの設定例、domain/ADRを新しい契約へ更新
- project versionを1.16.0へ更新

## 移行上の注意

--game-titleを使う設定では、run tableへgame_context_providerとgame_context_modelの両方を追加する必要があります。

## 確認

- UV_CACHE_DIR=/private/tmp/game-screen-pick-iss308-uv-cache uv run task check（384 passed）
- UV_CACHE_DIR=/private/tmp/game-screen-pick-iss308-uv-cache uv run pytest tests/services/test_video_pipeline.py -q（109 passed、簡素化後）
- UV_CACHE_DIR=/private/tmp/game-screen-pick-iss308-uv-cache uv lock --check
- git diff --check origin/main...HEAD

Closes #308