### PR TITLE
fix: Ollama評価にJSON Schemaを適用する

### DIFF
--- a/docs/adr/0008-cache-video-selection-phases-by-input-video.md
+++ b/docs/adr/0008-cache-video-selection-phases-by-input-video.md
@@ -62,6 +62,11 @@ consistently in the contact sheet, prompt, and response validation, and maps an
 exactly-once complete response back to stable IDs before checkpointing. A retry
 after an invalid response includes the validation error and expected display
 IDs instead of repeating the identical deterministic prompt.
+Each Ollama request also supplies a JSON Schema that requires every assessment
+field, constrains `blog_score` to a number from 0 through 100, constrains
+`transition` to a boolean, and limits the response to the current batch's Frame
+Display IDs and count. The existing local type, range, and exactly-once ID
+validation remains authoritative before any assessment is checkpointed.
 Issue #300 removes the fixed per-video and combined-run candidate limits without
 changing that identity contract. Candidate extraction and mechanical analysis
 keep only a worker-bounded window of unfinished jobs, while Ollama assessment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.17.0"
+version = "1.17.1"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/src/services/ollama_frame_assessor.py
+++ b/src/services/ollama_frame_assessor.py
@@ -25,6 +25,44 @@ def batch_display_frame_ids(candidate_count: int) -> tuple[str, ...]:
     return tuple(f"A{index:0{width}d}" for index in range(1, candidate_count + 1))
 
 
+def assessment_response_schema(display_ids: Sequence[str]) -> dict[str, Any]:
+    """frame評価batch用のOllama Structured Outputs schemaを返す."""
+    return {
+        "type": "object",
+        "properties": {
+            "frames": {
+                "type": "array",
+                "minItems": len(display_ids),
+                "maxItems": len(display_ids),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string", "enum": list(display_ids)},
+                        "blog_score": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 100,
+                        },
+                        "transition": {"type": "boolean"},
+                        "scene": {"type": "string"},
+                        "reason": {"type": "string"},
+                    },
+                    "required": [
+                        "id",
+                        "blog_score",
+                        "transition",
+                        "scene",
+                        "reason",
+                    ],
+                    "additionalProperties": False,
+                },
+            }
+        },
+        "required": ["frames"],
+        "additionalProperties": False,
+    }
+
+
 class OllamaModelValidationError(RuntimeError):
     """model identityまたはGPU実行条件が満たされないerror."""
 
@@ -122,10 +160,11 @@ class OllamaFrameAssessor:
         contact_sheet: Path,
     ) -> list[FrameAssessment]:
         """一枚のコンタクトシート内の全候補を評価する."""
+        display_ids = batch_display_frame_ids(len(candidates))
         payload = {
             "model": model,
             "stream": False,
-            "format": "json",
+            "format": assessment_response_schema(display_ids),
             "think": False,
             "keep_alive": "1h",
             "options": MODEL_OPTIONS,
@@ -165,7 +204,6 @@ class OllamaFrameAssessor:
                 )
             assessments_by_id[assessment.frame_id] = assessment
 
-        display_ids = batch_display_frame_ids(len(candidates))
         expected_ids = set(display_ids)
         actual_ids = set(assessments_by_id)
         if actual_ids != expected_ids:

--- a/tests/services/test_ollama_frame_assessor.py
+++ b/tests/services/test_ollama_frame_assessor.py
@@ -99,6 +99,7 @@ class FrameResponseAssessor(OllamaFrameAssessor):
         """Ollama応答のframe配列を保持する."""
         super().__init__("localhost", timeout_seconds=1.0, require_gpu=False)
         self.frames = frames
+        self.requested_chat_payloads: list[dict[str, Any]] = []
 
     def _request_json(
         self,
@@ -108,9 +109,10 @@ class FrameResponseAssessor(OllamaFrameAssessor):
         timeout_seconds: float,
     ) -> dict[str, Any]:
         """chat応答とloaded model一覧を固定する."""
-        del payload
         assert timeout_seconds > 0
         if url.endswith("/api/chat"):
+            assert payload is not None
+            self.requested_chat_payloads.append(payload)
             return {
                 "message": {
                     "content": json.dumps({"frames": self.frames}),
@@ -234,6 +236,81 @@ def test_assess_maps_short_display_ids_to_internal_ids_in_candidate_order(
 
     assert [assessment.frame_id for assessment in assessments] == candidate_ids
     assert [assessment.blog_score for assessment in assessments] == [81.0, 72.0]
+
+
+def test_assess_passes_structured_output_schema_for_batch(tmp_path: Path) -> None:
+    """評価fieldの型・必須性・件数・表示IDをJSON Schemaで拘束すること."""
+    contact_sheet = tmp_path / "sheet.jpg"
+    contact_sheet.write_bytes(b"image")
+    assessor = FrameResponseAssessor([frame_response("A01"), frame_response("A02")])
+    candidates = [
+        FrameCandidate("f00001", 1.0, "unused"),
+        FrameCandidate("f00002", 2.0, "unused"),
+    ]
+
+    assessor.assess(
+        model="llava:latest",
+        model_digest="stable-digest",
+        prompt="test",
+        candidates=candidates,
+        contact_sheet=contact_sheet,
+    )
+
+    assert assessor.requested_chat_payloads[0]["format"] == {
+        "type": "object",
+        "properties": {
+            "frames": {
+                "type": "array",
+                "minItems": 2,
+                "maxItems": 2,
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string", "enum": ["A01", "A02"]},
+                        "blog_score": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 100,
+                        },
+                        "transition": {"type": "boolean"},
+                        "scene": {"type": "string"},
+                        "reason": {"type": "string"},
+                    },
+                    "required": [
+                        "id",
+                        "blog_score",
+                        "transition",
+                        "scene",
+                        "reason",
+                    ],
+                    "additionalProperties": False,
+                },
+            }
+        },
+        "required": ["frames"],
+        "additionalProperties": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value", "expected_message"),
+    [
+        ("blog_score", True, "blog_score"),
+        ("transition", "false", "transition"),
+    ],
+)
+def test_assess_rejects_invalid_field_types(
+    tmp_path: Path,
+    field: str,
+    invalid_value: object,
+    expected_message: str,
+) -> None:
+    """Structured Outputsを外れた型不正値も保存前に拒否すること."""
+    response = frame_response("A01")
+    response[field] = invalid_value
+
+    with pytest.raises(ValueError, match=expected_message):
+        assess_frames(tmp_path, [response], ["f00001"])
 
 
 def test_assess_rejects_duplicate_display_id(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.17.0"
+version = "1.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

- Ollamaの評価リクエストへbatch固有のJSON Schemaを渡す
- blog_scoreの0〜100の数値型、transitionのboolean型、全fieldの必須性を生成段階で拘束する
- batch件数とFrame Display IDをschemaに反映し、既存のローカル検証も維持する
- Structured Outputsのpayloadと型不正応答の回帰テストを追加する
- project versionを1.17.1へ更新する

## 検証

- UV_CACHE_DIR=/private/tmp/game-screen-pick-issue319-uv-cache uv run task check（396 passed）
- UV_CACHE_DIR=/private/tmp/game-screen-pick-issue319-uv-cache uv run pytest tests/services/test_ollama_frame_assessor.py tests/services/test_video_pipeline.py::test_pipeline_logs_assessment_completion_and_failure_without_batch_start -q（11 passed）
- UV_CACHE_DIR=/private/tmp/game-screen-pick-issue319-uv-cache uv lock --check（版更新前後とも成功）

Closes #319