### PR TITLE
feat: 評価進捗をInput Video横断で累計表示する

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.17.1"
+version = "1.18.0"
 description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -197,6 +197,18 @@ class VideoSource:
         return self.identity.relative_path
 
 
+@dataclass
+class _AssessmentPlan:
+    """一つのInput Videoに必要な評価作業を保持する."""
+
+    source: VideoSource
+    candidates: list[FrameCandidate]
+    state_path: Path
+    cache_key: str
+    state: dict[str, FrameAssessment]
+    missing: list[FrameCandidate]
+
+
 class VideoSelector:
     """フレーム抽出、Ollama評価、選定、成果物生成を順に実行する."""
 
@@ -235,6 +247,8 @@ class VideoSelector:
         self._candidate_manifest_digests: dict[int, str] = {}
         self.manifest_digest = ""
         self._replace_registered_output = False
+        self._assessment_completed_batches: Counter[str] = Counter()
+        self._assessment_total_batches: Counter[str] = Counter()
 
     def run(self) -> Path:
         """選定を実行し、人間確認用コンタクトシートのパスを返す."""
@@ -2284,8 +2298,10 @@ class VideoSelector:
         if self.assessor is None:
             raise RuntimeError("Ollama assessorが初期化されていません")
         primary_stage = _is_primary_stage(stage)
+        progress_stage = "primary" if primary_stage else "secondary"
         batch_size = PRIMARY_BATCH_SIZE if primary_stage else SECONDARY_BATCH_SIZE
         result: dict[str, FrameAssessment] = {}
+        plans: list[_AssessmentPlan] = []
         for source in self.sources:
             source_candidates = [
                 candidate
@@ -2334,7 +2350,40 @@ class VideoSelector:
                         for candidate in source_candidates
                         if candidate.frame_id not in state
                     ]
-            batch_count = math.ceil(len(missing) / batch_size)
+            plans.append(
+                _AssessmentPlan(
+                    source=source,
+                    candidates=source_candidates,
+                    state_path=state_path,
+                    cache_key=cache_key,
+                    state=state,
+                    missing=missing,
+                )
+            )
+
+        added_batch_count = sum(
+            math.ceil(len(plan.missing) / batch_size) for plan in plans
+        )
+        previous_total = self._assessment_total_batches[progress_stage]
+        new_total = previous_total + added_batch_count
+        if added_batch_count > 0 and (previous_total > 0 or stage != progress_stage):
+            logger.info(
+                "%s評価の進捗母数を調整します: "
+                "変更前=%d batch, 変更後=%d batch, 理由=%s",
+                progress_stage,
+                previous_total,
+                new_total,
+                self._assessment_progress_adjustment_reason(stage),
+            )
+        self._assessment_total_batches[progress_stage] = new_total
+
+        for plan in plans:
+            source = plan.source
+            source_candidates = plan.candidates
+            state_path = plan.state_path
+            cache_key = plan.cache_key
+            state = plan.state
+            missing = plan.missing
             context_dir = None if primary_stage else self._context_directory(source)
             for batch_index, batch_start in enumerate(
                 range(0, len(missing), batch_size),
@@ -2392,11 +2441,17 @@ class VideoSelector:
                         )
                         save_assessment_state(state_path, cache_key, state)
                         self._write_gpu_evidence()
+                        self._assessment_completed_batches[progress_stage] += 1
+                        additional_label = (
+                            "（追加評価）" if stage != progress_stage else ""
+                        )
                         logger.info(
-                            "%s評価: %d/%d batch (%.1f秒)",
-                            stage,
-                            batch_index,
-                            batch_count,
+                            "%s評価%s: %d/%d batch（暫定, Input Video=%s） (%.1f秒)",
+                            progress_stage,
+                            additional_label,
+                            self._assessment_completed_batches[progress_stage],
+                            self._assessment_total_batches[progress_stage],
+                            _log_value(source.label),
                             time.monotonic() - started,
                         )
                         last_error = None
@@ -2423,6 +2478,15 @@ class VideoSelector:
                 }
             )
         return result
+
+    @staticmethod
+    def _assessment_progress_adjustment_reason(stage: str) -> str:
+        """評価stage名から進捗母数を増やす利用者向け理由を返す."""
+        if stage.startswith("primary-secondary-backfill-"):
+            return "二次候補補充に伴う一次追加評価"
+        if "-backfill-" in stage:
+            return "候補補充による追加評価"
+        return "同一run内の追加評価"
 
     @staticmethod
     def _load_assessment_state_or_miss(

--- a/src/services/video_selector.py
+++ b/src/services/video_selector.py
@@ -252,6 +252,8 @@ class VideoSelector:
 
     def run(self) -> Path:
         """選定を実行し、人間確認用コンタクトシートのパスを返す."""
+        self._assessment_completed_batches.clear()
+        self._assessment_total_batches.clear()
         self._prepare_paths()
         logger.info(
             "入力動画cacheの実行状態を確認しています: %s",

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -1252,6 +1252,89 @@ def test_pipeline_logs_assessment_completion_and_failure_without_batch_start(
     assert "期待する表示ID: A01, A02" in retry_prompt
 
 
+def test_pipeline_resets_assessment_progress_when_same_selector_retries(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """失敗後に同じselectorを再実行しても前runの評価進捗を持ち越さないこと."""
+
+    class FailingAfterOneBatchAssessor(FakeAssessor):
+        """最初のbatch完了後はrunを失敗させるfake."""
+
+        def __init__(self) -> None:
+            """最初のrunだけ失敗する状態で初期化する."""
+            super().__init__()
+            self.fail_run = True
+
+        def assess(
+            self,
+            *,
+            model: str,
+            model_digest: str,
+            prompt: str,
+            candidates: Sequence[FrameCandidate],
+            contact_sheet: Path,
+        ) -> list[FrameAssessment]:
+            """1 batch保存後の呼び出しを失敗させる."""
+            if self.fail_run and self.assess_calls == 1:
+                raise RuntimeError("最初のrunを中断します")
+            return super().assess(
+                model=model,
+                model_digest=model_digest,
+                prompt=prompt,
+                candidates=candidates,
+                contact_sheet=contact_sheet,
+            )
+
+    monkeypatch.setattr("src.services.video_selector.time.sleep", lambda _: None)
+    videos = (
+        tmp_path / "Sample Game Part1.mp4",
+        tmp_path / "Sample Game Part2.mp4",
+    )
+    for video in videos:
+        video.write_bytes(bytes(range(256)) * 16)
+    request = VideoSelectionRequest(
+        input_videos=tuple(str(video) for video in videos),
+        output_dir=str(tmp_path / "selected"),
+        output_count=2,
+        game_title=None,
+        game_context="テスト用のGame Context",
+        primary_model="primary",
+        secondary_model="secondary",
+        ollama_host="fake",
+        ollama_timeout=1.0,
+        allow_cpu=True,
+        ffmpeg_workers=2,
+        sample_interval_seconds=None,
+        debug=False,
+    )
+    assessor = FailingAfterOneBatchAssessor()
+    selector = SingleVideoSelector(
+        request,
+        frame_extractor=FakeFrameExtractor(),
+        assessor=assessor,
+    )
+    caplog.set_level(logging.INFO)
+
+    with pytest.raises(RuntimeError, match="最初のrunを中断します"):
+        selector.run()
+    assessor.fail_run = False
+    caplog.clear()
+
+    selector.run()
+
+    assert [
+        record.getMessage().rsplit(" (", maxsplit=1)[0]
+        for record in caplog.records
+        if record.getMessage().startswith("primary評価:")
+    ] == [
+        'primary評価: 1/3 batch（暫定, Input Video="Sample Game Part1.mp4"）',
+        'primary評価: 2/3 batch（暫定, Input Video="Sample Game Part2.mp4"）',
+        'primary評価: 3/3 batch（暫定, Input Video="Sample Game Part2.mp4"）',
+    ]
+
+
 def test_pipeline_selects_from_multiple_videos_and_reports_each_source(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/services/test_video_pipeline.py
+++ b/tests/services/test_video_pipeline.py
@@ -1254,8 +1254,9 @@ def test_pipeline_logs_assessment_completion_and_failure_without_batch_start(
 
 def test_pipeline_selects_from_multiple_videos_and_reports_each_source(
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """複数入力を一つのrunとして選定し各入力元をreportへ残すこと."""
+    """複数入力を一つのrunとして選定し評価進捗と入力元を累計表示すること."""
     videos = (
         tmp_path / "Sample Game Part1.mp4",
         tmp_path / "Sample Game Part2.mp4",
@@ -1281,12 +1282,32 @@ def test_pipeline_selects_from_multiple_videos_and_reports_each_source(
 
     extractor = FakeFrameExtractor()
     assessor = FakeAssessor()
+    caplog.set_level(logging.INFO)
     contact_sheet = SingleVideoSelector(
         request,
         frame_extractor=extractor,
         assessor=assessor,
     ).run()
 
+    messages = [record.getMessage() for record in caplog.records]
+    assert [
+        message.rsplit(" (", maxsplit=1)[0]
+        for message in messages
+        if message.startswith("primary評価:")
+    ] == [
+        'primary評価: 1/4 batch（暫定, Input Video="Sample Game Part1.mp4"）',
+        'primary評価: 2/4 batch（暫定, Input Video="Sample Game Part1.mp4"）',
+        'primary評価: 3/4 batch（暫定, Input Video="Sample Game Part2.mp4"）',
+        'primary評価: 4/4 batch（暫定, Input Video="Sample Game Part2.mp4"）',
+    ]
+    assert [
+        message.rsplit(" (", maxsplit=1)[0]
+        for message in messages
+        if message.startswith("secondary評価:")
+    ] == [
+        'secondary評価: 1/2 batch（暫定, Input Video="Sample Game Part1.mp4"）',
+        'secondary評価: 2/2 batch（暫定, Input Video="Sample Game Part2.mp4"）',
+    ]
     report = json.loads((output_dir / "report.json").read_text(encoding="utf-8"))
     assert [item["path"] for item in report["videos"]] == [
         str(video.resolve()) for video in videos
@@ -1376,6 +1397,7 @@ def test_pipeline_reuses_video_phase_cache_after_input_directory_move(
 
 def test_pipeline_processes_only_added_video_before_global_reselection(
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """動画追加時は既存動画phaseを保ち、新規動画だけを処理すること."""
     input_dir = tmp_path / "recordings"
@@ -1414,6 +1436,8 @@ def test_pipeline_processes_only_added_video_before_global_reselection(
     )
     extractor = TrackingFrameExtractor()
     assessor = FakeAssessor()
+    caplog.clear()
+    caplog.set_level(logging.INFO)
 
     SingleVideoSelector(
         second_request,
@@ -1421,6 +1445,16 @@ def test_pipeline_processes_only_added_video_before_global_reselection(
         assessor=assessor,
     ).run()
 
+    progress_messages = [
+        record.getMessage().rsplit(" (", maxsplit=1)[0]
+        for record in caplog.records
+        if record.getMessage().startswith(("primary評価:", "secondary評価:"))
+    ]
+    assert progress_messages == [
+        'primary評価: 1/2 batch（暫定, Input Video="Sample Game Part2.mp4"）',
+        'primary評価: 2/2 batch（暫定, Input Video="Sample Game Part2.mp4"）',
+        'secondary評価: 1/1 batch（暫定, Input Video="Sample Game Part2.mp4"）',
+    ]
     assert extractor.probed_videos == [second_video.name]
     assert extractor.candidate_videos
     assert set(extractor.candidate_videos) == {second_video.name}
@@ -1529,6 +1563,7 @@ def test_deleted_cache_directory_is_safely_regenerated(tmp_path: Path) -> None:
 def test_pipeline_backfills_source_when_reserved_primary_candidates_fail(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """入力元の予約候補が全遷移なら未評価候補を追加評価すること."""
     failed_primary_ids: set[str] = set()
@@ -1604,12 +1639,36 @@ def test_pipeline_backfills_source_when_reserved_primary_candidates_fail(
     )
 
     extractor = FakeFrameExtractor()
+    caplog.set_level(logging.INFO)
     SingleVideoSelector(
         request,
         frame_extractor=extractor,
         assessor=ReservedCandidateFailingAssessor(),
     ).run()
 
+    messages = [record.getMessage() for record in caplog.records]
+    normalized_messages = [message.rsplit(" (", maxsplit=1)[0] for message in messages]
+    adjustment_index = messages.index(
+        "primary評価の進捗母数を調整します: "
+        "変更前=2 batch, 変更後=4 batch, 理由=候補補充による追加評価"
+    )
+    additional_progress_index = normalized_messages.index(
+        "primary評価（追加評価）: 3/4 batch"
+        '（暫定, Input Video="Sample Game Part1.mp4"）'
+    )
+    assert adjustment_index < additional_progress_index
+    assert [
+        message.rsplit(" (", maxsplit=1)[0]
+        for message in messages
+        if message.startswith(("primary評価:", "primary評価（追加評価）:"))
+    ] == [
+        'primary評価: 1/2 batch（暫定, Input Video="Sample Game Part1.mp4"）',
+        'primary評価: 2/2 batch（暫定, Input Video="Sample Game Part2.mp4"）',
+        "primary評価（追加評価）: 3/4 batch"
+        '（暫定, Input Video="Sample Game Part1.mp4"）',
+        "primary評価（追加評価）: 4/4 batch"
+        '（暫定, Input Video="Sample Game Part2.mp4"）',
+    ]
     work_dir = _single_run_cache(tmp_path)
     report = json.loads((output_dir / "report.json").read_text(encoding="utf-8"))
     assert _assessment_files(tmp_path, "primary")

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.17.1"
+version = "1.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

- primary・secondary評価のcache miss batchをInput Video横断で累計表示
- 現在のInput Video、暫定母数、候補補充時の変更前後と理由をログへ追加
- cache hitを除外した実作業だけを再開時の進捗母数へ反映
- 失敗後に同じselector instanceを再実行しても前runの進捗を持ち越さないよう修正
- project versionを1.18.0へ更新

評価対象、batch size、候補補充、retry、phase cache、選定結果は変更していません。

## 検証

- uv run pytest tests/services/test_video_pipeline.py（111 passed）
- uv run task check（397 passed）
- uv lock --check（version更新前後とも成功）

Closes #322