### PR TITLE
chore: repo-templateの最新mainを適用

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -4,7 +4,7 @@ author_email: mizu.copo@gmail.com
 author_name: みず
 project_description: ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール
 project_name: game-screen-pick
-project_version: 1.18.0
+project_version: 1.18.1
 python_project_kind: application
 python_version: '3.13'
 use_chrome_extension: false

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,10 @@
-_commit: 3fc0cdb
+_commit: 56e724389877f2a8ab75420e9920cfadfaa07f11
 _src_path: git@github.com:mizucopo/repo-template.git
 author_email: mizu.copo@gmail.com
 author_name: みず
 project_description: ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール
 project_name: game-screen-pick
-project_version: 1.5.4
+project_version: 1.18.0
 python_project_kind: application
 python_version: '3.13'
 use_chrome_extension: false
@@ -16,4 +16,5 @@ use_mit_license: true
 use_python: true
 use_rust: false
 use_tauri: false
+use_version_management: true
 repo_template_tauri_branding_assets_created: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,34 @@
 ## Work boundaries
 
 - Do not make implementation changes directly on `main`.
-- Track implementation changes in GitHub Issues and use a corresponding non-`main` branch.
+- Use a non-`main` branch for implementation changes.
 - Do not weaken quality checks or test configuration to make a failing change pass.
+
+## Execution
+
+- Infer the requested outcome and scope from the conversation, and carry authorized work through implementation and verification. Treat action requests as instructions to do the work.
+- Make reasonable assumptions for routine details. Ask focused questions when missing information could materially change the result or an action needs approval; continue independent authorized work meanwhile.
+- Honor explicit approval gates and prior authorization. Prepare a concrete, reviewable result within the authorized scope before requesting any further approval.
+- Incorporate corrections and answer side questions while retaining the overall task unless the user cancels or replaces it.
+
+## Instructions
+
+- Follow the platform's instruction hierarchy and permissions. Within that hierarchy, explicit user instructions override lower-priority skill guidelines.
+- If a skill causes a pause, confirmation request, or unfinished work, explain how it applies and distinguish explicit requirements from your interpretation. Identify and quote the instruction only when its source may be shared with the user; link its `SKILL.md` when available, or cite its identifier or available source. Otherwise give only a permitted identifier and a brief explanation without disclosing confidential content.
+
+## Communication
+
+- Lead with the result and use concise, plain language. Use lists when they clarify parallel items or steps.
+- Give brief progress updates at meaningful milestones. Report what changed, the verification performed, and any unresolved blocker without claiming unverified success.
+
+## Delegation
+
+- When subagent tools are available, delegate independent, bounded tasks if parallel work can save time or improve quality. Give each task a clear scope and completion criterion, continue useful local work, and verify returned results before integrating them.
+
+## Verification
+
+- Run checks appropriate to the change and all required repository quality gates. Broaden or repeat passed checks only when new changes, failures, or unresolved concerns justify it.
+- Add tests that verify meaningful behavior or contracts; avoid tests that merely mirror the implementation for reversible, low-impact changes.
 
 ## Project context
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -6,7 +6,7 @@ name in agent instructions.
 
 ## Conventions
 
-- Create implementation issues and review-follow-up issues as GitHub Issues.
+- Create review-follow-up Issues as GitHub Issues.
 - Read the full issue body, comments, and labels before acting on an issue.
 - Keep issues concise and centered on the purpose, desired outcome, and problem
   or open question. Add acceptance criteria only when they clarify what done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "game-screen-pick"
 version = "1.18.0"
-description = "ゲームスクリーンショットから品質・多様性を考慮して最適な画像を自動選択するAIツール"
+description = "\u30b2\u30fc\u30e0\u30b9\u30af\u30ea\u30fc\u30f3\u30b7\u30e7\u30c3\u30c8\u304b\u3089\u54c1\u8cea\u30fb\u591a\u69d8\u6027\u3092\u8003\u616e\u3057\u3066\u6700\u9069\u306a\u753b\u50cf\u3092\u81ea\u52d5\u9078\u629e\u3059\u308bAI\u30c4\u30fc\u30eb"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "game-screen-pick"
-version = "1.18.0"
+version = "1.18.1"
 description = "\u30b2\u30fc\u30e0\u30b9\u30af\u30ea\u30fc\u30f3\u30b7\u30e7\u30c3\u30c8\u304b\u3089\u54c1\u8cea\u30fb\u591a\u69d8\u6027\u3092\u8003\u616e\u3057\u3066\u6700\u9069\u306a\u753b\u50cf\u3092\u81ea\u52d5\u9078\u629e\u3059\u308bAI\u30c4\u30fc\u30eb"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/stubs/__init__.py
+++ b/stubs/__init__.py
@@ -1,1 +1,0 @@
-"""Type stubs for external dependencies."""

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -2,17 +2,8 @@ from importlib import import_module
 
 
 def test_python_package_is_importable() -> None:
-    """Pythonパッケージがimportされること。
-
-    Arrange: import対象のパッケージ名が用意されること
-    Act: 指定されたパッケージがimportされること
-    Assert: importされたmodule名が一致すること
-    """
-    # Arrange
     module_name = "src"
 
-    # Act
     module = import_module(module_name)
 
-    # Assert
     assert module.__name__ == module_name

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "game-screen-pick"
-version = "1.18.0"
+version = "1.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
repo-templateを `3fc0cdb` から `56e724389877f2a8ab75420e9920cfadfaa07f11` へ更新し、エージェント共通指針・Issue規約を最新の生成内容へ揃えます。既存CLIのインストール構成、依存関係、設定・キャッシュの除外、setup-uv v10.0.1は維持します。

- `use_version_management: true` を追加し、古いCopier回答のバージョンを実装と同期。リリース準備として回答・Python metadata・lockfileを `1.18.1` に統一。
- 雛形の不要なコメント・docstringを整理。説明文のUnicode表記統一は意味上の変更なし。

検証:
- テンプレート適用後の `uv run task check`: Ruff・mypy成功、397 tests passed。
- バージョン更新前後の `uv lock --check`: 成功。
- 更新後のCLI/import関連テスト: 51 tests passed。インストール済みバージョン `1.18.1` を確認。
- `git diff --check`: 成功。Copier競合は解消済み。

Closes #325
